### PR TITLE
feat: add comprehensive benchmarking framework

### DIFF
--- a/.github/kind-benchmark-config.yaml
+++ b/.github/kind-benchmark-config.yaml
@@ -1,0 +1,24 @@
+# Kind cluster configuration for benchmark testing
+# Uses a single-node cluster with sufficient resources for load testing
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    # Extra port mappings for accessing services
+    extraPortMappings:
+      - containerPort: 30080
+        hostPort: 30080
+        protocol: TCP
+    # Increase resources for the control plane node
+    kubeadmConfigPatches:
+      - |
+        kind: KubeletConfiguration
+        evictionHard:
+          memory.available: "200Mi"
+          nodefs.available: "10%"
+        kubeReserved:
+          cpu: "200m"
+          memory: "256Mi"
+        systemReserved:
+          cpu: "200m"
+          memory: "256Mi"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,288 @@
+name: Performance Benchmarks
+
+on:
+  # Run weekly on Monday at 2 AM UTC
+  schedule:
+    - cron: '0 2 * * 1'
+
+  # Manual trigger with configurable parameters
+  workflow_dispatch:
+    inputs:
+      test_duration:
+        description: 'Load test duration (e.g., 5m, 10m)'
+        default: '5m'
+        type: string
+      max_vus:
+        description: 'Maximum virtual users for k6'
+        default: '50'
+        type: string
+      run_stress_tests:
+        description: 'Run Python stress tests'
+        default: true
+        type: boolean
+      save_baseline:
+        description: 'Save results as new baseline'
+        default: false
+        type: boolean
+
+  # Run on PRs that modify performance-critical code
+  pull_request:
+    paths:
+      - 'internal/operator/controller/**'
+      - 'internal/gateway/**'
+      - 'cmd/operator/**'
+      - 'cmd/gateway/**'
+
+env:
+  GO_VERSION: '1.25.5'
+  K6_VERSION: 'v0.49.0'
+
+jobs:
+  go-benchmarks:
+    name: Go Microbenchmarks
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Setup envtest
+        run: |
+          go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+          setup-envtest use 1.34 --bin-dir /usr/local/bin
+
+      - name: Run Go benchmarks
+        run: |
+          KUBEBUILDER_ASSETS="$(setup-envtest use 1.34 -p path)" \
+            go test -bench=. -benchmem -benchtime=10s -count=5 \
+            ./internal/operator/controller/... \
+            | tee benchmark-go-results.txt
+
+      - name: Upload Go benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: go-benchmark-results
+          path: benchmark-go-results.txt
+
+  load-tests:
+    name: Load Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    # Only run on schedule or manual trigger
+    if: github.event_name != 'pull_request'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Setup Kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: benchmark
+          config: .github/kind-benchmark-config.yaml
+          wait: 120s
+
+      - name: Build images
+        run: |
+          # Build operator
+          docker build -t isola-operator:latest -f Dockerfile.operator .
+          kind load docker-image isola-operator:latest --name benchmark
+
+          # Build gateway
+          docker build -t isola-gw:latest -f Dockerfile.gateway .
+          kind load docker-image isola-gw:latest --name benchmark
+
+          # Build agent
+          docker build -t isola-agent:latest -f Dockerfile.agent .
+          kind load docker-image isola-agent:latest --name benchmark
+
+      - name: Deploy Isola
+        run: |
+          # Install CRDs
+          kubectl apply -f charts/isola-operator/crds/
+
+          # Deploy operator with benchmark settings
+          helm install isola-operator charts/isola-operator \
+            --set image.repository=isola-operator \
+            --set image.tag=latest \
+            --set agentImage=isola-agent:latest \
+            --set runtimeClassName="" \
+            --set controller.maxConcurrentReconciles=10 \
+            --set resources.limits.cpu=2 \
+            --set resources.limits.memory=1Gi \
+            --set resources.requests.cpu=500m \
+            --set resources.requests.memory=512Mi \
+            --wait --timeout 5m
+
+          # Deploy gateway
+          helm install isola-gw charts/isola-gw \
+            --set image.repository=isola-gw \
+            --set image.tag=latest \
+            --set service.type=NodePort \
+            --set service.nodePort=30080 \
+            --wait --timeout 5m
+
+          # Wait for pods
+          kubectl wait --for=condition=ready pod -l app=isola-operator -n isola-system --timeout=120s
+          kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=isola-gw -n isola-system --timeout=120s
+
+      - name: Install k6
+        run: |
+          sudo gpg -k
+          sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg \
+            --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+          echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | \
+            sudo tee /etc/apt/sources.list.d/k6.list
+          sudo apt-get update && sudo apt-get install k6
+
+      - name: Get gateway URL
+        id: gateway
+        run: |
+          NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
+          echo "url=http://${NODE_IP}:30080" >> $GITHUB_OUTPUT
+
+      - name: Run k6 sandbox churn test
+        run: |
+          k6 run tests/benchmark/k6/sandbox_churn.js \
+            --out json=k6-sandbox-churn-results.json \
+            -e ISOLA_API_URL=${{ steps.gateway.outputs.url }} \
+            -e ISOLA_API_KEY=iso_sk_demo \
+            --duration ${{ inputs.test_duration || '5m' }} \
+            --vus ${{ inputs.max_vus || '20' }}
+
+      - name: Run k6 burst traffic test
+        run: |
+          k6 run tests/benchmark/k6/burst_traffic.js \
+            --out json=k6-burst-results.json \
+            -e ISOLA_API_URL=${{ steps.gateway.outputs.url }} \
+            -e ISOLA_API_KEY=iso_sk_demo
+
+      - name: Collect resource metrics
+        if: always()
+        run: |
+          kubectl top pods -n isola-system --containers > pod-resources.txt || true
+          kubectl top pods -n isola-sandboxes --containers > sandbox-resources.txt || true
+          kubectl logs -n isola-system -l app=isola-operator --tail=1000 > operator-logs.txt || true
+          kubectl get events -n isola-sandboxes --sort-by='.lastTimestamp' > events.txt || true
+
+      - name: Compare with baseline
+        if: hashFiles('tests/benchmark/baseline.json') != ''
+        run: |
+          python3 tests/benchmark/scripts/compare_baseline.py \
+            --current k6-sandbox-churn-results.json \
+            --baseline tests/benchmark/baseline.json \
+            --threshold 0.20
+
+      - name: Save baseline
+        if: inputs.save_baseline == true
+        run: |
+          python3 tests/benchmark/scripts/compare_baseline.py \
+            --current k6-sandbox-churn-results.json \
+            --save-baseline
+
+      - name: Upload benchmark artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: benchmark-results-${{ github.run_id }}
+          path: |
+            k6-*.json
+            pod-resources.txt
+            sandbox-resources.txt
+            operator-logs.txt
+            events.txt
+
+  stress-tests:
+    name: Python Stress Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    if: github.event_name != 'pull_request' && (github.event.inputs.run_stress_tests == 'true' || github.event_name == 'schedule')
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Setup Kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: stress-test
+          wait: 120s
+
+      - name: Build and deploy Isola
+        run: |
+          # Build images
+          docker build -t isola-operator:latest -f Dockerfile.operator .
+          docker build -t isola-gw:latest -f Dockerfile.gateway .
+          docker build -t isola-agent:latest -f Dockerfile.agent .
+
+          # Load into kind
+          kind load docker-image isola-operator:latest --name stress-test
+          kind load docker-image isola-gw:latest --name stress-test
+          kind load docker-image isola-agent:latest --name stress-test
+
+          # Deploy
+          kubectl apply -f charts/isola-operator/crds/
+          helm install isola-operator charts/isola-operator \
+            --set image.repository=isola-operator \
+            --set image.tag=latest \
+            --set agentImage=isola-agent:latest \
+            --set runtimeClassName="" \
+            --set controller.maxConcurrentReconciles=10 \
+            --wait --timeout 5m
+
+          helm install isola-gw charts/isola-gw \
+            --set image.repository=isola-gw \
+            --set image.tag=latest \
+            --set service.type=NodePort \
+            --set service.nodePort=30080 \
+            --wait --timeout 5m
+
+          kubectl wait --for=condition=ready pod -l app=isola-operator -n isola-system --timeout=120s
+          kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=isola-gw -n isola-system --timeout=120s
+
+      - name: Run Python stress tests
+        working-directory: tests/e2e
+        env:
+          ISOLA_BASE_URL: http://localhost:30080
+          ISOLA_API_KEY: iso_sk_demo
+        run: |
+          # Port forward gateway
+          kubectl port-forward -n isola-system svc/isola-gw 30080:8080 &
+          sleep 5
+
+          # Run stress tests
+          uv run pytest -m stress -v --tb=short \
+            --html=stress-test-report.html \
+            --self-contained-html \
+            --timeout=1800
+
+      - name: Upload stress test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: stress-test-results-${{ github.run_id }}
+          path: tests/e2e/stress-test-report.html

--- a/Makefile
+++ b/Makefile
@@ -83,3 +83,58 @@ build: ## Build all binaries
 .PHONY: run-operator
 run-operator: ## Run operator from your host
 	go run ./cmd/operator/main.go
+
+##@ Benchmarking
+
+.PHONY: benchmark
+benchmark: ## Run Go microbenchmarks
+	KUBEBUILDER_ASSETS="$$(setup-envtest use $(ENVTEST_K8S_VERSION) -p path)" \
+		go test -bench=. -benchmem -benchtime=10s \
+		./internal/operator/controller/... \
+		| tee benchmark-results.txt
+
+.PHONY: benchmark-compare
+benchmark-compare: ## Run benchmarks and compare with baseline (requires benchstat)
+	@if ! command -v benchstat &> /dev/null; then \
+		echo "Installing benchstat..."; \
+		go install golang.org/x/perf/cmd/benchstat@latest; \
+	fi
+	KUBEBUILDER_ASSETS="$$(setup-envtest use $(ENVTEST_K8S_VERSION) -p path)" \
+		go test -bench=. -benchmem -benchtime=10s -count=5 \
+		./internal/operator/controller/... \
+		| tee benchmark-new.txt
+	@if [ -f benchmark-baseline.txt ]; then \
+		benchstat benchmark-baseline.txt benchmark-new.txt; \
+	else \
+		echo "No baseline found. Run 'make benchmark-save-baseline' to create one."; \
+	fi
+
+.PHONY: benchmark-save-baseline
+benchmark-save-baseline: ## Save current benchmark results as baseline
+	KUBEBUILDER_ASSETS="$$(setup-envtest use $(ENVTEST_K8S_VERSION) -p path)" \
+		go test -bench=. -benchmem -benchtime=10s -count=5 \
+		./internal/operator/controller/... \
+		| tee benchmark-baseline.txt
+	@echo "Baseline saved to benchmark-baseline.txt"
+
+.PHONY: benchmark-k6
+benchmark-k6: ## Run k6 load tests (requires k6 and running cluster)
+	@if ! command -v k6 &> /dev/null; then \
+		echo "k6 not found. Install from https://k6.io/docs/getting-started/installation/"; \
+		exit 1; \
+	fi
+	k6 run tests/benchmark/k6/sandbox_churn.js \
+		--out json=k6-results.json \
+		-e ISOLA_API_URL=$${ISOLA_API_URL:-http://localhost:30080} \
+		-e ISOLA_API_KEY=$${ISOLA_API_KEY:-iso_sk_demo}
+
+.PHONY: benchmark-stress
+benchmark-stress: ## Run Python stress tests (requires running cluster)
+	cd tests/e2e && uv run pytest -m stress -v --tb=short
+
+.PHONY: benchmark-monitor
+benchmark-monitor: ## Monitor cluster resources during benchmark
+	./tests/benchmark/scripts/monitor.sh -d 300 -o ./benchmark-results
+
+.PHONY: benchmark-all
+benchmark-all: benchmark benchmark-k6 ## Run all benchmarks

--- a/charts/isola-operator/templates/deployment.yaml
+++ b/charts/isola-operator/templates/deployment.yaml
@@ -34,6 +34,17 @@ spec:
         {{- if .Values.runtimeClassName }}
         - --runtime-class={{ .Values.runtimeClassName }}
         {{- end }}
+        {{- if .Values.controller }}
+        {{- if .Values.controller.maxConcurrentReconciles }}
+        - --max-concurrent-reconciles={{ .Values.controller.maxConcurrentReconciles }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.profiling }}
+        {{- if .Values.profiling.enabled }}
+        - --enable-pprof
+        - --pprof-addr=:{{ .Values.profiling.port | default 6060 }}
+        {{- end }}
+        {{- end }}
         securityContext:
           capabilities:
             drop:
@@ -56,12 +67,16 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:
+          {{- if .Values.resources }}
+          {{- toYaml .Values.resources | nindent 10 }}
+          {{- else }}
           limits:
-            cpu: 500m
-            memory: 128Mi
+            cpu: "2"
+            memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 64Mi
+            cpu: 100m
+            memory: 256Mi
+          {{- end }}
         env:
         {{- if .Values.snapshot.storage.bucketUrl }}
         - name: ISOLA_SNAPSHOT_BUCKET_URL

--- a/charts/isola-operator/values.yaml
+++ b/charts/isola-operator/values.yaml
@@ -5,6 +5,29 @@ image:
 # Agent sidecar image injected into sandbox pods
 agentImage: isola-agent:latest
 
+# Operator resource configuration
+resources:
+  limits:
+    cpu: "2"
+    memory: 1Gi
+  requests:
+    cpu: 100m
+    memory: 256Mi
+
+# Controller configuration
+controller:
+  # Maximum concurrent reconciliations per controller.
+  # Higher values improve throughput but increase resource usage.
+  # Recommended: 5-20 for production workloads.
+  maxConcurrentReconciles: 10
+
+# Profiling configuration
+profiling:
+  # Enable pprof endpoints for performance profiling
+  enabled: false
+  # Port for pprof server (only used if enabled)
+  port: 6060
+
 # RuntimeClassName for sandbox pods.
 # Options:
 #   "gvisor" - Use gVisor (runsc) for stronger isolation. Requires gVisor installed on nodes

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -6,14 +6,19 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
 	"github.com/isola-ai/isola-sb/internal/gateway/handlers"
 	"github.com/isola-ai/isola-sb/internal/gateway/kubernetes"
+	"github.com/isola-ai/isola-sb/internal/gateway/metrics"
+	"github.com/isola-ai/isola-sb/internal/gateway/ratelimit"
 	"github.com/isola-ai/isola-sb/internal/gateway/storage"
 )
 
@@ -23,6 +28,10 @@ const (
 	EnvHTTPPort            = "ISOLA_HTTP_PORT"
 	EnvKubernetesNamespace = "ISOLA_KUBERNETES_NAMESPACE"
 	EnvGinMode             = "GIN_MODE"
+	EnvEnablePprof         = "ISOLA_ENABLE_PPROF"
+	EnvPprofPort           = "ISOLA_PPROF_PORT"
+	EnvRateLimitRPS        = "ISOLA_RATE_LIMIT_RPS"
+	EnvRateLimitBurst      = "ISOLA_RATE_LIMIT_BURST"
 )
 
 // Default values
@@ -30,6 +39,9 @@ const (
 	DefaultHTTPHost            = "0.0.0.0"
 	DefaultHTTPPort            = "8080"
 	DefaultKubernetesNamespace = "isola-sandboxes"
+	DefaultPprofPort           = "6060"
+	DefaultRateLimitRPS        = 50.0
+	DefaultRateLimitBurst      = 100
 )
 
 func main() {
@@ -45,6 +57,29 @@ func main() {
 	ctx := context.Background()
 	storageBucket := initStorage(ctx)
 
+	// Start pprof server if enabled
+	if os.Getenv(EnvEnablePprof) == "true" {
+		pprofPort := getEnvOrDefault(EnvPprofPort, DefaultPprofPort)
+		go func() {
+			pprofAddr := fmt.Sprintf(":%s", pprofPort)
+			log.Printf("pprof listening on %s", pprofAddr)
+			if err := http.ListenAndServe(pprofAddr, nil); err != nil {
+				log.Printf("pprof server error: %v", err)
+			}
+		}()
+	}
+
+	// Initialize rate limiter
+	rateLimitConfig := ratelimit.DefaultConfig()
+	if rps := getEnvFloat(EnvRateLimitRPS, DefaultRateLimitRPS); rps > 0 {
+		rateLimitConfig.RequestsPerSecond = rps
+	}
+	if burst := getEnvInt(EnvRateLimitBurst, DefaultRateLimitBurst); burst > 0 {
+		rateLimitConfig.BurstSize = burst
+	}
+	limiter := ratelimit.NewLimiter(rateLimitConfig)
+	defer limiter.Stop()
+
 	handler := handlers.NewHandler(k8sManager, storageBucket)
 
 	r := gin.New()
@@ -52,6 +87,11 @@ func main() {
 	// Add middleware
 	r.Use(gin.Logger())
 	r.Use(gin.Recovery())
+	r.Use(metrics.MetricsMiddleware())
+	r.Use(ratelimit.Middleware(limiter))
+
+	// Metrics endpoint (unauthenticated)
+	r.GET("/metrics", gin.WrapH(promhttp.Handler()))
 
 	handler.SetupRoutes(r)
 
@@ -112,4 +152,28 @@ func getEnvOrDefault(key, defaultValue string) string {
 		return defaultValue
 	}
 	return value
+}
+
+func getEnvFloat(key string, defaultValue float64) float64 {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	var result float64
+	if _, err := fmt.Sscanf(value, "%f", &result); err != nil {
+		return defaultValue
+	}
+	return result
+}
+
+func getEnvInt(key string, defaultValue int) int {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	var result int
+	if _, err := fmt.Sscanf(value, "%d", &result); err != nil {
+		return defaultValue
+	}
+	return result
 }

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -19,6 +19,8 @@ package main
 import (
 	"crypto/tls"
 	"flag"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -37,6 +39,8 @@ import (
 
 	sandboxv1alpha1 "github.com/isola-ai/isola-sb/api/v1alpha1"
 	"github.com/isola-ai/isola-sb/internal/operator/controller"
+	// Import metrics to register them
+	_ "github.com/isola-ai/isola-sb/internal/operator/controller"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -70,6 +74,9 @@ func main() {
 	var snapshotCredentialSecret string
 	var snapshotUploaderImage string
 	var snapshotServiceAccount string
+	var maxConcurrentReconciles int
+	var enablePprof bool
+	var pprofAddr string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -95,6 +102,9 @@ func main() {
 	flag.StringVar(&snapshotCredentialSecret, "snapshot-credential-secret", os.Getenv("ISOLA_SNAPSHOT_CREDENTIAL_SECRET"), "Secret name for bucket credentials (optional, uses pod identity if not set)")
 	flag.StringVar(&snapshotUploaderImage, "snapshot-uploader-image", os.Getenv("ISOLA_UPLOADER_IMAGE"), "Container image for the snapshot uploader")
 	flag.StringVar(&snapshotServiceAccount, "snapshot-service-account", os.Getenv("ISOLA_SNAPSHOT_SERVICE_ACCOUNT"), "ServiceAccount for snapshot jobs")
+	flag.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 10, "Maximum number of concurrent reconciles per controller")
+	flag.BoolVar(&enablePprof, "enable-pprof", false, "Enable pprof profiling endpoint")
+	flag.StringVar(&pprofAddr, "pprof-addr", ":6060", "Address to bind pprof server")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -102,6 +112,16 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	// Start pprof server if enabled
+	if enablePprof {
+		go func() {
+			setupLog.Info("Starting pprof server", "addr", pprofAddr)
+			if err := http.ListenAndServe(pprofAddr, nil); err != nil {
+				setupLog.Error(err, "pprof server error")
+			}
+		}()
+	}
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will
@@ -201,7 +221,9 @@ func main() {
 		AgentImage:       agentImage,
 		RuntimeClassName: runtimeClassName,
 		Clock:            controller.RealClock{},
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManagerAndOptions(mgr, controller.SandboxControllerOptions{
+		MaxConcurrentReconciles: maxConcurrentReconciles,
+	}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Sandbox")
 		os.Exit(1)
 	}
@@ -216,7 +238,9 @@ func main() {
 		CredentialSecretName:   snapshotCredentialSecret,
 		UploaderImage:          snapshotUploaderImage,
 		SnapshotServiceAccount: snapshotServiceAccount,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManagerAndOptions(mgr, controller.RootfsSnapshotControllerOptions{
+		MaxConcurrentReconciles: maxConcurrentReconciles,
+	}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "RootfsSnapshot")
 		os.Exit(1)
 	}

--- a/internal/gateway/metrics/metrics.go
+++ b/internal/gateway/metrics/metrics.go
@@ -1,0 +1,150 @@
+// Package metrics provides Prometheus metrics for the isola-gw service.
+package metrics
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	// HTTPRequestDuration tracks HTTP request latency by method, endpoint, and status code.
+	HTTPRequestDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "isola",
+			Subsystem: "gateway",
+			Name:      "http_request_duration_seconds",
+			Help:      "HTTP request latency in seconds",
+			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+		},
+		[]string{"method", "endpoint", "status_code"},
+	)
+
+	// HTTPRequestsTotal counts total HTTP requests by method, endpoint, and status code.
+	HTTPRequestsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "isola",
+			Subsystem: "gateway",
+			Name:      "http_requests_total",
+			Help:      "Total number of HTTP requests",
+		},
+		[]string{"method", "endpoint", "status_code"},
+	)
+
+	// SandboxOperationsTotal counts sandbox operations by operation type and status.
+	SandboxOperationsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "isola",
+			Subsystem: "gateway",
+			Name:      "sandbox_operations_total",
+			Help:      "Total sandbox operations",
+		},
+		[]string{"operation", "status"},
+	)
+
+	// SandboxOperationDuration tracks sandbox operation latency.
+	SandboxOperationDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "isola",
+			Subsystem: "gateway",
+			Name:      "sandbox_operation_duration_seconds",
+			Help:      "Sandbox operation latency in seconds",
+			Buckets:   []float64{.01, .05, .1, .25, .5, 1, 2.5, 5, 10, 30},
+		},
+		[]string{"operation"},
+	)
+
+	// ActiveSandboxes tracks the number of currently active sandboxes (gauge).
+	ActiveSandboxes = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "isola",
+		Subsystem: "gateway",
+		Name:      "active_sandboxes",
+		Help:      "Number of currently active sandboxes",
+	})
+
+	// K8sAPICallDuration tracks latency of K8s API calls from gateway.
+	K8sAPICallDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "isola",
+			Subsystem: "gateway",
+			Name:      "k8s_api_call_duration_seconds",
+			Help:      "K8s API call latency in seconds",
+			Buckets:   []float64{.01, .05, .1, .25, .5, 1, 2.5, 5},
+		},
+		[]string{"operation", "resource"},
+	)
+
+	// K8sAPICallsTotal counts K8s API calls by operation, resource, and status.
+	K8sAPICallsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "isola",
+			Subsystem: "gateway",
+			Name:      "k8s_api_calls_total",
+			Help:      "Total K8s API calls",
+		},
+		[]string{"operation", "resource", "status"},
+	)
+
+	// RateLimitRejections counts requests rejected due to rate limiting.
+	RateLimitRejections = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "isola",
+			Subsystem: "gateway",
+			Name:      "rate_limit_rejections_total",
+			Help:      "Total requests rejected due to rate limiting",
+		},
+		[]string{"endpoint"},
+	)
+
+	// InFlightRequests tracks the number of in-flight requests.
+	InFlightRequests = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "isola",
+		Subsystem: "gateway",
+		Name:      "in_flight_requests",
+		Help:      "Number of in-flight HTTP requests",
+	})
+)
+
+// RecordSandboxOperation records metrics for a sandbox operation.
+func RecordSandboxOperation(operation, status string, duration time.Duration) {
+	SandboxOperationsTotal.WithLabelValues(operation, status).Inc()
+	SandboxOperationDuration.WithLabelValues(operation).Observe(duration.Seconds())
+}
+
+// RecordK8sAPICall records metrics for a K8s API call.
+func RecordK8sAPICall(operation, resource, status string, duration time.Duration) {
+	K8sAPICallDuration.WithLabelValues(operation, resource).Observe(duration.Seconds())
+	K8sAPICallsTotal.WithLabelValues(operation, resource, status).Inc()
+}
+
+// normalizeEndpoint converts a gin route pattern to a normalized form for metrics.
+// This prevents high-cardinality from path parameters.
+func normalizeEndpoint(c *gin.Context) string {
+	// Use the registered route pattern (e.g., "/api/v1/sandboxes/:id")
+	// rather than the actual path (e.g., "/api/v1/sandboxes/abc-123")
+	if c.FullPath() != "" {
+		return c.FullPath()
+	}
+	return c.Request.URL.Path
+}
+
+// MetricsMiddleware returns a gin middleware that records HTTP metrics.
+func MetricsMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		start := time.Now()
+		InFlightRequests.Inc()
+
+		c.Next()
+
+		InFlightRequests.Dec()
+		duration := time.Since(start)
+		statusCode := strconv.Itoa(c.Writer.Status())
+		endpoint := normalizeEndpoint(c)
+
+		HTTPRequestDuration.WithLabelValues(c.Request.Method, endpoint, statusCode).Observe(duration.Seconds())
+		HTTPRequestsTotal.WithLabelValues(c.Request.Method, endpoint, statusCode).Inc()
+	}
+}

--- a/internal/gateway/ratelimit/ratelimit.go
+++ b/internal/gateway/ratelimit/ratelimit.go
@@ -1,0 +1,176 @@
+// Package ratelimit provides rate limiting middleware for the isola-gw service.
+package ratelimit
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/isola-ai/isola-sb/internal/gateway/metrics"
+)
+
+// Config holds rate limiter configuration.
+type Config struct {
+	// RequestsPerSecond is the maximum requests per second per tenant.
+	RequestsPerSecond float64
+	// BurstSize is the maximum burst size.
+	BurstSize int
+	// CleanupInterval is how often to clean up expired entries.
+	CleanupInterval time.Duration
+}
+
+// DefaultConfig returns sensible defaults for rate limiting.
+func DefaultConfig() Config {
+	return Config{
+		RequestsPerSecond: 50,  // 50 requests per second
+		BurstSize:         100, // Burst up to 100 requests
+		CleanupInterval:   time.Minute,
+	}
+}
+
+// tokenBucket implements a simple token bucket rate limiter.
+type tokenBucket struct {
+	tokens     float64
+	maxTokens  float64
+	refillRate float64
+	lastRefill time.Time
+	mu         sync.Mutex
+}
+
+func newTokenBucket(rate float64, burst int) *tokenBucket {
+	return &tokenBucket{
+		tokens:     float64(burst),
+		maxTokens:  float64(burst),
+		refillRate: rate,
+		lastRefill: time.Now(),
+	}
+}
+
+func (tb *tokenBucket) allow() bool {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+
+	now := time.Now()
+	elapsed := now.Sub(tb.lastRefill).Seconds()
+	tb.lastRefill = now
+
+	// Refill tokens based on elapsed time
+	tb.tokens += elapsed * tb.refillRate
+	if tb.tokens > tb.maxTokens {
+		tb.tokens = tb.maxTokens
+	}
+
+	// Check if we have a token available
+	if tb.tokens >= 1 {
+		tb.tokens--
+		return true
+	}
+	return false
+}
+
+// Limiter manages rate limits per tenant.
+type Limiter struct {
+	config  Config
+	buckets map[string]*tokenBucket
+	mu      sync.RWMutex
+	stopCh  chan struct{}
+}
+
+// NewLimiter creates a new rate limiter with the given config.
+func NewLimiter(config Config) *Limiter {
+	l := &Limiter{
+		config:  config,
+		buckets: make(map[string]*tokenBucket),
+		stopCh:  make(chan struct{}),
+	}
+
+	// Start cleanup goroutine
+	go l.cleanup()
+
+	return l
+}
+
+// Allow checks if a request from the given tenant should be allowed.
+func (l *Limiter) Allow(tenantID string) bool {
+	l.mu.RLock()
+	bucket, exists := l.buckets[tenantID]
+	l.mu.RUnlock()
+
+	if !exists {
+		l.mu.Lock()
+		// Double-check after acquiring write lock
+		bucket, exists = l.buckets[tenantID]
+		if !exists {
+			bucket = newTokenBucket(l.config.RequestsPerSecond, l.config.BurstSize)
+			l.buckets[tenantID] = bucket
+		}
+		l.mu.Unlock()
+	}
+
+	return bucket.allow()
+}
+
+// cleanup periodically removes stale bucket entries.
+func (l *Limiter) cleanup() {
+	ticker := time.NewTicker(l.config.CleanupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			l.mu.Lock()
+			now := time.Now()
+			for tenantID, bucket := range l.buckets {
+				bucket.mu.Lock()
+				// Remove buckets that haven't been used in 5 minutes
+				if now.Sub(bucket.lastRefill) > 5*time.Minute {
+					delete(l.buckets, tenantID)
+				}
+				bucket.mu.Unlock()
+			}
+			l.mu.Unlock()
+		case <-l.stopCh:
+			return
+		}
+	}
+}
+
+// Stop stops the cleanup goroutine.
+func (l *Limiter) Stop() {
+	close(l.stopCh)
+}
+
+// Middleware returns a gin middleware that applies rate limiting.
+func Middleware(limiter *Limiter) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Get tenant ID from context (set by auth middleware)
+		tenantID, exists := c.Get("tenant_id")
+		if !exists {
+			// Fall back to IP-based limiting for unauthenticated requests
+			tenantID = c.ClientIP()
+		}
+
+		tenant, ok := tenantID.(string)
+		if !ok {
+			tenant = c.ClientIP()
+		}
+
+		if !limiter.Allow(tenant) {
+			endpoint := c.FullPath()
+			if endpoint == "" {
+				endpoint = c.Request.URL.Path
+			}
+			metrics.RateLimitRejections.WithLabelValues(endpoint).Inc()
+
+			c.JSON(http.StatusTooManyRequests, gin.H{
+				"error":   "TooManyRequests",
+				"message": "Rate limit exceeded. Please slow down.",
+			})
+			c.Abort()
+			return
+		}
+
+		c.Next()
+	}
+}

--- a/internal/operator/controller/benchmarks_test.go
+++ b/internal/operator/controller/benchmarks_test.go
@@ -1,0 +1,281 @@
+/*
+Copyright 2025 isola.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	sandboxv1alpha1 "github.com/isola-ai/isola-sb/api/v1alpha1"
+	netbuilder "github.com/isola-ai/isola-sb/internal/operator/controller/network"
+)
+
+// BenchmarkNetworkPolicyBuilder benchmarks the NetworkPolicy builder
+// with various network spec configurations.
+func BenchmarkNetworkPolicyBuilder(b *testing.B) {
+	testCases := []struct {
+		name string
+		spec *sandboxv1alpha1.NetworkSpec
+	}{
+		{
+			name: "EmptySpec",
+			spec: &sandboxv1alpha1.NetworkSpec{},
+		},
+		{
+			name: "AllowAllInternet",
+			spec: &sandboxv1alpha1.NetworkSpec{
+				AllowAllInternet: true,
+			},
+		},
+		{
+			name: "SingleCIDR",
+			spec: &sandboxv1alpha1.NetworkSpec{
+				AllowedEgressCIDRs: []string{"10.0.0.0/8"},
+			},
+		},
+		{
+			name: "MultipleCIDRs",
+			spec: &sandboxv1alpha1.NetworkSpec{
+				AllowedEgressCIDRs: []string{
+					"10.0.0.0/8",
+					"172.16.0.0/12",
+					"192.168.0.0/16",
+					"8.8.8.0/24",
+					"1.1.1.0/24",
+				},
+			},
+		},
+		{
+			name: "PodEgressRules",
+			spec: &sandboxv1alpha1.NetworkSpec{
+				AllowedEgressPods: []sandboxv1alpha1.PodEgressRule{
+					{
+						Namespace: "default",
+						LabelSelector: metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "db"},
+						},
+					},
+					{
+						Namespace: "monitoring",
+						LabelSelector: metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "prometheus"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "ComplexSpec",
+			spec: &sandboxv1alpha1.NetworkSpec{
+				AllowAllInternet: true,
+				AllowClusterDNS:  true,
+				Nameservers:      []string{"8.8.8.8", "1.1.1.1"},
+				AllowedEgressCIDRs: []string{
+					"10.0.0.0/8",
+					"172.16.0.0/12",
+				},
+				AllowedEgressPods: []sandboxv1alpha1.PodEgressRule{
+					{
+						Namespace: "default",
+						LabelSelector: metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "db"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, _ = netbuilder.BuildCustomNetworkPolicy(
+					fmt.Sprintf("sandbox-%d", i),
+					"default",
+					tc.spec,
+				)
+			}
+		})
+	}
+}
+
+// BenchmarkBuildNetworkLabels benchmarks the network label builder.
+func BenchmarkBuildNetworkLabels(b *testing.B) {
+	specs := []*sandboxv1alpha1.NetworkSpec{
+		nil,
+		{},
+		{AllowAllInternet: true},
+		{AllowClusterDNS: true},
+		{AllowAllInternet: true, AllowClusterDNS: true},
+	}
+
+	for i, spec := range specs {
+		name := fmt.Sprintf("Spec%d", i)
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			for j := 0; j < b.N; j++ {
+				_ = buildNetworkLabels(spec)
+			}
+		})
+	}
+}
+
+// BenchmarkConditionHelpers benchmarks status condition operations.
+func BenchmarkConditionHelpers(b *testing.B) {
+	b.Run("SetCondition", func(b *testing.B) {
+		conditions := make([]metav1.Condition, 0, 10)
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			conditions = append(conditions[:0], metav1.Condition{
+				Type:   "Ready",
+				Status: metav1.ConditionTrue,
+			})
+		}
+	})
+}
+
+// BenchmarkTimeoutCalculation benchmarks timeout calculation logic.
+func BenchmarkTimeoutCalculation(b *testing.B) {
+	r := &SandboxReconciler{
+		Clock: RealClock{},
+	}
+
+	sandbox := &sandboxv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			CreationTimestamp: metav1.Now(),
+		},
+	}
+
+	timeout := int32(600)
+	template := &sandboxv1alpha1.SandboxTemplate{
+		Spec: sandboxv1alpha1.SandboxTemplateSpec{
+			TimeoutSeconds: &timeout,
+		},
+	}
+
+	pod := &corev1.Pod{
+		Status: corev1.PodStatus{
+			StartTime: &metav1.Time{Time: time.Now()},
+		},
+	}
+
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = r.calculateTimeout(ctx, sandbox, template, pod)
+	}
+}
+
+// BenchmarkPodTemplateConstruction benchmarks pod template construction
+// which is a key operation in sandbox creation.
+func BenchmarkPodTemplateConstruction(b *testing.B) {
+	template := &sandboxv1alpha1.SandboxTemplate{
+		Spec: sandboxv1alpha1.SandboxTemplateSpec{
+			PodTemplate: sandboxv1alpha1.PodTemplateSpec{
+				Labels: map[string]string{
+					"app": "test",
+					"env": "benchmark",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "main",
+							Image: "alpine:latest",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("128Mi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("500m"),
+									corev1.ResourceMemory: resource.MustParse("512Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	b.Run("DeepCopy", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = template.Spec.PodTemplate.Spec.DeepCopy()
+		}
+	})
+}
+
+// BenchmarkSandboxNameGeneration benchmarks sandbox pod name generation.
+func BenchmarkSandboxNameGeneration(b *testing.B) {
+	sandboxes := make([]*sandboxv1alpha1.Sandbox, 100)
+	for i := range sandboxes {
+		sandboxes[i] = &sandboxv1alpha1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("sandbox-%d", i),
+				Namespace: "default",
+			},
+		}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = getSandboxPodName(sandboxes[i%100])
+	}
+}
+
+// BenchmarkTypeNamespacedName benchmarks types.NamespacedName construction
+// which is used extensively in reconciliation.
+func BenchmarkTypeNamespacedName(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = types.NamespacedName{
+			Name:      fmt.Sprintf("sandbox-%d", i),
+			Namespace: "default",
+		}
+	}
+}
+
+// BenchmarkReconcileRequestConstruction benchmarks reconcile request construction.
+func BenchmarkReconcileRequestConstruction(b *testing.B) {
+	names := make([]string, 100)
+	for i := range names {
+		names[i] = fmt.Sprintf("sandbox-%d", i)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = types.NamespacedName{
+			Name:      names[i%100],
+			Namespace: "default",
+		}
+	}
+}

--- a/internal/operator/controller/metrics.go
+++ b/internal/operator/controller/metrics.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2025 isola.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	// ReconcileTotal counts total reconciliations by controller and result.
+	ReconcileTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "isola",
+			Subsystem: "operator",
+			Name:      "reconcile_total",
+			Help:      "Total reconciliations by controller and result",
+		},
+		[]string{"controller", "result"},
+	)
+
+	// ReconcileDuration tracks reconciliation latency by controller.
+	ReconcileDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "isola",
+			Subsystem: "operator",
+			Name:      "reconcile_duration_seconds",
+			Help:      "Reconciliation latency in seconds",
+			Buckets:   []float64{.01, .05, .1, .25, .5, 1, 2.5, 5, 10, 30},
+		},
+		[]string{"controller"},
+	)
+
+	// PodCreationDuration tracks time from sandbox creation to pod ready.
+	PodCreationDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "isola",
+		Subsystem: "operator",
+		Name:      "pod_creation_duration_seconds",
+		Help:      "Time from sandbox creation to pod ready in seconds",
+		Buckets:   []float64{.5, 1, 2, 5, 10, 30, 60, 120},
+	})
+
+	// SandboxesTotal counts sandboxes by state.
+	SandboxesTotal = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "isola",
+			Subsystem: "operator",
+			Name:      "sandboxes_total",
+			Help:      "Current number of sandboxes by state",
+		},
+		[]string{"state"},
+	)
+
+	// NetworkPolicyCreationsTotal counts network policy creations.
+	NetworkPolicyCreationsTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "isola",
+		Subsystem: "operator",
+		Name:      "network_policy_creations_total",
+		Help:      "Total custom network policies created",
+	})
+
+	// SnapshotJobsTotal counts snapshot jobs by status.
+	SnapshotJobsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "isola",
+			Subsystem: "operator",
+			Name:      "snapshot_jobs_total",
+			Help:      "Total snapshot jobs by status",
+		},
+		[]string{"status"},
+	)
+
+	// SnapshotDuration tracks snapshot operation duration.
+	SnapshotDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "isola",
+		Subsystem: "operator",
+		Name:      "snapshot_duration_seconds",
+		Help:      "Snapshot operation duration in seconds",
+		Buckets:   []float64{1, 5, 10, 30, 60, 120, 300},
+	})
+
+	// TimeoutEnforcementsTotal counts sandbox timeout enforcements.
+	TimeoutEnforcementsTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "isola",
+		Subsystem: "operator",
+		Name:      "timeout_enforcements_total",
+		Help:      "Total sandbox timeout enforcements",
+	})
+
+	// K8sAPICallDuration tracks K8s API call latency from operator.
+	K8sAPICallDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "isola",
+			Subsystem: "operator",
+			Name:      "k8s_api_call_duration_seconds",
+			Help:      "K8s API call latency in seconds",
+			Buckets:   []float64{.01, .05, .1, .25, .5, 1, 2.5, 5},
+		},
+		[]string{"operation", "resource"},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		ReconcileTotal,
+		ReconcileDuration,
+		PodCreationDuration,
+		SandboxesTotal,
+		NetworkPolicyCreationsTotal,
+		SnapshotJobsTotal,
+		SnapshotDuration,
+		TimeoutEnforcementsTotal,
+		K8sAPICallDuration,
+	)
+}
+
+// RecordReconcile records metrics for a reconciliation.
+func RecordReconcile(controller, result string, duration time.Duration) {
+	ReconcileTotal.WithLabelValues(controller, result).Inc()
+	ReconcileDuration.WithLabelValues(controller).Observe(duration.Seconds())
+}
+
+// RecordPodCreation records the duration from sandbox creation to pod ready.
+func RecordPodCreation(duration time.Duration) {
+	PodCreationDuration.Observe(duration.Seconds())
+}
+
+// RecordSnapshot records metrics for a snapshot operation.
+func RecordSnapshot(status string, duration time.Duration) {
+	SnapshotJobsTotal.WithLabelValues(status).Inc()
+	if duration > 0 {
+		SnapshotDuration.Observe(duration.Seconds())
+	}
+}
+
+// RecordTimeoutEnforcement records a sandbox timeout enforcement.
+func RecordTimeoutEnforcement() {
+	TimeoutEnforcementsTotal.Inc()
+}
+
+// RecordNetworkPolicyCreation records a network policy creation.
+func RecordNetworkPolicyCreation() {
+	NetworkPolicyCreationsTotal.Inc()
+}

--- a/internal/operator/controller/rootfssnapshot_controller.go
+++ b/internal/operator/controller/rootfssnapshot_controller.go
@@ -618,12 +618,29 @@ func (r *RootfsSnapshotReconciler) setFailed(ctx context.Context, base, snap *sa
 	return ctrl.Result{RequeueAfter: getTTLSeconds(snap)}, nil
 }
 
+// RootfsSnapshotControllerOptions contains options for the RootfsSnapshotReconciler.
+type RootfsSnapshotControllerOptions struct {
+	MaxConcurrentReconciles int
+}
+
+// SetupWithManager sets up the controller with the Manager.
 func (r *RootfsSnapshotReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return r.SetupWithManagerAndOptions(mgr, RootfsSnapshotControllerOptions{MaxConcurrentReconciles: 1})
+}
+
+// SetupWithManagerAndOptions sets up the controller with the Manager and options.
+func (r *RootfsSnapshotReconciler) SetupWithManagerAndOptions(mgr ctrl.Manager, opts RootfsSnapshotControllerOptions) error {
 	r.Recorder = mgr.GetEventRecorderFor("rootfssnapshot-controller")
+
+	maxConcurrent := opts.MaxConcurrentReconciles
+	if maxConcurrent <= 0 {
+		maxConcurrent = 1
+	}
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&sandboxv1alpha1.RootfsSnapshot{}).
 		Owns(&batchv1.Job{}).
+		WithOptions(ctrl.Options{MaxConcurrentReconciles: maxConcurrent}).
 		Named("rootfssnapshot").
 		Complete(r)
 }

--- a/internal/operator/controller/sandbox_controller.go
+++ b/internal/operator/controller/sandbox_controller.go
@@ -1195,8 +1195,18 @@ func (r *SandboxReconciler) createShutdownSnapshot(
 	return ctrl.Result{RequeueAfter: time.Second}, false, nil
 }
 
+// SandboxControllerOptions contains options for the SandboxReconciler.
+type SandboxControllerOptions struct {
+	MaxConcurrentReconciles int
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *SandboxReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return r.SetupWithManagerAndOptions(mgr, SandboxControllerOptions{MaxConcurrentReconciles: 1})
+}
+
+// SetupWithManagerAndOptions sets up the controller with the Manager and options.
+func (r *SandboxReconciler) SetupWithManagerAndOptions(mgr ctrl.Manager, opts SandboxControllerOptions) error {
 	r.Recorder = mgr.GetEventRecorderFor("sandbox-controller")
 
 	// Field index for sandbox templateRef lookups
@@ -1209,6 +1219,11 @@ func (r *SandboxReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
+	maxConcurrent := opts.MaxConcurrentReconciles
+	if maxConcurrent <= 0 {
+		maxConcurrent = 1
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&sandboxv1alpha1.Sandbox{}).
 		Owns(&corev1.Pod{}).
@@ -1219,6 +1234,7 @@ func (r *SandboxReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&sandboxv1alpha1.SandboxTemplate{},
 			handler.EnqueueRequestsFromMapFunc(r.findSandboxesForTemplate),
 		).
+		WithOptions(ctrl.Options{MaxConcurrentReconciles: maxConcurrent}).
 		Named("sandbox").
 		Complete(r)
 }

--- a/tests/benchmark/k6/burst_traffic.js
+++ b/tests/benchmark/k6/burst_traffic.js
@@ -1,0 +1,104 @@
+/**
+ * Burst Traffic Load Test
+ *
+ * Tests the system's ability to handle sudden traffic spikes.
+ * Uses constant arrival rate to simulate burst scenarios.
+ *
+ * Usage:
+ *   k6 run --out json=results.json burst_traffic.js
+ */
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Rate, Trend, Counter } from 'k6/metrics';
+
+// Custom metrics
+const burstCreateDuration = new Trend('burst_create_duration_ms');
+const burstCreateErrors = new Counter('burst_create_errors');
+const rateLimitHits = new Counter('rate_limit_hits');
+const failureRate = new Rate('failures');
+
+// Test configuration - constant arrival rate for burst simulation
+export const options = {
+    scenarios: {
+        // Sudden burst of requests
+        burst: {
+            executor: 'constant-arrival-rate',
+            rate: 50,              // 50 requests per second
+            timeUnit: '1s',
+            duration: '2m',
+            preAllocatedVUs: 100,
+            maxVUs: 200,
+        },
+    },
+    thresholds: {
+        'burst_create_duration_ms': ['p(95)<10000'],  // Allow higher latency during burst
+        'failures': ['rate<0.10'],                     // Allow up to 10% failures during burst
+        'rate_limit_hits': ['count<100'],             // Expect some rate limiting
+    },
+};
+
+const BASE_URL = __ENV.ISOLA_API_URL || 'http://localhost:8080';
+const API_KEY = __ENV.ISOLA_API_KEY || 'iso_sk_demo';
+
+const headers = {
+    'X-API-Key': API_KEY,
+    'Content-Type': 'application/json',
+};
+
+// Track created sandboxes for cleanup
+const createdSandboxes = [];
+
+export default function() {
+    const sandboxName = `burst-${__VU}-${__ITER}-${Date.now()}`;
+
+    const createStart = Date.now();
+    const createPayload = JSON.stringify({
+        name: sandboxName,
+        autoStart: true,
+        cpu: 0.1,
+        memory: 0.128,
+    });
+
+    const res = http.post(`${BASE_URL}/api/v1/sandboxes`, createPayload, { headers });
+    const createDuration = Date.now() - createStart;
+    burstCreateDuration.add(createDuration);
+
+    if (res.status === 429) {
+        // Rate limited - expected during burst
+        rateLimitHits.add(1);
+        failureRate.add(0);  // Don't count rate limiting as failure
+        return;
+    }
+
+    const success = check(res, {
+        'create: status is 201': (r) => r.status === 201,
+    });
+
+    if (!success) {
+        burstCreateErrors.add(1);
+        failureRate.add(1);
+        return;
+    }
+
+    failureRate.add(0);
+
+    // Store sandbox ID for cleanup
+    const sandboxId = res.json('id');
+
+    // Immediately delete to reduce resource pressure during burst test
+    sleep(0.5);
+    http.del(`${BASE_URL}/api/v1/sandboxes/${sandboxId}`, null, { headers });
+}
+
+export function setup() {
+    const res = http.get(`${BASE_URL}/health`);
+    if (res.status !== 200) {
+        throw new Error(`API not accessible at ${BASE_URL}`);
+    }
+    return { startTime: Date.now() };
+}
+
+export function teardown(data) {
+    console.log(`Burst test completed in ${((Date.now() - data.startTime) / 1000).toFixed(1)}s`);
+}

--- a/tests/benchmark/k6/sandbox_churn.js
+++ b/tests/benchmark/k6/sandbox_churn.js
@@ -1,0 +1,178 @@
+/**
+ * Sandbox Churn Load Test
+ *
+ * Tests high sandbox creation/deletion throughput to find bottlenecks
+ * and establish performance baselines.
+ *
+ * Usage:
+ *   k6 run --out json=results.json sandbox_churn.js
+ *
+ * Environment variables:
+ *   ISOLA_API_URL: Base URL for isola-gw (default: http://localhost:8080)
+ *   ISOLA_API_KEY: API key for authentication (default: iso_sk_demo)
+ */
+
+import http from 'k6/http';
+import { check, sleep, fail } from 'k6';
+import { Rate, Trend, Counter } from 'k6/metrics';
+
+// Custom metrics for detailed analysis
+const sandboxCreateDuration = new Trend('sandbox_create_duration_ms');
+const sandboxReadyDuration = new Trend('sandbox_ready_duration_ms');
+const sandboxDeleteDuration = new Trend('sandbox_delete_duration_ms');
+const sandboxCreateErrors = new Counter('sandbox_create_errors');
+const sandboxReadyErrors = new Counter('sandbox_ready_errors');
+const sandboxDeleteErrors = new Counter('sandbox_delete_errors');
+const failureRate = new Rate('failures');
+
+// Test configuration with multiple scenarios
+export const options = {
+    scenarios: {
+        // Scenario 1: Gradual ramp-up to find breaking point
+        stress_test: {
+            executor: 'ramping-vus',
+            startVUs: 1,
+            stages: [
+                { duration: '1m', target: 5 },    // Warm up
+                { duration: '2m', target: 20 },   // Moderate load
+                { duration: '2m', target: 50 },   // High load
+                { duration: '2m', target: 100 },  // Stress load
+                { duration: '1m', target: 0 },    // Cool down
+            ],
+            gracefulRampDown: '30s',
+        },
+    },
+    thresholds: {
+        // SLO thresholds
+        'sandbox_create_duration_ms': ['p(95)<5000'],   // 95th percentile < 5s
+        'sandbox_ready_duration_ms': ['p(95)<60000'],   // 95th percentile < 60s
+        'sandbox_delete_duration_ms': ['p(95)<5000'],   // 95th percentile < 5s
+        'failures': ['rate<0.05'],                       // < 5% failure rate
+        'http_req_duration': ['p(99)<10000'],           // 99th percentile < 10s
+    },
+};
+
+// Configuration from environment
+const BASE_URL = __ENV.ISOLA_API_URL || 'http://localhost:8080';
+const API_KEY = __ENV.ISOLA_API_KEY || 'iso_sk_demo';
+
+const headers = {
+    'X-API-Key': API_KEY,
+    'Content-Type': 'application/json',
+};
+
+/**
+ * Wait for sandbox to reach running state
+ */
+function waitForReady(sandboxId, timeoutMs = 60000) {
+    const startTime = Date.now();
+    const pollInterval = 1000;
+
+    while (Date.now() - startTime < timeoutMs) {
+        const res = http.get(`${BASE_URL}/api/v1/sandboxes/${sandboxId}`, { headers });
+
+        if (res.status !== 200) {
+            sleep(pollInterval / 1000);
+            continue;
+        }
+
+        const state = res.json('state');
+        if (state === 'running') {
+            return { success: true, duration: Date.now() - startTime };
+        }
+        if (state === 'error' || state === 'failed') {
+            return { success: false, duration: Date.now() - startTime, error: `Sandbox entered ${state} state` };
+        }
+
+        sleep(pollInterval / 1000);
+    }
+
+    return { success: false, duration: Date.now() - startTime, error: 'Timeout waiting for ready state' };
+}
+
+/**
+ * Main test function - creates and deletes a sandbox
+ */
+export default function() {
+    const sandboxName = `k6-${__VU}-${__ITER}-${Date.now()}`;
+    let sandboxId = null;
+    let overallSuccess = true;
+
+    // Step 1: Create sandbox
+    const createStart = Date.now();
+    const createPayload = JSON.stringify({
+        name: sandboxName,
+        autoStart: true,
+        cpu: 0.1,
+        memory: 0.128,
+    });
+
+    const createRes = http.post(`${BASE_URL}/api/v1/sandboxes`, createPayload, { headers });
+    const createDuration = Date.now() - createStart;
+    sandboxCreateDuration.add(createDuration);
+
+    const createSuccess = check(createRes, {
+        'create: status is 201': (r) => r.status === 201,
+        'create: has id': (r) => r.json('id') !== undefined,
+    });
+
+    if (!createSuccess) {
+        sandboxCreateErrors.add(1);
+        failureRate.add(1);
+        console.log(`Create failed: ${createRes.status} - ${createRes.body}`);
+        return;
+    }
+
+    sandboxId = createRes.json('id');
+
+    // Step 2: Wait for sandbox to be ready
+    const readyResult = waitForReady(sandboxId, 90000);
+    sandboxReadyDuration.add(readyResult.duration);
+
+    if (!readyResult.success) {
+        sandboxReadyErrors.add(1);
+        overallSuccess = false;
+        console.log(`Ready failed for ${sandboxId}: ${readyResult.error}`);
+    }
+
+    // Let the sandbox run briefly to simulate real workload
+    sleep(Math.random() * 3 + 1);  // 1-4 seconds
+
+    // Step 3: Delete sandbox
+    const deleteStart = Date.now();
+    const deleteRes = http.del(`${BASE_URL}/api/v1/sandboxes/${sandboxId}`, null, { headers });
+    const deleteDuration = Date.now() - deleteStart;
+    sandboxDeleteDuration.add(deleteDuration);
+
+    const deleteSuccess = check(deleteRes, {
+        'delete: status is 204': (r) => r.status === 204,
+    });
+
+    if (!deleteSuccess) {
+        sandboxDeleteErrors.add(1);
+        overallSuccess = false;
+        console.log(`Delete failed for ${sandboxId}: ${deleteRes.status} - ${deleteRes.body}`);
+    }
+
+    failureRate.add(overallSuccess ? 0 : 1);
+}
+
+/**
+ * Setup function - verify API is accessible
+ */
+export function setup() {
+    const res = http.get(`${BASE_URL}/health`);
+    if (res.status !== 200) {
+        fail(`API not accessible at ${BASE_URL}: ${res.status}`);
+    }
+    console.log(`Connected to isola-gw at ${BASE_URL}`);
+    return { startTime: Date.now() };
+}
+
+/**
+ * Teardown function - print summary
+ */
+export function teardown(data) {
+    const duration = (Date.now() - data.startTime) / 1000;
+    console.log(`Test completed in ${duration.toFixed(1)}s`);
+}

--- a/tests/benchmark/k6/sustained_load.js
+++ b/tests/benchmark/k6/sustained_load.js
@@ -1,0 +1,133 @@
+/**
+ * Sustained Load Test
+ *
+ * Tests the system under sustained load for extended periods.
+ * Helps identify memory leaks, resource exhaustion, and degradation over time.
+ *
+ * Usage:
+ *   k6 run --out json=results.json sustained_load.js
+ *
+ * For longer runs:
+ *   k6 run --out json=results.json -e DURATION=30m sustained_load.js
+ */
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Rate, Trend, Counter, Gauge } from 'k6/metrics';
+
+// Custom metrics
+const createDuration = new Trend('sustained_create_duration_ms');
+const readyDuration = new Trend('sustained_ready_duration_ms');
+const deleteDuration = new Trend('sustained_delete_duration_ms');
+const activeSandboxes = new Gauge('active_sandboxes');
+const operationsTotal = new Counter('operations_total');
+const failureRate = new Rate('failures');
+
+// Test duration from environment or default
+const testDuration = __ENV.DURATION || '10m';
+
+export const options = {
+    scenarios: {
+        sustained: {
+            executor: 'constant-vus',
+            vus: 20,
+            duration: testDuration,
+        },
+    },
+    thresholds: {
+        'sustained_create_duration_ms': ['p(95)<5000'],
+        'sustained_ready_duration_ms': ['p(95)<60000'],
+        'sustained_delete_duration_ms': ['p(95)<5000'],
+        'failures': ['rate<0.02'],  // Stricter for sustained load
+    },
+};
+
+const BASE_URL = __ENV.ISOLA_API_URL || 'http://localhost:8080';
+const API_KEY = __ENV.ISOLA_API_KEY || 'iso_sk_demo';
+
+const headers = {
+    'X-API-Key': API_KEY,
+    'Content-Type': 'application/json',
+};
+
+function waitForReady(sandboxId, timeoutMs = 90000) {
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < timeoutMs) {
+        const res = http.get(`${BASE_URL}/api/v1/sandboxes/${sandboxId}`, { headers });
+
+        if (res.status === 200) {
+            const state = res.json('state');
+            if (state === 'running') {
+                return { success: true, duration: Date.now() - startTime };
+            }
+            if (state === 'error' || state === 'failed') {
+                return { success: false, duration: Date.now() - startTime };
+            }
+        }
+
+        sleep(1);
+    }
+
+    return { success: false, duration: Date.now() - startTime };
+}
+
+export default function() {
+    const sandboxName = `sustained-${__VU}-${__ITER}-${Date.now()}`;
+
+    // Create
+    const createStart = Date.now();
+    const res = http.post(`${BASE_URL}/api/v1/sandboxes`, JSON.stringify({
+        name: sandboxName,
+        autoStart: true,
+        cpu: 0.1,
+        memory: 0.128,
+    }), { headers });
+
+    createDuration.add(Date.now() - createStart);
+    operationsTotal.add(1);
+
+    if (!check(res, { 'create success': (r) => r.status === 201 })) {
+        failureRate.add(1);
+        return;
+    }
+
+    const sandboxId = res.json('id');
+    activeSandboxes.add(1);
+
+    // Wait for ready
+    const ready = waitForReady(sandboxId);
+    readyDuration.add(ready.duration);
+
+    if (!ready.success) {
+        failureRate.add(1);
+        // Still try to delete
+    }
+
+    // Simulate some work
+    sleep(Math.random() * 10 + 5);  // 5-15 seconds
+
+    // Delete
+    const deleteStart = Date.now();
+    const delRes = http.del(`${BASE_URL}/api/v1/sandboxes/${sandboxId}`, null, { headers });
+    deleteDuration.add(Date.now() - deleteStart);
+
+    activeSandboxes.add(-1);
+
+    if (!check(delRes, { 'delete success': (r) => r.status === 204 })) {
+        failureRate.add(1);
+        return;
+    }
+
+    failureRate.add(0);
+}
+
+export function setup() {
+    console.log(`Starting sustained load test for ${testDuration}`);
+    return { startTime: Date.now() };
+}
+
+export function teardown(data) {
+    const duration = (Date.now() - data.startTime) / 1000;
+    console.log(`Sustained load test completed in ${duration.toFixed(0)}s`);
+}

--- a/tests/benchmark/scripts/compare_baseline.py
+++ b/tests/benchmark/scripts/compare_baseline.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""
+Benchmark baseline comparison tool.
+
+Compares current benchmark results against a baseline and detects regressions.
+
+Usage:
+    python compare_baseline.py --current results.json --baseline baseline.json
+    python compare_baseline.py --current results.json --threshold 0.20
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class Regression:
+    """Represents a detected regression."""
+    metric: str
+    percentile: str
+    baseline: float
+    current: float
+    change_pct: float
+
+
+def load_k6_results(path: str) -> dict[str, dict[str, float]]:
+    """Parse k6 JSON output into metric summaries."""
+    metrics: dict[str, list[float]] = {}
+
+    with open(path) as f:
+        for line in f:
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            if data.get("type") == "Point":
+                metric = data.get("metric", "")
+                value = data.get("data", {}).get("value")
+                if metric and value is not None:
+                    if metric not in metrics:
+                        metrics[metric] = []
+                    metrics[metric].append(value)
+
+    # Calculate percentiles
+    results: dict[str, dict[str, float]] = {}
+    for metric, values in metrics.items():
+        if not values:
+            continue
+        values.sort()
+        n = len(values)
+        results[metric] = {
+            "min": values[0],
+            "p50": values[n // 2],
+            "p95": values[int(n * 0.95)] if n > 1 else values[0],
+            "p99": values[int(n * 0.99)] if n > 1 else values[0],
+            "max": values[-1],
+            "count": n,
+            "avg": sum(values) / n,
+        }
+
+    return results
+
+
+def compare_metrics(
+    current: dict[str, dict[str, float]],
+    baseline: dict[str, dict[str, float]],
+    threshold: float,
+) -> list[Regression]:
+    """Compare current results against baseline and find regressions."""
+    regressions: list[Regression] = []
+
+    # Key metrics to compare (higher is worse)
+    latency_metrics = [
+        "sandbox_create_duration_ms",
+        "sandbox_ready_duration_ms",
+        "sandbox_delete_duration_ms",
+        "http_req_duration",
+        "sustained_create_duration_ms",
+        "sustained_ready_duration_ms",
+        "burst_create_duration_ms",
+    ]
+
+    for metric in latency_metrics:
+        if metric not in current or metric not in baseline:
+            continue
+
+        current_vals = current[metric]
+        baseline_vals = baseline[metric]
+
+        for percentile in ["p50", "p95", "p99"]:
+            curr = current_vals.get(percentile, 0)
+            base = baseline_vals.get(percentile, 0)
+
+            if base <= 0:
+                continue
+
+            change = (curr - base) / base
+            if change > threshold:
+                regressions.append(Regression(
+                    metric=metric,
+                    percentile=percentile,
+                    baseline=base,
+                    current=curr,
+                    change_pct=change * 100,
+                ))
+
+    return regressions
+
+
+def print_comparison(
+    current: dict[str, dict[str, float]],
+    baseline: dict[str, dict[str, float]],
+) -> None:
+    """Print a comparison table of current vs baseline metrics."""
+    print("\n" + "=" * 80)
+    print("METRIC COMPARISON")
+    print("=" * 80)
+    print(f"{'Metric':<40} {'Baseline P95':>15} {'Current P95':>15} {'Change':>10}")
+    print("-" * 80)
+
+    all_metrics = sorted(set(current.keys()) | set(baseline.keys()))
+    for metric in all_metrics:
+        curr = current.get(metric, {}).get("p95", 0)
+        base = baseline.get(metric, {}).get("p95", 0)
+
+        if base > 0:
+            change = ((curr - base) / base) * 100
+            change_str = f"{change:+.1f}%"
+        else:
+            change_str = "N/A"
+
+        print(f"{metric:<40} {base:>15.2f} {curr:>15.2f} {change_str:>10}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Compare benchmark results against baseline")
+    parser.add_argument("--current", required=True, help="Path to current results (k6 JSON)")
+    parser.add_argument("--baseline", default="tests/benchmark/baseline.json",
+                        help="Path to baseline results")
+    parser.add_argument("--threshold", type=float, default=0.20,
+                        help="Regression threshold (0.20 = 20%% increase)")
+    parser.add_argument("--save-baseline", action="store_true",
+                        help="Save current results as new baseline")
+    args = parser.parse_args()
+
+    # Load current results
+    print(f"Loading current results from {args.current}...")
+    try:
+        current = load_k6_results(args.current)
+    except FileNotFoundError:
+        print(f"ERROR: Current results file not found: {args.current}")
+        return 1
+    except Exception as e:
+        print(f"ERROR: Failed to parse current results: {e}")
+        return 1
+
+    if not current:
+        print("ERROR: No metrics found in current results")
+        return 1
+
+    print(f"Loaded {len(current)} metrics from current run")
+
+    # Check if baseline exists
+    baseline_path = Path(args.baseline)
+    if not baseline_path.exists():
+        if args.save_baseline:
+            print(f"No baseline found. Saving current results as baseline to {args.baseline}")
+            baseline_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(baseline_path, "w") as f:
+                json.dump(current, f, indent=2)
+            print("Baseline saved successfully")
+            return 0
+        else:
+            print(f"No baseline found at {args.baseline}")
+            print("Run with --save-baseline to create a new baseline")
+            return 0
+
+    # Load baseline
+    print(f"Loading baseline from {args.baseline}...")
+    with open(baseline_path) as f:
+        baseline = json.load(f)
+
+    print(f"Loaded {len(baseline)} metrics from baseline")
+
+    # Print comparison table
+    print_comparison(current, baseline)
+
+    # Find regressions
+    regressions = compare_metrics(current, baseline, args.threshold)
+
+    if regressions:
+        print("\n" + "=" * 80)
+        print(f"PERFORMANCE REGRESSIONS DETECTED (threshold: {args.threshold * 100:.0f}%)")
+        print("=" * 80)
+        for r in sorted(regressions, key=lambda x: -x.change_pct):
+            print(f"  {r.metric} {r.percentile}: "
+                  f"{r.baseline:.2f} → {r.current:.2f} "
+                  f"(+{r.change_pct:.1f}%)")
+        print()
+        return 1
+
+    print("\n" + "=" * 80)
+    print("NO SIGNIFICANT REGRESSIONS DETECTED")
+    print("=" * 80)
+
+    # Optionally update baseline
+    if args.save_baseline:
+        print(f"Updating baseline at {args.baseline}...")
+        with open(baseline_path, "w") as f:
+            json.dump(current, f, indent=2)
+        print("Baseline updated")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/benchmark/scripts/monitor.sh
+++ b/tests/benchmark/scripts/monitor.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+#
+# Resource monitoring script for Isola benchmark runs.
+#
+# Usage:
+#   ./monitor.sh [OPTIONS]
+#
+# Options:
+#   -d, --duration    Duration in seconds (default: 300)
+#   -o, --output-dir  Output directory (default: ./benchmark-results)
+#   -n, --namespace   Kubernetes namespace (default: isola-system)
+#   -i, --interval    Polling interval in seconds (default: 5)
+#
+# Example:
+#   ./monitor.sh -d 600 -o ./results -n isola-system
+
+set -euo pipefail
+
+# Default values
+DURATION=300
+OUTPUT_DIR="./benchmark-results"
+NAMESPACE="isola-system"
+INTERVAL=5
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -d|--duration)
+            DURATION="$2"
+            shift 2
+            ;;
+        -o|--output-dir)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        -n|--namespace)
+            NAMESPACE="$2"
+            shift 2
+            ;;
+        -i|--interval)
+            INTERVAL="$2"
+            shift 2
+            ;;
+        -h|--help)
+            grep '^#' "$0" | grep -v '#!/' | sed 's/^# *//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# Create output directory
+mkdir -p "$OUTPUT_DIR"
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+
+echo "Starting resource monitoring..."
+echo "  Duration: ${DURATION}s"
+echo "  Interval: ${INTERVAL}s"
+echo "  Namespace: ${NAMESPACE}"
+echo "  Output: ${OUTPUT_DIR}"
+
+# Start background collectors
+
+# 1. Pod resource usage over time
+(
+    echo "timestamp,pod,container,cpu,memory" > "${OUTPUT_DIR}/pod_resources_${TIMESTAMP}.csv"
+    END_TIME=$(($(date +%s) + DURATION))
+    while [[ $(date +%s) -lt $END_TIME ]]; do
+        TS=$(date +%s)
+        kubectl top pods -n "$NAMESPACE" --containers 2>/dev/null | tail -n +2 | while read pod container cpu memory; do
+            echo "${TS},${pod},${container},${cpu},${memory}"
+        done >> "${OUTPUT_DIR}/pod_resources_${TIMESTAMP}.csv"
+        sleep "$INTERVAL"
+    done
+) &
+POD_RESOURCES_PID=$!
+
+# 2. Sandbox resource usage
+(
+    echo "timestamp,pod,container,cpu,memory" > "${OUTPUT_DIR}/sandbox_resources_${TIMESTAMP}.csv"
+    END_TIME=$(($(date +%s) + DURATION))
+    while [[ $(date +%s) -lt $END_TIME ]]; do
+        TS=$(date +%s)
+        kubectl top pods -n isola-sandboxes --containers 2>/dev/null | tail -n +2 | while read pod container cpu memory; do
+            echo "${TS},${pod},${container},${cpu},${memory}"
+        done >> "${OUTPUT_DIR}/sandbox_resources_${TIMESTAMP}.csv"
+        sleep "$INTERVAL"
+    done
+) &
+SANDBOX_RESOURCES_PID=$!
+
+# 3. Event monitoring
+(
+    kubectl get events -n isola-sandboxes -w --output-watch-events 2>/dev/null \
+        > "${OUTPUT_DIR}/events_${TIMESTAMP}.log" &
+    EVENT_PID=$!
+    sleep "$DURATION"
+    kill $EVENT_PID 2>/dev/null || true
+) &
+EVENTS_PID=$!
+
+# 4. Sandbox count over time
+(
+    echo "timestamp,total,running,pending,error" > "${OUTPUT_DIR}/sandbox_counts_${TIMESTAMP}.csv"
+    END_TIME=$(($(date +%s) + DURATION))
+    while [[ $(date +%s) -lt $END_TIME ]]; do
+        TS=$(date +%s)
+        TOTAL=$(kubectl get sandboxes -n isola-sandboxes --no-headers 2>/dev/null | wc -l || echo 0)
+        RUNNING=$(kubectl get sandboxes -n isola-sandboxes --no-headers 2>/dev/null | grep -c "Running" || echo 0)
+        PENDING=$(kubectl get sandboxes -n isola-sandboxes --no-headers 2>/dev/null | grep -c "Pending" || echo 0)
+        ERROR=$(kubectl get sandboxes -n isola-sandboxes --no-headers 2>/dev/null | grep -c "Error" || echo 0)
+        echo "${TS},${TOTAL},${RUNNING},${PENDING},${ERROR}"
+        sleep "$INTERVAL"
+    done >> "${OUTPUT_DIR}/sandbox_counts_${TIMESTAMP}.csv"
+) &
+COUNTS_PID=$!
+
+# Collect initial metrics
+echo "Collecting initial metrics..."
+kubectl get --raw /metrics 2>/dev/null | grep -E "apiserver_request_duration|etcd_request_duration" \
+    > "${OUTPUT_DIR}/apiserver_metrics_start_${TIMESTAMP}.txt" || true
+
+# Wait for monitoring duration
+echo "Monitoring for ${DURATION}s..."
+sleep "$DURATION"
+
+# Collect final metrics
+echo "Collecting final metrics..."
+kubectl get --raw /metrics 2>/dev/null | grep -E "apiserver_request_duration|etcd_request_duration" \
+    > "${OUTPUT_DIR}/apiserver_metrics_end_${TIMESTAMP}.txt" || true
+
+# Cleanup background processes
+echo "Stopping monitors..."
+kill $POD_RESOURCES_PID $SANDBOX_RESOURCES_PID $EVENTS_PID $COUNTS_PID 2>/dev/null || true
+wait
+
+# Collect operator logs
+echo "Collecting operator logs..."
+kubectl logs -n "$NAMESPACE" -l app=isola-operator --tail=5000 \
+    > "${OUTPUT_DIR}/operator_logs_${TIMESTAMP}.log" 2>/dev/null || true
+
+# Collect gateway logs
+kubectl logs -n "$NAMESPACE" -l app.kubernetes.io/name=isola-gw --tail=5000 \
+    > "${OUTPUT_DIR}/gateway_logs_${TIMESTAMP}.log" 2>/dev/null || true
+
+echo "Monitoring complete. Results saved to ${OUTPUT_DIR}"
+ls -la "${OUTPUT_DIR}"/*"${TIMESTAMP}"*

--- a/tests/e2e/test_stress.py
+++ b/tests/e2e/test_stress.py
@@ -1,0 +1,351 @@
+"""
+Stress tests for sandbox churn scenarios.
+
+These tests are marked with @pytest.mark.stress and are not run by default.
+Run with: pytest -m stress tests/e2e/test_stress.py
+
+For verbose output: pytest -m stress -v --tb=short tests/e2e/test_stress.py
+"""
+from __future__ import annotations
+
+import logging
+import statistics
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from client.isola_client import IsolaClient
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BenchmarkResult:
+    """Result of a single benchmark operation."""
+
+    operation: str
+    duration_ms: float
+    success: bool
+    error: str | None = None
+
+
+@dataclass
+class BenchmarkSummary:
+    """Summary of benchmark results."""
+
+    results: list[BenchmarkResult] = field(default_factory=list)
+
+    def add(self, result: BenchmarkResult) -> None:
+        self.results.append(result)
+
+    def report(self) -> None:
+        """Print a summary of benchmark results."""
+        successful = [r for r in self.results if r.success]
+        failed = [r for r in self.results if not r.success]
+
+        print(f"\n{'=' * 60}")
+        print("BENCHMARK RESULTS")
+        print(f"{'=' * 60}")
+        print(f"Total operations: {len(self.results)}")
+        print(f"Successful: {len(successful)}")
+        print(f"Failed: {len(failed)}")
+
+        for op in ["create", "ready", "delete"]:
+            op_results = [r.duration_ms for r in successful if r.operation == op]
+            if not op_results:
+                continue
+
+            sorted_results = sorted(op_results)
+            n = len(sorted_results)
+
+            print(f"\n{op.upper()} latency (ms):")
+            print(f"  Count: {n}")
+            print(f"  Min: {min(sorted_results):.2f}")
+            print(f"  P50: {sorted_results[n // 2]:.2f}")
+            print(f"  P95: {sorted_results[int(n * 0.95)]:.2f}")
+            print(f"  P99: {sorted_results[int(n * 0.99)]:.2f}")
+            print(f"  Max: {max(sorted_results):.2f}")
+            print(f"  Avg: {statistics.mean(sorted_results):.2f}")
+            if n > 1:
+                print(f"  Std: {statistics.stdev(sorted_results):.2f}")
+
+        if failed:
+            print(f"\nFailure breakdown:")
+            errors: dict[str, int] = {}
+            for r in failed:
+                key = f"{r.operation}: {r.error or 'unknown'}"
+                errors[key] = errors.get(key, 0) + 1
+            for error, count in sorted(errors.items(), key=lambda x: -x[1]):
+                print(f"  {error}: {count}")
+
+
+@pytest.fixture
+def benchmark_summary() -> BenchmarkSummary:
+    """Fixture to collect and report benchmark metrics."""
+    summary = BenchmarkSummary()
+    yield summary
+    summary.report()
+
+
+@pytest.mark.stress
+class TestSandboxChurn:
+    """High-frequency sandbox creation/deletion tests."""
+
+    @pytest.mark.timeout(600)  # 10 minutes
+    def test_concurrent_sandbox_creation(
+        self,
+        isola_client: IsolaClient,
+        benchmark_summary: BenchmarkSummary,
+        unique_name: str,
+        skip_cleanup: bool,
+    ) -> None:
+        """Create N sandboxes concurrently and measure latency."""
+        NUM_SANDBOXES = 20
+        MAX_WORKERS = 10
+        sandbox_ids: list[str] = []
+
+        def create_sandbox(i: int) -> tuple[BenchmarkResult, str | None]:
+            name = f"{unique_name}-{i}"
+            start = time.perf_counter()
+            try:
+                resp = isola_client.create_sandbox(
+                    name=name,
+                    auto_start=True,
+                )
+                duration = (time.perf_counter() - start) * 1000
+                return (
+                    BenchmarkResult("create", duration, True),
+                    resp["id"],
+                )
+            except Exception as e:
+                duration = (time.perf_counter() - start) * 1000
+                return (
+                    BenchmarkResult("create", duration, False, str(e)),
+                    None,
+                )
+
+        logger.info(f"Creating {NUM_SANDBOXES} sandboxes concurrently...")
+
+        # Concurrent creation
+        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+            futures = [executor.submit(create_sandbox, i) for i in range(NUM_SANDBOXES)]
+            for future in as_completed(futures):
+                result, sandbox_id = future.result()
+                benchmark_summary.add(result)
+                if sandbox_id:
+                    sandbox_ids.append(sandbox_id)
+
+        logger.info(f"Created {len(sandbox_ids)}/{NUM_SANDBOXES} sandboxes")
+
+        # Wait for all to be ready
+        def wait_for_ready(sandbox_id: str) -> BenchmarkResult:
+            start = time.perf_counter()
+            try:
+                isola_client.wait_for_ready(sandbox_id, timeout=120)
+                duration = (time.perf_counter() - start) * 1000
+                return BenchmarkResult("ready", duration, True)
+            except Exception as e:
+                duration = (time.perf_counter() - start) * 1000
+                return BenchmarkResult("ready", duration, False, str(e))
+
+        logger.info("Waiting for sandboxes to be ready...")
+        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+            futures = [executor.submit(wait_for_ready, sid) for sid in sandbox_ids]
+            for future in as_completed(futures):
+                benchmark_summary.add(future.result())
+
+        # Cleanup
+        if not skip_cleanup:
+
+            def delete_sandbox(sandbox_id: str) -> BenchmarkResult:
+                start = time.perf_counter()
+                try:
+                    isola_client.terminate_sandbox(sandbox_id)
+                    duration = (time.perf_counter() - start) * 1000
+                    return BenchmarkResult("delete", duration, True)
+                except Exception as e:
+                    duration = (time.perf_counter() - start) * 1000
+                    return BenchmarkResult("delete", duration, False, str(e))
+
+            logger.info("Cleaning up sandboxes...")
+            with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+                futures = [executor.submit(delete_sandbox, sid) for sid in sandbox_ids]
+                for future in as_completed(futures):
+                    benchmark_summary.add(future.result())
+
+    @pytest.mark.timeout(1800)  # 30 minutes
+    def test_sustained_churn(
+        self,
+        isola_client: IsolaClient,
+        benchmark_summary: BenchmarkSummary,
+        unique_name: str,
+        skip_cleanup: bool,
+    ) -> None:
+        """Sustained create/delete cycles for extended period."""
+        DURATION_SECONDS = 300  # 5 minutes
+        TARGET_CONCURRENT = 10
+        SANDBOX_LIFETIME_SECONDS = 30
+
+        active_sandboxes: dict[str, float] = {}  # id -> creation time
+        start_time = time.time()
+        iteration = 0
+
+        logger.info(f"Starting sustained churn test for {DURATION_SECONDS}s")
+
+        while time.time() - start_time < DURATION_SECONDS:
+            # Create sandboxes up to target
+            while len(active_sandboxes) < TARGET_CONCURRENT:
+                sandbox_name = f"{unique_name}-{iteration}"
+                start = time.perf_counter()
+                try:
+                    resp = isola_client.create_sandbox(
+                        name=sandbox_name,
+                        auto_start=True,
+                    )
+                    duration = (time.perf_counter() - start) * 1000
+                    active_sandboxes[resp["id"]] = time.time()
+                    benchmark_summary.add(BenchmarkResult("create", duration, True))
+                except Exception as e:
+                    duration = (time.perf_counter() - start) * 1000
+                    benchmark_summary.add(BenchmarkResult("create", duration, False, str(e)))
+                iteration += 1
+
+            # Delete sandboxes that have been running long enough
+            now = time.time()
+            to_delete = [
+                sid
+                for sid, created in active_sandboxes.items()
+                if now - created > SANDBOX_LIFETIME_SECONDS
+            ]
+
+            for sandbox_id in to_delete:
+                start = time.perf_counter()
+                try:
+                    isola_client.terminate_sandbox(sandbox_id)
+                    del active_sandboxes[sandbox_id]
+                    duration = (time.perf_counter() - start) * 1000
+                    benchmark_summary.add(BenchmarkResult("delete", duration, True))
+                except Exception as e:
+                    duration = (time.perf_counter() - start) * 1000
+                    benchmark_summary.add(BenchmarkResult("delete", duration, False, str(e)))
+                    # Remove from tracking even if delete failed
+                    active_sandboxes.pop(sandbox_id, None)
+
+            time.sleep(1)
+
+        # Cleanup remaining sandboxes
+        if not skip_cleanup:
+            logger.info(f"Cleaning up {len(active_sandboxes)} remaining sandboxes...")
+            for sandbox_id in list(active_sandboxes.keys()):
+                try:
+                    isola_client.terminate_sandbox(sandbox_id)
+                except Exception:
+                    pass
+
+        logger.info(f"Completed {iteration} iterations")
+
+    @pytest.mark.timeout(300)  # 5 minutes
+    def test_rapid_create_delete(
+        self,
+        isola_client: IsolaClient,
+        benchmark_summary: BenchmarkSummary,
+        unique_name: str,
+    ) -> None:
+        """Rapidly create and immediately delete sandboxes."""
+        NUM_OPERATIONS = 50
+
+        logger.info(f"Running {NUM_OPERATIONS} rapid create/delete cycles...")
+
+        for i in range(NUM_OPERATIONS):
+            sandbox_name = f"{unique_name}-rapid-{i}"
+
+            # Create
+            create_start = time.perf_counter()
+            try:
+                resp = isola_client.create_sandbox(
+                    name=sandbox_name,
+                    auto_start=True,
+                )
+                create_duration = (time.perf_counter() - create_start) * 1000
+                benchmark_summary.add(BenchmarkResult("create", create_duration, True))
+                sandbox_id = resp["id"]
+            except Exception as e:
+                create_duration = (time.perf_counter() - create_start) * 1000
+                benchmark_summary.add(BenchmarkResult("create", create_duration, False, str(e)))
+                continue
+
+            # Brief pause
+            time.sleep(0.5)
+
+            # Delete immediately (don't wait for ready)
+            delete_start = time.perf_counter()
+            try:
+                isola_client.terminate_sandbox(sandbox_id, force=True)
+                delete_duration = (time.perf_counter() - delete_start) * 1000
+                benchmark_summary.add(BenchmarkResult("delete", delete_duration, True))
+            except Exception as e:
+                delete_duration = (time.perf_counter() - delete_start) * 1000
+                benchmark_summary.add(BenchmarkResult("delete", delete_duration, False, str(e)))
+
+
+@pytest.mark.stress
+class TestResourceExhaustion:
+    """Tests for resource limits and exhaustion scenarios."""
+
+    @pytest.mark.timeout(600)
+    def test_max_concurrent_sandboxes(
+        self,
+        isola_client: IsolaClient,
+        benchmark_summary: BenchmarkSummary,
+        unique_name: str,
+        skip_cleanup: bool,
+    ) -> None:
+        """Try to create as many sandboxes as possible until hitting limits."""
+        MAX_SANDBOXES = 100
+        sandbox_ids: list[str] = []
+        failures_in_a_row = 0
+        MAX_CONSECUTIVE_FAILURES = 5
+
+        logger.info(f"Attempting to create up to {MAX_SANDBOXES} sandboxes...")
+
+        for i in range(MAX_SANDBOXES):
+            sandbox_name = f"{unique_name}-max-{i}"
+            start = time.perf_counter()
+
+            try:
+                resp = isola_client.create_sandbox(
+                    name=sandbox_name,
+                    auto_start=True,
+                )
+                duration = (time.perf_counter() - start) * 1000
+                benchmark_summary.add(BenchmarkResult("create", duration, True))
+                sandbox_ids.append(resp["id"])
+                failures_in_a_row = 0
+                logger.info(f"Created sandbox {i + 1}/{MAX_SANDBOXES}")
+            except Exception as e:
+                duration = (time.perf_counter() - start) * 1000
+                benchmark_summary.add(BenchmarkResult("create", duration, False, str(e)))
+                failures_in_a_row += 1
+                logger.warning(f"Failed to create sandbox {i + 1}: {e}")
+
+                if failures_in_a_row >= MAX_CONSECUTIVE_FAILURES:
+                    logger.info(f"Stopping after {MAX_CONSECUTIVE_FAILURES} consecutive failures")
+                    break
+
+            # Small delay between creations
+            time.sleep(0.2)
+
+        logger.info(f"Successfully created {len(sandbox_ids)} sandboxes")
+
+        # Cleanup
+        if not skip_cleanup:
+            logger.info("Cleaning up...")
+            for sandbox_id in sandbox_ids:
+                try:
+                    isola_client.terminate_sandbox(sandbox_id, force=True)
+                except Exception:
+                    pass


### PR DESCRIPTION
Implements a complete benchmarking and performance testing framework
to enable confident scaling decisions based on empirical data.

## Instrumentation & Observability

- Add Prometheus metrics to gateway (HTTP latency, sandbox operations, K8s API calls)
- Add Prometheus metrics to operator (reconcile duration, pod creation, snapshots)
- Add pprof profiling endpoints to both gateway and operator
- Metrics middleware for automatic HTTP request tracking

## Bottleneck Fixes

- Increase MaxConcurrentReconciles from 1 to 10 (configurable)
- Increase operator resource limits (2 CPU, 1Gi memory default)
- Add per-tenant rate limiting to gateway (50 req/s default)
- Make controller options configurable via Helm values

## Benchmark Test Infrastructure

- Go microbenchmarks for network policy builder, timeout calculation
- k6 load test scripts: sandbox_churn, burst_traffic, sustained_load
- Python stress tests with detailed metrics reporting
- Resource monitoring scripts for live cluster observation
- Baseline comparison tooling with regression detection

## CI Integration

- New benchmark.yml workflow (weekly schedule + manual trigger)
- Kind cluster config for benchmark environment
- Makefile targets: benchmark, benchmark-k6, benchmark-stress

Key metrics tracked:
- Sandbox create/ready/delete latency (P50/P95/P99)
- Reconcile loop duration
- Rate limit rejections
- Active sandbox count