### PR TITLE
Simplify the sandbox identification scheme

### DIFF
--- a/services/isola-gw/internal/handlers/sandboxes.go
+++ b/services/isola-gw/internal/handlers/sandboxes.go
@@ -115,8 +115,7 @@ func (h *Handler) CreateSandbox(c *gin.Context) {
 	log.Printf("Creating sandbox: %+v", sandbox)
 
 	ctx := c.Request.Context()
-	templateName := "sandbox-template-" + sandboxID
-	success, errorReason := h.k8sManager.CreateSandboxCR(ctx, sandboxID, req, templateName)
+	success, errorReason := h.k8sManager.CreateSandboxCR(ctx, sandboxID, req)
 	if !success {
 		errMsg := "unknown error"
 		if errorReason != nil {
@@ -204,26 +203,18 @@ func (h *Handler) sandboxCRToModel(cr *unstructured.Unstructured) *models.Sandbo
 		return nil
 	}
 
-	// Get sandbox ID from labels
-	labels, _ := metadata["labels"].(map[string]interface{})
-	sandboxID, ok := labels["sandbox-id"].(string)
+	// Sandbox ID is the K8s resource name (UUID)
+	sandboxID, ok := metadata["name"].(string)
 	if !ok || sandboxID == "" {
 		return nil
 	}
 
-	// Get name from annotation or fallback to CR name
-	var sandboxName string
+	// Get optional display name from annotation, fallback to ID
+	sandboxName := sandboxID
 	annotations, _ := metadata["annotations"].(map[string]interface{})
 	if annotations != nil {
-		if nameVal, ok := annotations["isola.run/sandbox-name"].(string); ok {
-			sandboxName = nameVal
-		}
-	}
-	if sandboxName == "" {
-		if nameVal, ok := metadata["name"].(string); ok {
-			sandboxName = nameVal
-		} else {
-			sandboxName = "sandbox-" + sandboxID[:min(8, len(sandboxID))]
+		if displayName, ok := annotations["isola.run/display-name"].(string); ok && displayName != "" {
+			sandboxName = displayName
 		}
 	}
 

--- a/services/isola-gw/internal/kubernetes/manager.go
+++ b/services/isola-gw/internal/kubernetes/manager.go
@@ -13,7 +13,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -91,13 +90,13 @@ func (m *Manager) doInitialize() error {
 	return nil
 }
 
-func (m *Manager) CreateSandboxCR(ctx context.Context, sandboxID string, req models.CreateSandboxRequest, templateName string) (bool, *string) {
+func (m *Manager) CreateSandboxCR(ctx context.Context, sandboxID string, req models.CreateSandboxRequest) (bool, *string) {
 	if err := m.Initialize(); err != nil {
 		errorMsg := fmt.Sprintf("Failed to initialize: %v", err)
 		return false, &errorMsg
 	}
 
-	// First create the SandboxTemplate CR
+	// First create the SandboxTemplate CR (uses same name as sandbox)
 	templateSpec := map[string]interface{}{
 		"podTemplate": map[string]interface{}{
 			"spec": map[string]interface{}{
@@ -128,35 +127,40 @@ func (m *Manager) CreateSandboxCR(ctx context.Context, sandboxID string, req mod
 		},
 	}
 
-	err := m.createSandboxTemplateCR(ctx, templateName, templateSpec)
+	// sandboxID (UUID) is used directly as the K8s resource name
+	// UUID format (e.g., "8d295c17-bea5-41a7-b74e-47ac60402bd9") is DNS-1123 compliant
+	err := m.createSandboxTemplateCR(ctx, sandboxID, templateSpec)
 	if err != nil {
 		errorMsg := fmt.Sprintf("Failed to create SandboxTemplate: %v", err)
 		return false, &errorMsg
 	}
 
-	// Create Sandbox CR
-	sandboxName := fmt.Sprintf("sandbox-%s", sandboxID[:min(8, len(sandboxID))])
-	log.Printf("Creating Sandbox CR '%s' (template=%s) in namespace '%s'",
-		sandboxName, templateName, m.namespace)
+	// Create Sandbox CR with UUID as the name
+	log.Printf("Creating Sandbox CR '%s' in namespace '%s'", sandboxID, m.namespace)
+
+	metadata := map[string]interface{}{
+		"name":      sandboxID,
+		"namespace": m.namespace,
+		"labels": map[string]interface{}{
+			"app.kubernetes.io/managed-by": "isola-gw",
+		},
+	}
+
+	// Add optional display name annotation if user provided a name
+	if req.Name != "" {
+		metadata["annotations"] = map[string]interface{}{
+			"isola.run/display-name": req.Name,
+		}
+	}
 
 	sandboxBody := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": fmt.Sprintf("%s/%s", sandboxGroup, sandboxVersion),
 			"kind":       "Sandbox",
-			"metadata": map[string]interface{}{
-				"name":      sandboxName,
-				"namespace": m.namespace,
-				"labels": map[string]interface{}{
-					"sandbox-id": sandboxID,
-					"managed-by": "isola-gw",
-				},
-				"annotations": map[string]interface{}{
-					"isola.run/sandbox-name": req.Name,
-				},
-			},
+			"metadata":   metadata,
 			"spec": map[string]interface{}{
 				"templateRef": map[string]interface{}{
-					"name": templateName,
+					"name": sandboxID,
 				},
 			},
 		},
@@ -171,15 +175,15 @@ func (m *Manager) CreateSandboxCR(ctx context.Context, sandboxID string, req mod
 	_, err = m.dynamicClient.Resource(gvr).Namespace(m.namespace).Create(ctx, sandboxBody, metav1.CreateOptions{})
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {
-			log.Printf("Sandbox CR '%s' already exists", sandboxName)
+			log.Printf("Sandbox CR '%s' already exists", sandboxID)
 			return true, nil
 		}
-		log.Printf("Failed to create Sandbox CR for %s: %v", sandboxID, err)
+		log.Printf("Failed to create Sandbox CR '%s': %v", sandboxID, err)
 		errorMsg := fmt.Sprintf("Kubernetes API error: %v", err)
 		return false, &errorMsg
 	}
 
-	log.Printf("Created Sandbox CR 'sandbox-%s' for sandbox %s", sandboxID[:min(8, len(sandboxID))], sandboxID)
+	log.Printf("Created Sandbox CR '%s'", sandboxID)
 	return true, nil
 }
 
@@ -235,14 +239,14 @@ func (m *Manager) GetSandboxCR(ctx context.Context, sandboxID string) (*unstruct
 		return nil, fmt.Errorf("failed to initialize: %w", err)
 	}
 
-	sandboxName := fmt.Sprintf("sandbox-%s", sandboxID[:min(8, len(sandboxID))])
+	// sandboxID is the K8s resource name directly
 	gvr := schema.GroupVersionResource{
 		Group:    sandboxGroup,
 		Version:  sandboxVersion,
 		Resource: sandboxPlural,
 	}
 
-	sandbox, err := m.dynamicClient.Resource(gvr).Namespace(m.namespace).Get(ctx, sandboxName, metav1.GetOptions{})
+	sandbox, err := m.dynamicClient.Resource(gvr).Namespace(m.namespace).Get(ctx, sandboxID, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, nil
@@ -283,8 +287,8 @@ func (m *Manager) DeleteSandboxCR(ctx context.Context, sandboxID string) error {
 		return fmt.Errorf("failed to initialize: %w", err)
 	}
 
-	sandboxName := fmt.Sprintf("sandbox-%s", sandboxID[:min(8, len(sandboxID))])
-	log.Printf("Deleting Sandbox CR '%s'", sandboxName)
+	// sandboxID is the K8s resource name directly
+	log.Printf("Deleting Sandbox CR '%s'", sandboxID)
 
 	gvr := schema.GroupVersionResource{
 		Group:    sandboxGroup,
@@ -292,17 +296,17 @@ func (m *Manager) DeleteSandboxCR(ctx context.Context, sandboxID string) error {
 		Resource: sandboxPlural,
 	}
 
-	err := m.dynamicClient.Resource(gvr).Namespace(m.namespace).Delete(ctx, sandboxName, metav1.DeleteOptions{})
+	err := m.dynamicClient.Resource(gvr).Namespace(m.namespace).Delete(ctx, sandboxID, metav1.DeleteOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			log.Printf("Sandbox CR '%s' already deleted", sandboxName)
+			log.Printf("Sandbox CR '%s' already deleted", sandboxID)
 			return nil // Idempotent: already gone is success
 		}
-		log.Printf("Failed to delete Sandbox CR '%s': %v", sandboxName, err)
+		log.Printf("Failed to delete Sandbox CR '%s': %v", sandboxID, err)
 		return err // Preserve original error for apierrors.IsNotFound() etc.
 	}
 
-	log.Printf("Deleted Sandbox CR '%s'", sandboxName)
+	log.Printf("Deleted Sandbox CR '%s'", sandboxID)
 	return nil
 }
 
@@ -345,10 +349,9 @@ func (m *Manager) GetSandboxStatus(ctx context.Context, sandboxID string) (*Sand
 
 // getAgentAddress constructs the DNS-resolvable address for the sandbox agent.
 // Format: <pod-name>.<headless-service>.<namespace>.svc.cluster.local
+// Pod name is the same as sandbox ID (UUID).
 func (m *Manager) getAgentAddress(sandboxID string) string {
-	sandboxName := fmt.Sprintf("sandbox-%s", sandboxID[:min(8, len(sandboxID))])
-	podName := sandboxName + "-pod"
-	return fmt.Sprintf("%s.%s.%s.svc.cluster.local", podName, agentServiceName, m.namespace)
+	return fmt.Sprintf("%s.%s.%s.svc.cluster.local", sandboxID, agentServiceName, m.namespace)
 }
 
 // parseStateFromConditions derives the SandboxState from the Sandbox CR conditions.
@@ -426,26 +429,21 @@ func (m *Manager) ExecuteCommand(ctx context.Context, sandboxID string, command 
 		return "", fmt.Sprintf("Failed to initialize: %v", err), 1, err
 	}
 
-	labelSelector := labels.SelectorFromSet(map[string]string{
-		"sandbox-id": sandboxID,
-	}).String()
+	// Pod name is the same as sandboxID (UUID)
+	podName := sandboxID
 
-	pods, err := m.clientset.CoreV1().Pods(m.namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: labelSelector,
-	})
+	pod, err := m.clientset.CoreV1().Pods(m.namespace).Get(ctx, podName, metav1.GetOptions{})
 	if err != nil {
-		log.Printf("Failed to list pods for sandbox %s: %v", sandboxID, err)
+		if apierrors.IsNotFound(err) {
+			errorMsg := fmt.Sprintf("Pod not found for sandbox %s", sandboxID)
+			log.Print(errorMsg)
+			return "", errorMsg, 1, errors.New(errorMsg)
+		}
+		log.Printf("Failed to get pod for sandbox %s: %v", sandboxID, err)
 		return "", fmt.Sprintf("API error: %v", err), 1, err
 	}
 
-	if len(pods.Items) == 0 {
-		errorMsg := fmt.Sprintf("Pod not found for sandbox %s", sandboxID)
-		log.Print(errorMsg)
-		return "", errorMsg, 1, errors.New(errorMsg)
-	}
-
-	pod := pods.Items[0]
-	podName := pod.Name
+	_ = pod // pod retrieved successfully
 
 	// Execute command in pod using /bin/sh -c
 	execCommand := []string{"/bin/sh", "-c", command}

--- a/services/isola-operator/api/v1alpha1/sandbox_types.go
+++ b/services/isola-operator/api/v1alpha1/sandbox_types.go
@@ -100,7 +100,7 @@ type SandboxSpec struct {
 
 // GetNetworkTemplateName returns the effective NetworkTemplate name for this sandbox.
 // - For templateRef: returns the referenced template name
-// - For spec: returns "{sandbox-name}-network"
+// - For spec: returns "{sandbox-name}-net"
 // - otherwise defaults to DefaultNetworkTemplate
 func (s *Sandbox) GetNetworkTemplateName() string {
 	if s.Spec.Network == nil {
@@ -113,7 +113,7 @@ func (s *Sandbox) GetNetworkTemplateName() string {
 }
 
 func (s *Sandbox) GetOwnedNetworkTemplateName() string {
-	return s.Name + "-network"
+	return s.Name + "-net"
 }
 
 func (s *Sandbox) HasNetworkSpec() bool {

--- a/services/isola-operator/api/v1alpha1/sandbox_types_test.go
+++ b/services/isola-operator/api/v1alpha1/sandbox_types_test.go
@@ -59,7 +59,7 @@ func TestGetNetworkTemplateName(t *testing.T) {
 					},
 				},
 			},
-			expected: "my-sandbox-network",
+			expected: "my-sandbox-net",
 		},
 		{
 			name: "network config with nil templateRef and nil spec returns owned name",
@@ -72,7 +72,7 @@ func TestGetNetworkTemplateName(t *testing.T) {
 					},
 				},
 			},
-			expected: "edge-case-network",
+			expected: "edge-case-net",
 		},
 	}
 
@@ -88,7 +88,7 @@ func TestGetOwnedNetworkTemplateName(t *testing.T) {
 	sandbox := Sandbox{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-sandbox"},
 	}
-	assert.Equal(t, "my-sandbox-network", sandbox.GetOwnedNetworkTemplateName())
+	assert.Equal(t, "my-sandbox-net", sandbox.GetOwnedNetworkTemplateName())
 }
 
 func TestHasNetworkSpec(t *testing.T) {

--- a/services/isola-operator/internal/controller/sandbox_controller.go
+++ b/services/isola-operator/internal/controller/sandbox_controller.go
@@ -340,13 +340,6 @@ func (r *SandboxReconciler) CreateSandboxPod(ctx context.Context, sandbox *sandb
 		labels[network.NetworkTemplateLabelKey] = networkTemplate.Name
 	}
 
-	// todo benl: why this exists? ("sandbox-id")
-	if sandbox.Labels != nil {
-		if sandboxID, exists := sandbox.Labels["sandbox-id"]; exists {
-			labels["sandbox-id"] = sandboxID
-		}
-	}
-
 	if template.Spec.PodTemplate.Labels != nil {
 		maps.Copy(labels, template.Spec.PodTemplate.Labels)
 	}
@@ -661,7 +654,8 @@ func (r *SandboxReconciler) CreateSnapshotterJob(
 }
 
 func getSandboxPodName(sandbox *sandboxv1alpha1.Sandbox) string {
-	return sandbox.Name + "-pod"
+	// Pod name is the same as sandbox name (UUID)
+	return sandbox.Name
 }
 
 func (r *SandboxReconciler) getSandboxPod(ctx context.Context, sandbox *sandboxv1alpha1.Sandbox) (*corev1.Pod, error) {
@@ -680,7 +674,7 @@ func (r *SandboxReconciler) getSandboxPod(ctx context.Context, sandbox *sandboxv
 }
 
 func getFilesystemSnapshotterJobName(sandbox *sandboxv1alpha1.Sandbox) string {
-	return sandbox.Name + "-fssnapshotter"
+	return sandbox.Name + "-snap"
 }
 
 func (r *SandboxReconciler) getFilesystemSnapshotterJob(ctx context.Context, sandbox *sandboxv1alpha1.Sandbox) (*batchv1.Job, error) {

--- a/services/isola-operator/internal/controller/sandbox_controller_test.go
+++ b/services/isola-operator/internal/controller/sandbox_controller_test.go
@@ -304,7 +304,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
-			defer deletePod(ctx, sandboxName+"-pod")
+			defer deletePod(ctx, sandboxName)
 
 			_, err := doReconcile(ctx, reconciler, sandboxName)
 			Expect(err).NotTo(HaveOccurred())
@@ -322,7 +322,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
-			defer deletePod(ctx, sandboxName+"-pod")
+			defer deletePod(ctx, sandboxName)
 
 			_, err := doReconcile(ctx, reconciler, sandboxName)
 			Expect(err).NotTo(HaveOccurred())
@@ -377,11 +377,11 @@ var _ = Describe("Sandbox Controller", func() {
 
 			createSandbox(ctx, sandbox1Name, templateName)
 			defer deleteSandbox(ctx, sandbox1Name)
-			defer deletePod(ctx, sandbox1Name+"-pod")
+			defer deletePod(ctx, sandbox1Name)
 
 			createSandbox(ctx, sandbox2Name, templateName)
 			defer deleteSandbox(ctx, sandbox2Name)
-			defer deletePod(ctx, sandbox2Name+"-pod")
+			defer deletePod(ctx, sandbox2Name)
 
 			createSandbox(ctx, sandbox3Name, "other-template")
 			defer deleteSandbox(ctx, sandbox3Name)
@@ -433,7 +433,7 @@ var _ = Describe("Sandbox Controller", func() {
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
 
-			podName := sandboxName + "-pod"
+			podName := sandboxName
 			defer deletePod(ctx, podName)
 
 			_, err := doReconcile(ctx, reconciler, sandboxName)
@@ -456,7 +456,7 @@ var _ = Describe("Sandbox Controller", func() {
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
 
-			podName := sandboxName + "-pod"
+			podName := sandboxName
 			defer deletePod(ctx, podName)
 
 			_, err := doReconcile(ctx, reconciler, sandboxName)
@@ -479,7 +479,7 @@ var _ = Describe("Sandbox Controller", func() {
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
 
-			podName := sandboxName + "-pod"
+			podName := sandboxName
 			defer deletePod(ctx, podName)
 
 			_, err := doReconcile(ctx, reconciler, sandboxName)
@@ -504,7 +504,7 @@ var _ = Describe("Sandbox Controller", func() {
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
 
-			podName := sandboxName + "-pod"
+			podName := sandboxName
 			defer deletePod(ctx, podName)
 
 			_, err := doReconcile(ctx, reconciler, sandboxName)
@@ -534,7 +534,7 @@ var _ = Describe("Sandbox Controller", func() {
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
 
-			podName := sandboxName + "-pod"
+			podName := sandboxName
 			defer deletePod(ctx, podName)
 
 			_, err := doReconcile(ctx, reconcilerWithRuntime, sandboxName)
@@ -557,7 +557,7 @@ var _ = Describe("Sandbox Controller", func() {
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
 
-			podName := sandboxName + "-pod"
+			podName := sandboxName
 			defer deletePod(ctx, podName)
 
 			_, err := doReconcile(ctx, reconciler, sandboxName)
@@ -592,7 +592,7 @@ var _ = Describe("Sandbox Controller", func() {
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
 
-			podName := sandboxName + "-pod"
+			podName := sandboxName
 			defer deletePod(ctx, podName)
 
 			_, err := doReconcile(ctx, reconciler, sandboxName)
@@ -630,7 +630,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
-			defer deletePod(ctx, sandboxName+"-pod")
+			defer deletePod(ctx, sandboxName)
 
 			_, err := doReconcile(ctx, reconciler, sandboxName)
 			Expect(err).NotTo(HaveOccurred())
@@ -649,7 +649,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
-			defer deletePod(ctx, sandboxName+"-pod")
+			defer deletePod(ctx, sandboxName)
 
 			_, err := doReconcile(ctx, reconciler, sandboxName)
 			Expect(err).NotTo(HaveOccurred())
@@ -675,7 +675,7 @@ var _ = Describe("Sandbox Controller", func() {
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
 
-			podName := sandboxName + "-pod"
+			podName := sandboxName
 			defer deletePod(ctx, podName)
 
 			_, err := doReconcile(ctx, reconciler, sandboxName)
@@ -711,7 +711,7 @@ var _ = Describe("Sandbox Controller", func() {
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
 
-			podName := sandboxName + "-pod"
+			podName := sandboxName
 			defer deletePod(ctx, podName)
 
 			_, err := doReconcile(ctx, reconciler, sandboxName)
@@ -746,7 +746,7 @@ var _ = Describe("Sandbox Controller", func() {
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
 
-			podName := sandboxName + "-pod"
+			podName := sandboxName
 			defer deletePod(ctx, podName)
 
 			_, err := doReconcile(ctx, reconciler, sandboxName)
@@ -781,7 +781,7 @@ var _ = Describe("Sandbox Controller", func() {
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
 
-			podName := sandboxName + "-pod"
+			podName := sandboxName
 			defer deletePod(ctx, podName)
 
 			_, err := doReconcile(ctx, reconciler, sandboxName)
@@ -821,7 +821,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
-			defer deletePod(ctx, sandboxName+"-pod")
+			defer deletePod(ctx, sandboxName)
 
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: sandboxName, Namespace: testNamespace},
@@ -858,7 +858,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
-			defer deletePod(ctx, sandboxName+"-pod")
+			defer deletePod(ctx, sandboxName)
 
 			_, err := doReconcile(ctx, reconciler, sandboxName)
 			Expect(err).NotTo(HaveOccurred())
@@ -880,7 +880,7 @@ var _ = Describe("Sandbox Controller", func() {
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
 
-			podName := sandboxName + "-pod"
+			podName := sandboxName
 			defer deletePod(ctx, podName)
 
 			_, err := doReconcile(ctx, reconciler, sandboxName)
@@ -921,7 +921,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
-			defer deletePod(ctx, sandboxName+"-pod")
+			defer deletePod(ctx, sandboxName)
 
 			_, err := doReconcile(ctx, reconciler, sandboxName)
 			Expect(err).NotTo(HaveOccurred())
@@ -948,7 +948,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
-			defer deletePod(ctx, sandboxName+"-pod")
+			defer deletePod(ctx, sandboxName)
 
 			_, err := doReconcile(ctx, reconciler, sandboxName)
 			Expect(err).NotTo(HaveOccurred())
@@ -979,7 +979,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 			sandbox := createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
-			defer deletePod(ctx, sandboxName+"-pod")
+			defer deletePod(ctx, sandboxName)
 
 			_, err := doReconcile(ctx, reconciler, sandboxName)
 			Expect(err).NotTo(HaveOccurred())
@@ -1010,7 +1010,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
-			defer deletePod(ctx, sandboxName+"-pod")
+			defer deletePod(ctx, sandboxName)
 
 			result, err := doReconcile(ctx, reconciler, sandboxName)
 			Expect(err).NotTo(HaveOccurred())
@@ -1052,7 +1052,7 @@ var _ = Describe("Sandbox Controller", func() {
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
 
-			podName := sandboxName + "-pod"
+			podName := sandboxName
 			defer deletePod(ctx, podName)
 
 			_, err := doReconcile(ctx, reconciler, sandboxName)
@@ -1113,7 +1113,7 @@ var _ = Describe("Sandbox Controller", func() {
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
 
-			podName := sandboxName + "-pod"
+			podName := sandboxName
 			defer deletePod(ctx, podName)
 
 			_, err := doReconcile(ctx, reconciler, sandboxName)
@@ -1171,8 +1171,8 @@ var _ = Describe("Sandbox Controller", func() {
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
 
-			podName := sandboxName + "-pod"
-			snapshotterJobName := sandboxName + "-fssnapshotter"
+			podName := sandboxName
+			snapshotterJobName := sandboxName + "-snap"
 			defer deletePod(ctx, podName)
 			defer deleteJob(ctx, snapshotterJobName)
 
@@ -1246,7 +1246,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
-			defer deletePod(ctx, sandboxName+"-pod")
+			defer deletePod(ctx, sandboxName)
 
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: sandboxName, Namespace: testNamespace},
@@ -1254,7 +1254,7 @@ var _ = Describe("Sandbox Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Simulate pod being gone
-			deletePod(ctx, sandboxName+"-pod")
+			deletePod(ctx, sandboxName)
 			fakeClock.Advance(2 * time.Second)
 
 			// Reconcile - sandbox deleted after snapshot skipped (pod missing)
@@ -1291,8 +1291,8 @@ var _ = Describe("Sandbox Controller", func() {
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
 
-			podName := sandboxName + "-pod"
-			snapshotterJobName := sandboxName + "-fssnapshotter"
+			podName := sandboxName
+			snapshotterJobName := sandboxName + "-snap"
 			defer deletePod(ctx, podName)
 			defer deleteJob(ctx, snapshotterJobName)
 
@@ -1381,8 +1381,8 @@ var _ = Describe("Sandbox Controller", func() {
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
 
-			podName := sandboxName + "-pod"
-			snapshotterJobName := sandboxName + "-fssnapshotter"
+			podName := sandboxName
+			snapshotterJobName := sandboxName + "-snap"
 			defer deletePod(ctx, podName)
 			defer deleteJob(ctx, snapshotterJobName)
 
@@ -1445,7 +1445,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
-			defer deletePod(ctx, sandboxName+"-pod")
+			defer deletePod(ctx, sandboxName)
 
 			template := &sandboxv1alpha1.SandboxTemplate{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: templateName, Namespace: testNamespace}, template)).To(Succeed())
@@ -1475,8 +1475,8 @@ var _ = Describe("Sandbox Controller", func() {
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
 
-			podName := sandboxName + "-pod"
-			snapshotterJobName := sandboxName + "-fssnapshotter"
+			podName := sandboxName
+			snapshotterJobName := sandboxName + "-snap"
 			defer deletePod(ctx, podName)
 			defer deleteJob(ctx, snapshotterJobName)
 
@@ -1536,7 +1536,7 @@ var _ = Describe("Sandbox Controller", func() {
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
 
-			podName := sandboxName + "-pod"
+			podName := sandboxName
 			defer deletePod(ctx, podName)
 
 			// Reconcile to try to create pod - this should fail because RuntimeClass doesn't exist
@@ -1568,8 +1568,8 @@ var _ = Describe("Sandbox Controller", func() {
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
 
-			podName := sandboxName + "-pod"
-			snapshotterJobName := sandboxName + "-fssnapshotter"
+			podName := sandboxName
+			snapshotterJobName := sandboxName + "-snap"
 			defer deletePod(ctx, podName)
 			defer deleteJob(ctx, snapshotterJobName)
 
@@ -1659,7 +1659,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
-			defer deletePod(ctx, sandboxName+"-pod")
+			defer deletePod(ctx, sandboxName)
 
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: sandboxName, Namespace: testNamespace},
@@ -1696,8 +1696,8 @@ var _ = Describe("Sandbox Controller", func() {
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
 
-			podName := sandboxName + "-pod"
-			snapshotterJobName := sandboxName + "-fssnapshotter"
+			podName := sandboxName
+			snapshotterJobName := sandboxName + "-snap"
 			defer deletePod(ctx, podName)
 			defer deleteJob(ctx, snapshotterJobName)
 
@@ -1743,8 +1743,8 @@ var _ = Describe("Sandbox Controller", func() {
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
 
-			podName := sandboxName + "-pod"
-			snapshotterJobName := sandboxName + "-fssnapshotter"
+			podName := sandboxName
+			snapshotterJobName := sandboxName + "-snap"
 			defer deletePod(ctx, podName)
 			defer deleteJob(ctx, snapshotterJobName)
 
@@ -1819,8 +1819,8 @@ var _ = Describe("Sandbox Controller", func() {
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
 
-			podName := sandboxName + "-pod"
-			snapshotterJobName := sandboxName + "-fssnapshotter"
+			podName := sandboxName
+			snapshotterJobName := sandboxName + "-snap"
 			defer deletePod(ctx, podName)
 			defer deleteJob(ctx, snapshotterJobName)
 
@@ -1900,7 +1900,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 			sandbox := createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
-			defer deletePod(ctx, sandboxName+"-pod")
+			defer deletePod(ctx, sandboxName)
 
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: sandboxName, Namespace: testNamespace},
@@ -1932,7 +1932,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
-			defer deletePod(ctx, sandboxName+"-pod")
+			defer deletePod(ctx, sandboxName)
 
 			// First reconcile
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
@@ -1978,7 +1978,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
-			defer deletePod(ctx, sandboxName+"-pod")
+			defer deletePod(ctx, sandboxName)
 
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: sandboxName, Namespace: testNamespace},
@@ -1999,7 +1999,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
-			defer deletePod(ctx, sandboxName+"-pod")
+			defer deletePod(ctx, sandboxName)
 
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: sandboxName, Namespace: testNamespace},
@@ -2032,7 +2032,7 @@ var _ = Describe("Sandbox Controller", func() {
 			defer deleteTemplate(ctx, templateName)
 
 			createSandbox(ctx, sandboxName, templateName)
-			defer deletePod(ctx, sandboxName+"-pod")
+			defer deletePod(ctx, sandboxName)
 
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: sandboxName, Namespace: testNamespace},
@@ -2058,7 +2058,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 			createTemplate(ctx, templateName)
 			createSandbox(ctx, sandboxName, templateName)
-			defer deletePod(ctx, sandboxName+"-pod")
+			defer deletePod(ctx, sandboxName)
 
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: sandboxName, Namespace: testNamespace},
@@ -2101,8 +2101,8 @@ var _ = Describe("Sandbox Controller", func() {
 
 			createSandbox(ctx, sandboxName, templateName)
 
-			podName := sandboxName + "-pod"
-			snapshotterJobName := sandboxName + "-fssnapshotter"
+			podName := sandboxName
+			snapshotterJobName := sandboxName + "-snap"
 			defer deletePod(ctx, podName)
 			defer deleteJob(ctx, snapshotterJobName)
 
@@ -2227,7 +2227,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 			createSandboxWithNetworkTemplate(ctx, sandboxName, templateName, networkTemplateName)
 			defer deleteSandbox(ctx, sandboxName)
-			defer deletePod(ctx, sandboxName+"-pod")
+			defer deletePod(ctx, sandboxName)
 
 			_, err := doReconcile(ctx, reconciler, sandboxName)
 			Expect(err).NotTo(HaveOccurred())
@@ -2267,7 +2267,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 			createSandbox(ctx, sandboxName, templateName)
 			defer deleteSandbox(ctx, sandboxName)
-			defer deletePod(ctx, sandboxName+"-pod")
+			defer deletePod(ctx, sandboxName)
 
 			_, err := doReconcile(ctx, reconciler, sandboxName)
 			Expect(err).NotTo(HaveOccurred())
@@ -2293,7 +2293,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 			createSandboxWithNetworkTemplate(ctx, sandboxName, templateName, networkTemplateName)
 			defer deleteSandbox(ctx, sandboxName)
-			defer deletePod(ctx, sandboxName+"-pod")
+			defer deletePod(ctx, sandboxName)
 
 			_, err := doReconcile(ctx, reconciler, sandboxName)
 			Expect(err).NotTo(HaveOccurred())
@@ -2330,7 +2330,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 			createSandboxWithNetworkTemplate(ctx, sandboxName, templateName, networkTemplateName)
 			defer deleteSandbox(ctx, sandboxName)
-			defer deletePod(ctx, sandboxName+"-pod")
+			defer deletePod(ctx, sandboxName)
 
 			_, err := doReconcile(ctx, reconciler, sandboxName)
 			Expect(err).NotTo(HaveOccurred())
@@ -2366,7 +2366,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 			createSandboxWithNetworkTemplate(ctx, sandboxName, templateName, networkTemplateName)
 			defer deleteSandbox(ctx, sandboxName)
-			defer deletePod(ctx, sandboxName+"-pod")
+			defer deletePod(ctx, sandboxName)
 
 			_, err := doReconcile(ctx, reconciler, sandboxName)
 			Expect(err).NotTo(HaveOccurred())
@@ -2407,7 +2407,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 			createSandboxWithNetworkTemplate(ctx, sandboxName, templateName, networkTemplateName)
 			defer deleteSandbox(ctx, sandboxName)
-			defer deletePod(ctx, sandboxName+"-pod")
+			defer deletePod(ctx, sandboxName)
 
 			_, err := doReconcile(ctx, reconciler, sandboxName)
 			Expect(err).NotTo(HaveOccurred())
@@ -2459,7 +2459,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 			createSandboxWithNetworkTemplate(ctx, sandboxName, templateName, networkTemplateName)
 			defer deleteSandbox(ctx, sandboxName)
-			defer deletePod(ctx, sandboxName+"-pod")
+			defer deletePod(ctx, sandboxName)
 
 			_, err := doReconcile(ctx, reconciler, sandboxName)
 			Expect(err).NotTo(HaveOccurred())
@@ -2514,7 +2514,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 			createSandboxWithNetworkTemplate(ctx, sandboxName, templateName, networkTemplateName)
 			defer deleteSandbox(ctx, sandboxName)
-			defer deletePod(ctx, sandboxName+"-pod")
+			defer deletePod(ctx, sandboxName)
 
 			// Initial reconcile - creates Pod
 			_, err := doReconcile(ctx, reconciler, sandboxName)
@@ -2560,7 +2560,7 @@ var _ = Describe("Sandbox Controller", func() {
 			// Create first sandbox
 			createSandboxWithNetworkTemplate(ctx, sandbox1Name, templateName, networkTemplateName)
 			defer deleteSandbox(ctx, sandbox1Name)
-			defer deletePod(ctx, sandbox1Name+"-pod")
+			defer deletePod(ctx, sandbox1Name)
 
 			// Reconcile first sandbox - creates Pod, reuses NetworkPolicy
 			_, err := doReconcile(ctx, reconciler, sandbox1Name)
@@ -2569,7 +2569,7 @@ var _ = Describe("Sandbox Controller", func() {
 			// Create second sandbox using the same NetworkTemplate
 			createSandboxWithNetworkTemplate(ctx, sandbox2Name, templateName, networkTemplateName)
 			defer deleteSandbox(ctx, sandbox2Name)
-			defer deletePod(ctx, sandbox2Name+"-pod")
+			defer deletePod(ctx, sandbox2Name)
 
 			// Reconcile second sandbox - should not fail, reuses existing NetworkPolicy
 			_, err = doReconcile(ctx, reconciler, sandbox2Name)
@@ -2621,7 +2621,7 @@ var _ = Describe("Sandbox Controller", func() {
 			// Create sandbox referencing the deleting template
 			createSandboxWithNetworkTemplate(ctx, sandboxName, templateName, networkTemplateName)
 			defer deleteSandbox(ctx, sandboxName)
-			defer deletePod(ctx, sandboxName+"-pod")
+			defer deletePod(ctx, sandboxName)
 
 			// Reconcile - should detect template is being deleted
 			_, err := doReconcile(ctx, reconciler, sandboxName)
@@ -2633,7 +2633,7 @@ var _ = Describe("Sandbox Controller", func() {
 				metav1.ConditionFalse, CondReasonNetworkTemplateDeleting)).To(BeTrue())
 
 			// Verify no pod was created (template is being deleted)
-			pod := getPod(ctx, sandboxName+"-pod")
+			pod := getPod(ctx, sandboxName)
 			Expect(pod).To(BeNil())
 		})
 	})
@@ -2689,14 +2689,14 @@ var _ = Describe("Sandbox Controller", func() {
 			}
 			createSandboxWithNetworkSpec(sandboxName, templateName, networkSpec)
 			defer deleteSandbox(ctx, sandboxName)
-			defer deletePod(ctx, sandboxName+"-pod")
+			defer deletePod(ctx, sandboxName)
 
 			// Reconcile - should create owned NetworkTemplate
 			_, err := doReconcile(ctx, reconciler, sandboxName)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify owned NetworkTemplate was created
-			ownedTemplateName := sandboxName + "-network"
+			ownedTemplateName := sandboxName + "-net"
 			nt := &sandboxv1alpha1.NetworkTemplate{}
 			err = k8sClient.Get(ctx, types.NamespacedName{Name: ownedTemplateName, Namespace: testNamespace}, nt)
 			Expect(err).NotTo(HaveOccurred())
@@ -2731,14 +2731,14 @@ var _ = Describe("Sandbox Controller", func() {
 			}
 			createSandboxWithNetworkSpec(sandboxName, templateName, networkSpec)
 			defer deleteSandbox(ctx, sandboxName)
-			defer deletePod(ctx, sandboxName+"-pod")
+			defer deletePod(ctx, sandboxName)
 
 			// First reconcile - creates owned template
 			_, err := doReconcile(ctx, reconciler, sandboxName)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify initial spec
-			ownedTemplateName := sandboxName + "-network"
+			ownedTemplateName := sandboxName + "-net"
 			nt := &sandboxv1alpha1.NetworkTemplate{}
 			err = k8sClient.Get(ctx, types.NamespacedName{Name: ownedTemplateName, Namespace: testNamespace}, nt)
 			Expect(err).NotTo(HaveOccurred())
@@ -2766,7 +2766,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 		It("should fail with error when owned template name conflicts with non-owned template", func() {
 			// Create a non-owned NetworkTemplate with the expected owned name
-			conflictingName := sandboxName + "-network"
+			conflictingName := sandboxName + "-net"
 			conflictingNT := &sandboxv1alpha1.NetworkTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      conflictingName,
@@ -2836,13 +2836,13 @@ var _ = Describe("Sandbox Controller", func() {
 			}
 			createSandboxWithNetworkSpec(sandbox1Name, templateName, networkSpec)
 			defer deleteSandbox(ctx, sandbox1Name)
-			defer deletePod(ctx, sandbox1Name+"-pod")
+			defer deletePod(ctx, sandbox1Name)
 
 			// Create sandbox2 with templateRef
 			sandbox2Name := sandboxName + "-2"
 			createSandboxWithNetworkTemplate(ctx, sandbox2Name, templateName, sharedTemplateName)
 			defer deleteSandbox(ctx, sandbox2Name)
-			defer deletePod(ctx, sandbox2Name+"-pod")
+			defer deletePod(ctx, sandbox2Name)
 
 			// Reconcile sandbox1
 			_, err = doReconcile(ctx, reconciler, sandbox1Name)
@@ -2850,7 +2850,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 			// Verify sandbox1's owned template
 			owned1 := &sandboxv1alpha1.NetworkTemplate{}
-			err = k8sClient.Get(ctx, types.NamespacedName{Name: sandbox1Name + "-network", Namespace: testNamespace}, owned1)
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: sandbox1Name + "-net", Namespace: testNamespace}, owned1)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(owned1.Labels["sandbox.isola.run/owned"]).To(Equal("true"))
 			defer func() {
@@ -2867,7 +2867,7 @@ var _ = Describe("Sandbox Controller", func() {
 			Expect(sandbox2.GetNetworkTemplateName()).To(Equal(sharedTemplateName))
 
 			// The owned template for sandbox1 should not have sandbox2 as owner
-			err = k8sClient.Get(ctx, types.NamespacedName{Name: sandbox1Name + "-network", Namespace: testNamespace}, owned1)
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: sandbox1Name + "-net", Namespace: testNamespace}, owned1)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(owned1.OwnerReferences).To(HaveLen(1))
 			Expect(owned1.OwnerReferences[0].Name).To(Equal(sandbox1Name))
@@ -2933,7 +2933,7 @@ var _ = Describe("Sandbox Controller", func() {
 			_, err := doReconcile(ctx, reconciler, sandboxName)
 			Expect(err).NotTo(HaveOccurred())
 
-			podName := sandboxName + "-pod"
+			podName := sandboxName
 			pod := getPod(ctx, podName)
 			Expect(pod).To(BeNil(), "pod should not exist when default NetworkTemplate is missing")
 
@@ -2947,7 +2947,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 		It("should create pod with default template label when default template exists", func() {
 			sandboxName := fmt.Sprintf("sandbox-default-template-%d", time.Now().UnixNano())
-			podName := sandboxName + "-pod"
+			podName := sandboxName
 
 			// Default template already exists from BeforeSuite
 
@@ -2979,7 +2979,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 		It("should configure ClusterFirst DNS when dnsPolicy is ClusterFirst", func() {
 			sandboxName := fmt.Sprintf("sandbox-dns-cluster-%d", time.Now().UnixNano())
-			podName := sandboxName + "-pod"
+			podName := sandboxName
 			networkTemplateName := fmt.Sprintf("dns-cluster-template-%d", time.Now().UnixNano())
 
 			// Create network template with ClusterFirst - needs egress to DNS pods
@@ -3014,7 +3014,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 		It("should configure DNS None with ndots:1 when dnsPolicy is None", func() {
 			sandboxName := fmt.Sprintf("sandbox-dns-none-%d", time.Now().UnixNano())
-			podName := sandboxName + "-pod"
+			podName := sandboxName
 			networkTemplateName := fmt.Sprintf("dns-none-template-%d", time.Now().UnixNano())
 
 			createNetworkTemplate(ctx, networkTemplateName, func(nt *sandboxv1alpha1.NetworkTemplate) {
@@ -3044,7 +3044,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 		It("should use sink nameserver with fast-fail options when dnsPolicy is None and nameservers is empty", func() {
 			sandboxName := fmt.Sprintf("sandbox-dns-sink-%d", time.Now().UnixNano())
-			podName := sandboxName + "-pod"
+			podName := sandboxName
 			networkTemplateName := fmt.Sprintf("dns-sink-template-%d", time.Now().UnixNano())
 
 			createNetworkTemplate(ctx, networkTemplateName, func(nt *sandboxv1alpha1.NetworkTemplate) {
@@ -3082,7 +3082,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 		It("should preserve existing DNSConfig options when adding nameservers for ClusterFirst", func() {
 			sandboxName := fmt.Sprintf("sandbox-dns-preserve-%d", time.Now().UnixNano())
-			podName := sandboxName + "-pod"
+			podName := sandboxName
 			networkTemplateName := fmt.Sprintf("dns-preserve-template-%d", time.Now().UnixNano())
 			customTemplateName := fmt.Sprintf("template-dns-preserve-%d", time.Now().UnixNano())
 
@@ -3155,7 +3155,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 		It("should have NetworkReady=False when network template not ready", func() {
 			sandboxName := fmt.Sprintf("sandbox-ready-network-%d", time.Now().UnixNano())
-			podName := sandboxName + "-pod"
+			podName := sandboxName
 
 			// Replace the default template with one that is NOT reconciled (not ready)
 			deleteNetworkTemplate(ctx, sandboxv1alpha1.DefaultNetworkTemplate)
@@ -3216,7 +3216,7 @@ var _ = Describe("Sandbox Controller", func() {
 
 		It("should reconcile sandbox when referenced NetworkTemplate is created", func() {
 			sandboxName := fmt.Sprintf("sandbox-watch-test-%d", time.Now().UnixNano())
-			podName := sandboxName + "-pod"
+			podName := sandboxName
 			networkTemplateName := fmt.Sprintf("watch-template-%d", time.Now().UnixNano())
 
 			cachedReconciler := newTestReconcilerWithCache(fakeClock)

--- a/tests/helpers/k8s.py
+++ b/tests/helpers/k8s.py
@@ -45,16 +45,16 @@ class K8sHelper:
         sandbox_id: str,
         namespace: str = "isola-sandboxes",
     ) -> V1Pod | None:
-        """Get the pod for a sandbox by its ID."""
+        """Get the pod for a sandbox by its ID (UUID = pod name)."""
         try:
-            pods = self.core_v1.list_namespaced_pod(
+            # Pod name is the same as sandbox_id (UUID)
+            return self.core_v1.read_namespaced_pod(
+                name=sandbox_id,
                 namespace=namespace,
-                label_selector=f"sandbox-id={sandbox_id}",
             )
-            if pods.items:
-                return pods.items[0]
-            return None
         except ApiException as e:
+            if e.status == 404:
+                return None
             logger.error(f"Failed to get sandbox pod: {e}")
             return None
 
@@ -63,14 +63,14 @@ class K8sHelper:
         sandbox_id: str,
         namespace: str = "isola-sandboxes",
     ) -> dict | None:
-        """Get the Sandbox custom resource."""
+        """Get the Sandbox custom resource (sandbox_id is the K8s resource name)."""
         try:
             return self.custom.get_namespaced_custom_object(
                 group="sandbox.isola.run",
                 version="v1alpha1",
                 namespace=namespace,
                 plural="sandboxes",
-                name=f"sandbox-{sandbox_id}",
+                name=sandbox_id,
             )
         except ApiException as e:
             if e.status == 404:

--- a/tests/test_network_connectivity.py
+++ b/tests/test_network_connectivity.py
@@ -135,9 +135,10 @@ def sandbox_with_localstack_access(
     This creates the Sandbox CR directly with the network template reference.
     """
     namespace = "isola-sandboxes"
-    sandbox_id = uuid.uuid4().hex
-    sandbox_name = f"sandbox-{sandbox_id[:8]}"
-    template_name = f"template-{sandbox_id[:8]}"
+    # Use full UUID as the sandbox name (K8s resource name = ID)
+    sandbox_id = str(uuid.uuid4())
+    sandbox_name = sandbox_id
+    template_name = sandbox_id  # SandboxTemplate uses same name
 
     # Create SandboxTemplate first
     template_body = {
@@ -179,8 +180,7 @@ def sandbox_with_localstack_access(
             "name": sandbox_name,
             "namespace": namespace,
             "labels": {
-                "sandbox-id": sandbox_id,
-                "managed-by": "e2e-test",
+                "app.kubernetes.io/managed-by": "e2e-test",
             },
         },
         "spec": {


### PR DESCRIPTION
Simplify the sandbox identification scheme by using the UUID directly as the Kubernetes resource name. This eliminates the complexity of having multiple identifiers (sandbox-id label, isola.run/sandbox-name annotation, truncated prefix in resource name, etc.)

Key changes:

Gateway (isola-gw):
- CreateSandboxCR: Use UUID directly as Sandbox and SandboxTemplate names
- Replace sandbox-id label with app.kubernetes.io/managed-by label
- Replace isola.run/sandbox-name annotation with isola.run/display-name
- Simplify GetSandboxCR, DeleteSandboxCR to use sandboxID directly
- Update getAgentAddress to use sandboxID as pod name
- ExecuteCommand: Use direct pod lookup by name instead of label selector

Operator (isola-operator):
- getSandboxPodName: Return sandbox.Name (no -pod suffix)
- getFilesystemSnapshotterJobName: Return sandbox.Name + "-snap"
- GetOwnedNetworkTemplateName: Return sandbox.Name + "-net"
- Remove sandbox-id label copying from sandbox to pod

Resource naming convention:
- Sandbox:          {uuid}
- Pod:              {uuid}
- SandboxTemplate:  {uuid}
- NetworkTemplate:  {uuid}-net (if owned)
- Snapshotter Job:  {uuid}-snap

Benefits:
- Single canonical ID (UUID = K8s name)
- Globally unique for S3 storage paths
- Simpler mental model and code
- kubectl-friendly: kubectl get sandbox,pod {uuid}