### PR TITLE
Rename TimedOut condition to DeadlineExceeded

### DIFF
--- a/services/isola-gw/internal/handlers/sandboxes.go
+++ b/services/isola-gw/internal/handlers/sandboxes.go
@@ -245,7 +245,7 @@ func (h *Handler) sandboxCRToModel(cr *unstructured.Unstructured) *models.Sandbo
 					}
 					break
 				}
-				if condType == "TimedOut" && condStatus == "True" {
+				if condType == "DeadlineExceeded" && condStatus == "True" {
 					state = models.SandboxStateStopped
 					break
 				}

--- a/services/isola-gw/internal/kubernetes/manager.go
+++ b/services/isola-gw/internal/kubernetes/manager.go
@@ -400,7 +400,7 @@ func (m *Manager) parseStateFromConditions(sandbox *unstructured.Unstructured) (
 		case "PodFailed", "PodCreationFailed":
 			errorReason := message
 			return models.SandboxStateError, &errorReason
-		case "PodSucceeded", "TimedOut", "Deleting":
+		case "PodSucceeded", "DeadlineExceeded", "Deleting":
 			return models.SandboxStateStopped, nil
 		case "NetworkConfigNotApplied", "NetworkTemplateNotFound", "NetworkTemplateDeleting":
 			// Network not ready yet, but pod might be pending/running

--- a/services/isola-operator/api/v1alpha1/sandbox_types.go
+++ b/services/isola-operator/api/v1alpha1/sandbox_types.go
@@ -31,9 +31,9 @@ const (
 	SandboxPodReady SandboxConditionType = "PodReady"
 	// Network is configured
 	SandboxNetworkConfigured SandboxConditionType = "NetworkConfigured"
-	// set when sandbox is past its timeout
+	// set when sandbox is past its deadline
 	// todo benl: necessary? helpful?
-	SandboxTimedOut SandboxConditionType = "TimedOut"
+	SandboxDeadlineExceeded SandboxConditionType = "DeadlineExceeded"
 	// Filesystem snapshotting is in progress
 	SandboxSnapshottingFilesystem SandboxConditionType = "SnapshottingFilesystem"
 )

--- a/services/isola-operator/internal/controller/sandbox_controller.go
+++ b/services/isola-operator/internal/controller/sandbox_controller.go
@@ -67,7 +67,7 @@ const (
 	CondReasonPodSucceeded      = "PodSucceeded"
 	CondReasonPodCreating       = "PodCreating"
 	CondReasonPodCreationFailed = "PodCreationFailed"
-	CondReasonSandboxTimedOut   = "TimedOut"
+	CondReasonSandboxDeadlineExceeded = "DeadlineExceeded"
 	CondReasonDeleting          = "Deleting"
 	CondReasonReconciling       = "Reconciling"
 
@@ -1215,7 +1215,7 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	if optionalTimeoutAt != nil && r.clock().Now().After(optionalTimeoutAt.Time) {
-		log.Info("Sandbox timed out")
+		log.Info("Sandbox deadline exceeded")
 
 		res, cleanupDone, err := r.finalizeSandbox(ctx, sandbox, baseSandbox, template)
 		if err != nil {
@@ -1323,8 +1323,8 @@ func (r *SandboxReconciler) executeShutdownPolicy(
 	// Determine reason and message based on trigger
 	var reason, message string
 	if trigger == CleanupTriggerTimeout {
-		reason = CondReasonSandboxTimedOut
-		message = "Sandbox timed out"
+		reason = CondReasonSandboxDeadlineExceeded
+		message = "Sandbox deadline exceeded"
 	} else {
 		reason = CondReasonDeleting
 		message = "Sandbox being deleted"

--- a/services/isola-operator/internal/controller/sandbox_controller_test.go
+++ b/services/isola-operator/internal/controller/sandbox_controller_test.go
@@ -899,7 +899,7 @@ var _ = Describe("Sandbox Controller", func() {
 			Expect(sandbox.Status.TimeoutAt.Time).To(BeTemporally("~", expectedTimeout, time.Second))
 		})
 
-		It("should delete sandbox with Delete policy when timeout exceeded and set TimedOut reason", func() {
+		It("should delete sandbox with Delete policy when timeout exceeded and set DeadlineExceeded reason", func() {
 			sandboxName := "sandbox-timeout-delete"
 			templateName := "template-timeout-delete"
 
@@ -932,7 +932,7 @@ var _ = Describe("Sandbox Controller", func() {
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("should set TimedOut condition reason before deleting sandbox", func() {
+		It("should set DeadlineExceeded condition reason before deleting sandbox", func() {
 			sandboxName := "sandbox-timeout-condition"
 			templateName := "template-timeout-condition"
 


### PR DESCRIPTION
Align with Kubernetes naming conventions used by other resources
like Jobs which use DeadlineExceeded for their condition reasons.

Changes:
- Rename SandboxTimedOut constant to SandboxDeadlineExceeded
- Rename CondReasonSandboxTimedOut to CondReasonSandboxDeadlineExceeded
- Update condition reason value from "TimedOut" to "DeadlineExceeded"
- Update log messages from "timed out" to "deadline exceeded"
- Update gateway handlers and manager to check for new condition name
- Update test descriptions to reflect new naming