### PR TITLE
use k8s secrets for bucket credentials with service account fallback

### DIFF
--- a/charts/isola-gw/templates/_helpers.tpl
+++ b/charts/isola-gw/templates/_helpers.tpl
@@ -1,4 +1,15 @@
 {{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "isola-gw.fullname" -}}
+{{- if contains "isola-gw" .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name "isola-gw" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
 Selector labels for matching pods
 */}}
 {{- define "isola-gw.selectorLabels" -}}

--- a/charts/isola-gw/templates/deployment.yaml
+++ b/charts/isola-gw/templates/deployment.yaml
@@ -66,14 +66,15 @@ spec:
         {{- if .Values.storage.enabled }}
         - name: ISOLA_BUCKET_URL
           value: {{ .Values.storage.bucketUrl | quote }}
-        {{- if .Values.storage.awsAccessKeyId }}
-        - name: AWS_ACCESS_KEY_ID
-          value: {{ .Values.storage.awsAccessKeyId | quote }}
         {{- end }}
-        {{- if .Values.storage.awsSecretAccessKey }}
-        - name: AWS_SECRET_ACCESS_KEY
-          value: {{ .Values.storage.awsSecretAccessKey | quote }}
+        # Bucket credentials loaded from secret (if configured)
+        # Falls back to service account auth (IRSA/Workload Identity) when no secret provided
+        {{- if .Values.storage.credentialsSecretRef }}
+        envFrom:
+        - secretRef:
+            name: {{ .Values.storage.credentialsSecretRef }}
+        {{- else if and .Values.storage.enabled .Values.storage.credentials.create }}
+        envFrom:
+        - secretRef:
+            name: {{ include "isola-gw.fullname" . }}-storage-credentials
         {{- end }}
-        {{- end }}
-#TODO: REMOVE SECRETS FROM THIS FILE - THEY SHOULD BE MOUNTED AS SECRETS
-#TODO: it doe ISOLA_GIN_MODE is determined by logLevel as it affects more than just logs

--- a/charts/isola-gw/templates/storage-secret.yaml
+++ b/charts/isola-gw/templates/storage-secret.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.storage.enabled .Values.storage.credentials.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "isola-gw.fullname" . }}-storage-credentials
+  labels:
+    app: isola-gw
+type: Opaque
+stringData:
+  {{- if .Values.storage.credentials.awsAccessKeyId }}
+  AWS_ACCESS_KEY_ID: {{ .Values.storage.credentials.awsAccessKeyId | quote }}
+  {{- end }}
+  {{- if .Values.storage.credentials.awsSecretAccessKey }}
+  AWS_SECRET_ACCESS_KEY: {{ .Values.storage.credentials.awsSecretAccessKey | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/isola-gw/values-dev.yaml
+++ b/charts/isola-gw/values-dev.yaml
@@ -16,5 +16,8 @@ nodePort:
 storage:
   enabled: true
   bucketUrl: "s3://isola-uploads?endpoint=http://localstack.localstack.svc.cluster.local:4566&use_path_style=true&region=us-east-1"
-  awsAccessKeyId: "test"
-  awsSecretAccessKey: "test"
+  # For development: create a Helm-managed secret with LocalStack test credentials
+  credentials:
+    create: true
+    awsAccessKeyId: "test"
+    awsSecretAccessKey: "test"

--- a/charts/isola-gw/values.yaml
+++ b/charts/isola-gw/values.yaml
@@ -13,6 +13,25 @@ nodePort:
 storage:
   enabled: false
   bucketUrl: ""
-  # Credentials (read automatically by go-cloud from standard env vars)
-  awsAccessKeyId: ""
-  awsSecretAccessKey: ""
+  # Credentials configuration - choose ONE of the following methods:
+  #
+  # Option 1: Reference an existing Kubernetes secret (recommended for production)
+  # The secret should contain keys matching cloud provider env vars:
+  #   - AWS: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+  #   - GCS: GOOGLE_APPLICATION_CREDENTIALS (path to mounted credentials file)
+  #   - Azure: AZURE_STORAGE_ACCOUNT, AZURE_STORAGE_KEY
+  credentialsSecretRef: ""
+  #
+  # Option 2: Let Helm create a secret with provided credentials
+  # Only use for development/testing - production should use existing secrets or IRSA
+  credentials:
+    create: false
+    # AWS credentials (only used if create: true)
+    awsAccessKeyId: ""
+    awsSecretAccessKey: ""
+  #
+  # Option 3: No credentials configured (default)
+  # Falls back to pod service account authentication:
+  #   - AWS: IRSA (IAM Roles for Service Accounts)
+  #   - GCP: Workload Identity
+  #   - Azure: Workload Identity


### PR DESCRIPTION
- Remove hardcoded credentials from helm values (no env vars in charts)
- Add credentialsSecretRef option to reference existing k8s secrets
- Add credentials.create option for Helm-managed secrets (dev/testing)
- Fall back to pod service account auth (IRSA/Workload Identity) when no secret configured
- Add storage-secret.yaml template for Helm-managed credentials
- Add fullname helper to _helpers.tpl