### PR TITLE
Add sandbox UUID certificate verification for agent TLS

### DIFF
--- a/charts/isola-gw/templates/deployment.yaml
+++ b/charts/isola-gw/templates/deployment.yaml
@@ -79,3 +79,13 @@ spec:
           value: {{ .Values.storage.awsSecretAccessKey | quote }}
         {{- end }}
         {{- end }}
+        - name: ISOLA_CA_BUNDLE_PATH
+          value: "/etc/isola/ca/ca-bundle.crt"
+        volumeMounts:
+        - name: ca-bundle
+          mountPath: /etc/isola/ca
+          readOnly: true
+      volumes:
+      - name: ca-bundle
+        configMap:
+          name: isola-sandbox-ca-bundle

--- a/charts/isola-operator/templates/deployment.yaml
+++ b/charts/isola-operator/templates/deployment.yaml
@@ -40,6 +40,11 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: IfNotPresent
         ports: []
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/isola-operator/templates/sandbox-agents-service.yaml
+++ b/charts/isola-operator/templates/sandbox-agents-service.yaml
@@ -14,7 +14,7 @@ spec:
   selector:
     app: isola-sandbox
   ports:
-    - name: agent
-      port: 8080
-      targetPort: 8080
+    - name: agent-tls
+      port: 8443
+      targetPort: 8443
 

--- a/services/isola-agent/cmd/main.go
+++ b/services/isola-agent/cmd/main.go
@@ -2,12 +2,15 @@
 package main
 
 import (
+	"crypto/tls"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 
 	"github.com/gin-gonic/gin"
 	"github.com/omereli/dev-isola/services/isola-agent/internal/handlers"
+	agenttls "github.com/omereli/dev-isola/services/isola-agent/internal/tls"
 )
 
 // Environment variable keys
@@ -20,17 +23,13 @@ const (
 const (
 	DefaultHTTPHost = "0.0.0.0"
 	DefaultHTTPPort = "8080"
+	DefaultTLSPort  = "8443"
 )
 
 func main() {
 	host := os.Getenv(EnvHTTPHost)
 	if host == "" {
 		host = DefaultHTTPHost
-	}
-
-	port := os.Getenv(EnvHTTPPort)
-	if port == "" {
-		port = DefaultHTTPPort
 	}
 
 	// Create handler
@@ -51,10 +50,44 @@ func main() {
 	r.Use(gin.Logger())
 	handler.RegisterRoutes(r)
 
-	addr := fmt.Sprintf("%s:%s", host, port)
-	log.Printf("Starting isola-agent server on %s", addr)
+	// Check if TLS is configured via environment variables
+	cert, tlsEnabled, err := agenttls.LoadCertFromEnv()
+	if err != nil {
+		log.Fatalf("Failed to load TLS certificate: %v", err)
+	}
 
-	if err := r.Run(addr); err != nil {
-		log.Fatalf("Failed to start server: %v", err)
+	if tlsEnabled {
+		// TLS mode - use port 8443
+		port := os.Getenv(EnvHTTPPort)
+		if port == "" {
+			port = DefaultTLSPort
+		}
+		addr := fmt.Sprintf("%s:%s", host, port)
+		log.Printf("Starting isola-agent TLS server on %s", addr)
+
+		server := &http.Server{
+			Addr:    addr,
+			Handler: r,
+			TLSConfig: &tls.Config{
+				Certificates: []tls.Certificate{cert},
+				MinVersion:   tls.VersionTLS13,
+			},
+		}
+
+		if err := server.ListenAndServeTLS("", ""); err != nil {
+			log.Fatalf("Failed to start TLS server: %v", err)
+		}
+	} else {
+		// HTTP mode (fallback for backward compatibility during transition)
+		port := os.Getenv(EnvHTTPPort)
+		if port == "" {
+			port = DefaultHTTPPort
+		}
+		addr := fmt.Sprintf("%s:%s", host, port)
+		log.Printf("Starting isola-agent HTTP server on %s (TLS not configured)", addr)
+
+		if err := r.Run(addr); err != nil {
+			log.Fatalf("Failed to start server: %v", err)
+		}
 	}
 }

--- a/services/isola-agent/internal/tls/tls.go
+++ b/services/isola-agent/internal/tls/tls.go
@@ -1,0 +1,53 @@
+// Package tls provides TLS certificate loading from environment variables for the isola-agent.
+package tls
+
+import (
+	"crypto/tls"
+	"encoding/base64"
+	"fmt"
+	"os"
+)
+
+const (
+	// EnvTLSCert is the environment variable containing the base64-encoded TLS certificate
+	EnvTLSCert = "ISOLA_AGENT_TLS_CERT"
+	// EnvTLSKey is the environment variable containing the base64-encoded TLS private key
+	EnvTLSKey = "ISOLA_AGENT_TLS_KEY"
+)
+
+// LoadCertFromEnv loads a TLS certificate from base64-encoded environment variables.
+// Returns the certificate and a boolean indicating if TLS is enabled.
+func LoadCertFromEnv() (tls.Certificate, bool, error) {
+	certB64 := os.Getenv(EnvTLSCert)
+	keyB64 := os.Getenv(EnvTLSKey)
+
+	if certB64 == "" || keyB64 == "" {
+		// TLS not configured - run in HTTP mode
+		return tls.Certificate{}, false, nil
+	}
+
+	certPEM, err := base64.StdEncoding.DecodeString(certB64)
+	if err != nil {
+		return tls.Certificate{}, false, fmt.Errorf("decoding TLS cert: %w", err)
+	}
+
+	keyPEM, err := base64.StdEncoding.DecodeString(keyB64)
+	if err != nil {
+		return tls.Certificate{}, false, fmt.Errorf("decoding TLS key: %w", err)
+	}
+
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return tls.Certificate{}, false, fmt.Errorf("parsing TLS key pair: %w", err)
+	}
+
+	return cert, true, nil
+}
+
+// NewTLSConfig creates a TLS configuration with the given certificate.
+func NewTLSConfig(cert tls.Certificate) *tls.Config {
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS13,
+	}
+}

--- a/services/isola-gw/cmd/main.go
+++ b/services/isola-gw/cmd/main.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/omereli/dev-isola/services/isola-gw/internal/agent"
 	"github.com/omereli/dev-isola/services/isola-gw/internal/handlers"
 	"github.com/omereli/dev-isola/services/isola-gw/internal/kubernetes"
 	"github.com/omereli/dev-isola/services/isola-gw/internal/storage"
@@ -23,6 +24,7 @@ const (
 	EnvHTTPPort            = "ISOLA_HTTP_PORT"
 	EnvKubernetesNamespace = "ISOLA_KUBERNETES_NAMESPACE"
 	EnvGinMode             = "ISOLA_GIN_MODE"
+	EnvCABundlePath        = "ISOLA_CA_BUNDLE_PATH"
 )
 
 // Default values
@@ -30,6 +32,7 @@ const (
 	DefaultHTTPHost            = "0.0.0.0"
 	DefaultHTTPPort            = "8080"
 	DefaultKubernetesNamespace = "isola-sandboxes"
+	DefaultCABundlePath        = "/etc/isola/ca/ca-bundle.crt"
 )
 
 func main() {
@@ -40,12 +43,21 @@ func main() {
 	host := getEnvOrDefault(EnvHTTPHost, DefaultHTTPHost)
 	port := getEnvOrDefault(EnvHTTPPort, DefaultHTTPPort)
 	namespace := getEnvOrDefault(EnvKubernetesNamespace, DefaultKubernetesNamespace)
+	caBundlePath := getEnvOrDefault(EnvCABundlePath, DefaultCABundlePath)
+
 	k8sManager := kubernetes.NewManager(namespace)
 
 	ctx := context.Background()
 	storageBucket := initStorage(ctx)
 
-	handler := handlers.NewHandler(k8sManager, storageBucket)
+	// Initialize agent client for TLS communication with sandbox agents
+	agentClient, err := agent.NewClient(caBundlePath)
+	if err != nil {
+		log.Fatalf("Failed to initialize agent client: %v", err)
+	}
+	log.Printf("Agent client initialized with CA bundle: %s", caBundlePath)
+
+	handler := handlers.NewHandler(k8sManager, storageBucket, agentClient)
 
 	r := gin.New()
 

--- a/services/isola-gw/internal/agent/client.go
+++ b/services/isola-gw/internal/agent/client.go
@@ -1,0 +1,147 @@
+// Package agent provides a TLS client for communicating with sandbox agents.
+// It verifies that the agent's certificate is signed by the trusted CA and
+// contains the expected sandbox UUID, preventing stale IP reuse attacks.
+package agent
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+)
+
+const (
+	// SPIFFEIDPrefix is the expected prefix for sandbox SPIFFE IDs in certificates
+	SPIFFEIDPrefix = "spiffe://isola.run/sandbox/"
+
+	// DefaultAgentPort is the TLS port used by sandbox agents
+	DefaultAgentPort = 8443
+)
+
+// Client provides HTTP clients for communicating with sandbox agents over TLS.
+// It periodically reloads the CA bundle to support CA rotation.
+type Client struct {
+	caBundlePath string
+	mu           sync.RWMutex
+	caCertPool   *x509.CertPool
+	lastModTime  time.Time
+}
+
+// NewClient creates a new agent client that verifies certificates against the CA bundle.
+func NewClient(caBundlePath string) (*Client, error) {
+	c := &Client{caBundlePath: caBundlePath}
+	if err := c.loadCABundle(); err != nil {
+		return nil, err
+	}
+	go c.pollCABundle()
+	return c, nil
+}
+
+func (c *Client) loadCABundle() error {
+	bundlePEM, err := os.ReadFile(c.caBundlePath)
+	if err != nil {
+		return fmt.Errorf("reading CA bundle from %s: %w", c.caBundlePath, err)
+	}
+
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(bundlePEM) {
+		return fmt.Errorf("no valid certificates found in CA bundle")
+	}
+
+	info, err := os.Stat(c.caBundlePath)
+	if err != nil {
+		return fmt.Errorf("stat CA bundle: %w", err)
+	}
+
+	c.mu.Lock()
+	c.caCertPool = pool
+	c.lastModTime = info.ModTime()
+	c.mu.Unlock()
+
+	log.Printf("Loaded CA bundle from %s", c.caBundlePath)
+	return nil
+}
+
+func (c *Client) pollCABundle() {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		info, err := os.Stat(c.caBundlePath)
+		if err != nil {
+			continue
+		}
+
+		c.mu.RLock()
+		lastMod := c.lastModTime
+		c.mu.RUnlock()
+
+		if info.ModTime().After(lastMod) {
+			if err := c.loadCABundle(); err != nil {
+				log.Printf("Failed to reload CA bundle: %v", err)
+			}
+		}
+	}
+}
+
+func (c *Client) getCertPool() *x509.CertPool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.caCertPool
+}
+
+// HTTPClient returns an HTTP client configured to verify the agent's certificate
+// contains the expected sandbox UUID. The certificate must be signed by the trusted CA
+// and contain the sandbox UUID in its URI SAN as a SPIFFE ID.
+func (c *Client) HTTPClient(expectedUUID string) *http.Client {
+	expectedSPIFFE := SPIFFEIDPrefix + expectedUUID
+
+	return &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				MinVersion: tls.VersionTLS13,
+				RootCAs:    c.getCertPool(),
+				VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+					return verifySandboxUUID(rawCerts, expectedSPIFFE, expectedUUID)
+				},
+			},
+		},
+	}
+}
+
+// verifySandboxUUID checks that the certificate contains the expected sandbox UUID.
+func verifySandboxUUID(rawCerts [][]byte, expectedSPIFFE, expectedUUID string) error {
+	if len(rawCerts) == 0 {
+		return fmt.Errorf("no certificate presented by agent")
+	}
+
+	cert, err := x509.ParseCertificate(rawCerts[0])
+	if err != nil {
+		return fmt.Errorf("parsing agent certificate: %w", err)
+	}
+
+	// Check URI SANs for SPIFFE ID
+	for _, uri := range cert.URIs {
+		if uri.String() == expectedSPIFFE {
+			return nil
+		}
+	}
+
+	// Fallback: check Common Name contains UUID
+	if cert.Subject.CommonName == "sandbox-"+expectedUUID {
+		return nil
+	}
+
+	return fmt.Errorf("agent certificate does not contain expected sandbox UUID %s (CN=%s, URIs=%v)",
+		expectedUUID, cert.Subject.CommonName, cert.URIs)
+}
+
+// Port returns the default agent TLS port.
+func Port() int {
+	return DefaultAgentPort
+}

--- a/services/isola-gw/internal/handlers/files.go
+++ b/services/isola-gw/internal/handlers/files.go
@@ -120,7 +120,7 @@ func (h *Handler) UploadFile(c *gin.Context) {
 		return
 	}
 
-	agentURL := fmt.Sprintf("http://%s:%d/upload", agentAddress, agentSidecarPort)
+	agentURL := fmt.Sprintf("https://%s:%d/upload", agentAddress, agentSidecarPort)
 	log.Printf("[UPLOAD] Forwarding to agent at %s", agentURL)
 
 	// Create multipart form for agent
@@ -165,7 +165,8 @@ func (h *Handler) UploadFile(c *gin.Context) {
 
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 
-	client := &http.Client{Timeout: 30 * time.Second}
+	// Use TLS client with sandbox UUID verification
+	client := h.agentClient.HTTPClient(sandboxID)
 	resp, err := client.Do(req)
 	if err != nil {
 		log.Printf("[UPLOAD] Failed to connect to agent at %s: %v", agentURL, err)
@@ -385,7 +386,7 @@ func (h *Handler) ConfirmUpload(c *gin.Context) {
 	}
 
 	// Call agent's /download endpoint
-	agentURL := fmt.Sprintf("http://%s:%d/download", agentAddress, agentSidecarPort)
+	agentURL := fmt.Sprintf("https://%s:%d/download", agentAddress, agentSidecarPort)
 	log.Printf("[CONFIRM] Triggering agent download at %s", agentURL)
 
 	downloadReq := models.DownloadRequest{
@@ -415,7 +416,8 @@ func (h *Handler) ConfirmUpload(c *gin.Context) {
 
 	httpReq.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{Timeout: 60 * time.Second}
+	// Use TLS client with sandbox UUID verification
+	client := h.agentClient.HTTPClient(sandboxID)
 	resp, err := client.Do(httpReq)
 	if err != nil {
 		log.Printf("[CONFIRM] Failed to connect to agent at %s: %v", agentURL, err)

--- a/services/isola-gw/internal/handlers/handlers.go
+++ b/services/isola-gw/internal/handlers/handlers.go
@@ -3,23 +3,27 @@ package handlers
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/omereli/dev-isola/services/isola-gw/internal/agent"
 	"github.com/omereli/dev-isola/services/isola-gw/internal/kubernetes"
 	"github.com/omereli/dev-isola/services/isola-gw/internal/storage"
 )
 
 const (
-	agentSidecarPort = 8080
+	// agentSidecarPort is the TLS port used by sandbox agents
+	agentSidecarPort = 8443
 )
 
 type Handler struct {
-	k8sManager *kubernetes.Manager
-	storage    *storage.BucketWrapper
+	k8sManager  *kubernetes.Manager
+	storage     *storage.BucketWrapper
+	agentClient *agent.Client
 }
 
-func NewHandler(k8sManager *kubernetes.Manager, storageBucket *storage.BucketWrapper) *Handler {
+func NewHandler(k8sManager *kubernetes.Manager, storageBucket *storage.BucketWrapper, agentClient *agent.Client) *Handler {
 	return &Handler{
-		k8sManager: k8sManager,
-		storage:    storageBucket,
+		k8sManager:  k8sManager,
+		storage:     storageBucket,
+		agentClient: agentClient,
 	}
 }
 

--- a/services/isola-operator/cmd/main.go
+++ b/services/isola-operator/cmd/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"flag"
 	"os"
@@ -36,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	sandboxv1alpha1 "github.com/omereli/dev-isola/services/isola-operator/api/v1alpha1"
+	"github.com/omereli/dev-isola/services/isola-operator/internal/ca"
 	"github.com/omereli/dev-isola/services/isola-operator/internal/controller"
 	// +kubebuilder:scaffold:imports
 )
@@ -184,11 +186,27 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Initialize CA manager for sandbox agent certificate issuance.
+	// The CA is stored in the operator's namespace and used to sign certificates
+	// that embed the sandbox UUID for verification by isola-gw.
+	operatorNamespace := os.Getenv("POD_NAMESPACE")
+	if operatorNamespace == "" {
+		operatorNamespace = "isola-system"
+	}
+
+	caManager := ca.NewManager(mgr.GetClient(), operatorNamespace)
+	if err := caManager.Initialize(context.Background()); err != nil {
+		setupLog.Error(err, "unable to initialize CA manager")
+		os.Exit(1)
+	}
+	setupLog.Info("CA manager initialized", "namespace", operatorNamespace)
+
 	// SandboxReconciler manages Sandbox resources.
 	if err := (&controller.SandboxReconciler{
 		Client:     mgr.GetClient(),
 		Scheme:     mgr.GetScheme(),
 		AgentImage: agentImage,
+		CAManager:  caManager,
 		Clock:      controller.RealClock{},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Sandbox")

--- a/services/isola-operator/go.mod
+++ b/services/isola-operator/go.mod
@@ -9,6 +9,7 @@ require (
 	k8s.io/api v0.34.1
 	k8s.io/apimachinery v0.34.1
 	k8s.io/client-go v0.34.1
+	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 	sigs.k8s.io/controller-runtime v0.22.4
 )
 
@@ -92,7 +93,6 @@ require (
 	k8s.io/component-base v0.34.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
-	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/services/isola-operator/internal/ca/ca.go
+++ b/services/isola-operator/internal/ca/ca.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2025 isola.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package ca provides certificate authority management for sandbox agent mTLS.
+// The CA signs certificates for sandbox agents, embedding the sandbox UUID in the
+// certificate's URI SAN. This allows isola-gw to verify it's communicating with
+// the intended sandbox, preventing stale IP reuse attacks.
+package ca
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net/url"
+	"time"
+)
+
+const (
+	// SPIFFEIDPrefix is the prefix for sandbox SPIFFE IDs
+	SPIFFEIDPrefix = "spiffe://isola.run/sandbox/"
+)
+
+// CA represents a certificate authority for signing sandbox agent certificates.
+type CA struct {
+	cert    *x509.Certificate
+	key     *rsa.PrivateKey
+	certPEM []byte
+	keyPEM  []byte
+}
+
+// Generate creates a new self-signed CA certificate and private key.
+func Generate() (*CA, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, fmt.Errorf("generating CA key: %w", err)
+	}
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, fmt.Errorf("generating serial number: %w", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: "isola-sandbox-ca"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(10, 0, 0), // 10 years
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		MaxPathLen:            0,
+		MaxPathLenZero:        true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		return nil, fmt.Errorf("creating CA certificate: %w", err)
+	}
+
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		return nil, fmt.Errorf("parsing CA certificate: %w", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+
+	return &CA{cert: cert, key: key, certPEM: certPEM, keyPEM: keyPEM}, nil
+}
+
+// Load creates a CA from existing PEM-encoded certificate and key.
+func Load(certPEM, keyPEM []byte) (*CA, error) {
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode CA cert PEM")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing CA certificate: %w", err)
+	}
+
+	keyBlock, _ := pem.Decode(keyPEM)
+	if keyBlock == nil {
+		return nil, fmt.Errorf("failed to decode CA key PEM")
+	}
+	key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing CA key: %w", err)
+	}
+
+	return &CA{cert: cert, key: key, certPEM: certPEM, keyPEM: keyPEM}, nil
+}
+
+// CertPEM returns the PEM-encoded CA certificate.
+func (c *CA) CertPEM() []byte {
+	return c.certPEM
+}
+
+// KeyPEM returns the PEM-encoded CA private key.
+func (c *CA) KeyPEM() []byte {
+	return c.keyPEM
+}
+
+// IssueCert generates a certificate for a sandbox agent, signed by this CA.
+// The sandbox UUID is embedded in the certificate's URI SAN as a SPIFFE ID.
+func (c *CA) IssueCert(sandboxUUID, podDNS string) (certPEM, keyPEM []byte, err error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generating agent key: %w", err)
+	}
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, nil, fmt.Errorf("generating serial number: %w", err)
+	}
+
+	spiffeID, err := url.Parse(SPIFFEIDPrefix + sandboxUUID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parsing SPIFFE ID: %w", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: "sandbox-" + sandboxUUID},
+		URIs:         []*url.URL{spiffeID},
+		DNSNames:     []string{podDNS},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(7 * 24 * time.Hour), // 7 days
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, c.cert, &key.PublicKey, c.key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating agent certificate: %w", err)
+	}
+
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+
+	return certPEM, keyPEM, nil
+}

--- a/services/isola-operator/internal/ca/manager.go
+++ b/services/isola-operator/internal/ca/manager.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2025 isola.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ca
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	// CASecretName is the name of the Secret containing the CA certificate and key
+	CASecretName = "isola-sandbox-ca"
+	// CABundleConfigMapName is the name of the ConfigMap containing CA certificates for verification
+	CABundleConfigMapName = "isola-sandbox-ca-bundle"
+)
+
+// Manager handles CA lifecycle including initialization, persistence, and certificate issuance.
+type Manager struct {
+	client    client.Client
+	namespace string
+	ca        *CA
+	mu        sync.RWMutex
+}
+
+// NewManager creates a new CA manager.
+func NewManager(c client.Client, namespace string) *Manager {
+	return &Manager{
+		client:    c,
+		namespace: namespace,
+	}
+}
+
+// Initialize loads an existing CA from the cluster or creates a new one.
+// This should be called during operator startup.
+func (m *Manager) Initialize(ctx context.Context) error {
+	log := logf.FromContext(ctx).WithName("ca-manager")
+
+	secret := &corev1.Secret{}
+	err := m.client.Get(ctx, client.ObjectKey{Name: CASecretName, Namespace: m.namespace}, secret)
+
+	if apierrors.IsNotFound(err) {
+		log.Info("CA secret not found, generating new CA")
+		return m.createCA(ctx)
+	}
+	if err != nil {
+		return fmt.Errorf("getting CA secret: %w", err)
+	}
+
+	ca, err := Load(secret.Data["ca.crt"], secret.Data["ca.key"])
+	if err != nil {
+		return fmt.Errorf("loading CA from secret: %w", err)
+	}
+
+	m.mu.Lock()
+	m.ca = ca
+	m.mu.Unlock()
+
+	log.Info("Loaded existing CA from secret")
+
+	// Ensure ConfigMap exists and is up to date
+	if err := m.ensureCABundleConfigMap(ctx); err != nil {
+		return fmt.Errorf("ensuring CA bundle ConfigMap: %w", err)
+	}
+
+	return nil
+}
+
+func (m *Manager) createCA(ctx context.Context) error {
+	log := logf.FromContext(ctx).WithName("ca-manager")
+
+	ca, err := Generate()
+	if err != nil {
+		return fmt.Errorf("generating CA: %w", err)
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      CASecretName,
+			Namespace: m.namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "isola-sandbox-ca",
+				"app.kubernetes.io/component":  "security",
+				"app.kubernetes.io/managed-by": "isola-operator",
+			},
+		},
+		Type: corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			"tls.crt": ca.CertPEM(),
+			"tls.key": ca.KeyPEM(),
+			"ca.crt":  ca.CertPEM(),
+			"ca.key":  ca.KeyPEM(),
+		},
+	}
+
+	if err := m.client.Create(ctx, secret); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			// Race condition - another instance created it, reload
+			return m.Initialize(ctx)
+		}
+		return fmt.Errorf("creating CA secret: %w", err)
+	}
+
+	m.mu.Lock()
+	m.ca = ca
+	m.mu.Unlock()
+
+	log.Info("Created new CA secret")
+
+	// Create ConfigMap with CA public cert for isola-gw
+	if err := m.ensureCABundleConfigMap(ctx); err != nil {
+		return fmt.Errorf("creating CA bundle ConfigMap: %w", err)
+	}
+
+	return nil
+}
+
+func (m *Manager) ensureCABundleConfigMap(ctx context.Context) error {
+	log := logf.FromContext(ctx).WithName("ca-manager")
+
+	m.mu.RLock()
+	caCertPEM := string(m.ca.CertPEM())
+	m.mu.RUnlock()
+
+	cm := &corev1.ConfigMap{}
+	err := m.client.Get(ctx, client.ObjectKey{Name: CABundleConfigMapName, Namespace: m.namespace}, cm)
+
+	if apierrors.IsNotFound(err) {
+		cm = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      CABundleConfigMapName,
+				Namespace: m.namespace,
+				Labels: map[string]string{
+					"app.kubernetes.io/name":       "isola-sandbox-ca-bundle",
+					"app.kubernetes.io/component":  "security",
+					"app.kubernetes.io/managed-by": "isola-operator",
+				},
+			},
+			Data: map[string]string{
+				"ca-bundle.crt": caCertPEM,
+			},
+		}
+		if err := m.client.Create(ctx, cm); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				return nil
+			}
+			return fmt.Errorf("creating CA bundle ConfigMap: %w", err)
+		}
+		log.Info("Created CA bundle ConfigMap")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("getting CA bundle ConfigMap: %w", err)
+	}
+
+	// Update if needed (e.g., after CA rotation)
+	if cm.Data["ca-bundle.crt"] != caCertPEM {
+		// Append new CA to bundle (keeps old CA for transition period)
+		existingBundle := cm.Data["ca-bundle.crt"]
+		if existingBundle != "" && existingBundle != caCertPEM {
+			cm.Data["ca-bundle.crt"] = caCertPEM + existingBundle
+		} else {
+			cm.Data["ca-bundle.crt"] = caCertPEM
+		}
+		if err := m.client.Update(ctx, cm); err != nil {
+			return fmt.Errorf("updating CA bundle ConfigMap: %w", err)
+		}
+		log.Info("Updated CA bundle ConfigMap")
+	}
+
+	return nil
+}
+
+// IssueCert generates a certificate for a sandbox agent.
+// The sandbox UUID is embedded in the certificate for verification by isola-gw.
+func (m *Manager) IssueCert(sandboxUUID, podDNS string) (certPEM, keyPEM []byte, err error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if m.ca == nil {
+		return nil, nil, fmt.Errorf("CA not initialized")
+	}
+
+	return m.ca.IssueCert(sandboxUUID, podDNS)
+}
+
+// CACertPEM returns the CA certificate in PEM format.
+func (m *Manager) CACertPEM() []byte {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if m.ca == nil {
+		return nil
+	}
+	return m.ca.CertPEM()
+}
+
+// Namespace returns the namespace where CA resources are stored.
+func (m *Manager) Namespace() string {
+	return m.namespace
+}

--- a/services/isola-operator/internal/controller/network/builder.go
+++ b/services/isola-operator/internal/controller/network/builder.go
@@ -101,8 +101,8 @@ const (
 
 	NetworkTemplateLabelKey = "sandbox.isola.run/network-template"
 
-	// the port used by the isola-agent sidecar
-	isolaAgentIngressPort = 8080
+	// the TLS port used by the isola-agent sidecar
+	isolaAgentIngressPort = 8443
 )
 
 func GetNetworkPolicyName(templateName string) string {

--- a/services/isola-operator/internal/controller/sandbox_controller.go
+++ b/services/isola-operator/internal/controller/sandbox_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"strings"
@@ -41,6 +42,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	sandboxv1alpha1 "github.com/omereli/dev-isola/services/isola-operator/api/v1alpha1"
+	"github.com/omereli/dev-isola/services/isola-operator/internal/ca"
 	"github.com/omereli/dev-isola/services/isola-operator/internal/controller/network"
 	"k8s.io/client-go/tools/record"
 )
@@ -105,6 +107,7 @@ type SandboxReconciler struct {
 	Scheme     *runtime.Scheme
 	Recorder   record.EventRecorder
 	AgentImage string
+	CAManager  *ca.Manager
 	Clock      Clock // Clock interface for time operations, allows mocking in tests
 }
 
@@ -139,9 +142,10 @@ func isNetworkTemplateReady(networkTemplate *sandboxv1alpha1.NetworkTemplate) bo
 	return readyCond != nil && readyCond.Status == metav1.ConditionTrue
 }
 
-func (r *SandboxReconciler) buildAgentContainer() corev1.Container {
+func (r *SandboxReconciler) buildAgentContainer(sandboxID, podDNS string) (corev1.Container, error) {
 	rp := corev1.ContainerRestartPolicyAlways
-	return corev1.Container{
+
+	container := corev1.Container{
 		Name:          agentContainerName,
 		Image:         r.AgentImage,
 		RestartPolicy: &rp,
@@ -151,9 +155,30 @@ func (r *SandboxReconciler) buildAgentContainer() corev1.Container {
 			RunAsUser: ptr.To(int64(0)),
 		},
 	}
+
+	// Issue TLS certificate for the agent with sandbox UUID embedded
+	if r.CAManager != nil {
+		certPEM, keyPEM, err := r.CAManager.IssueCert(sandboxID, podDNS)
+		if err != nil {
+			return corev1.Container{}, fmt.Errorf("issuing agent certificate: %w", err)
+		}
+
+		container.Env = append(container.Env,
+			corev1.EnvVar{
+				Name:  "ISOLA_AGENT_TLS_CERT",
+				Value: base64.StdEncoding.EncodeToString(certPEM),
+			},
+			corev1.EnvVar{
+				Name:  "ISOLA_AGENT_TLS_KEY",
+				Value: base64.StdEncoding.EncodeToString(keyPEM),
+			},
+		)
+	}
+
+	return container, nil
 }
 
-func (r *SandboxReconciler) injectSidecar(sandboxPod *corev1.Pod) error {
+func (r *SandboxReconciler) injectSidecar(sandboxPod *corev1.Pod, sandboxID, podDNS string) error {
 	if len(sandboxPod.Spec.Containers) != 1 {
 		// todo: remove this assumption
 		return fmt.Errorf("Sandbox pod must have exactly one container")
@@ -167,7 +192,10 @@ func (r *SandboxReconciler) injectSidecar(sandboxPod *corev1.Pod) error {
 		Value: "true",
 	})
 
-	agentContainer := r.buildAgentContainer()
+	agentContainer, err := r.buildAgentContainer(sandboxID, podDNS)
+	if err != nil {
+		return fmt.Errorf("building agent container: %w", err)
+	}
 	sandboxPod.Spec.InitContainers = append(sandboxPod.Spec.InitContainers, agentContainer)
 	return nil
 }
@@ -412,7 +440,16 @@ func (r *SandboxReconciler) CreateSandboxPod(ctx context.Context, sandbox *sandb
 		Options:     dnsOptions,
 	}
 
-	if err := r.injectSidecar(sandboxPod); err != nil {
+	// Get sandbox ID for certificate issuance
+	sandboxID := ""
+	if sandbox.Labels != nil {
+		sandboxID = sandbox.Labels["sandbox-id"]
+	}
+
+	// Construct the DNS name for the agent pod
+	podDNS := fmt.Sprintf("%s.sandbox-agents.%s.svc.cluster.local", getSandboxPodName(sandbox), sandbox.Namespace)
+
+	if err := r.injectSidecar(sandboxPod, sandboxID, podDNS); err != nil {
 		log.Error(err, "Failed to inject sidecar")
 		return err
 	}


### PR DESCRIPTION
Implement mTLS between isola-gw and sandbox agents with UUID-based
certificate verification to prevent stale IP reuse attacks.

Key changes:
- Add CA package in isola-operator for generating and signing certs
- Operator issues certificates with sandbox UUID in SPIFFE ID SAN
- Pass certificates to agent via environment variables (no secrets churn)
- Agent serves TLS on port 8443 when certificate is configured
- isola-gw verifies certificate is signed by CA and contains expected UUID
- CA bundle ConfigMap allows graceful CA rotation
- Update network policy for TLS port 8443

This ensures isola-gw can cryptographically verify it's communicating
with the intended sandbox, even if IPs are reused after sandbox termination.