### PR TITLE
fix: use pod IP instead of DNS to address sandbox agents

### DIFF
--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -158,7 +158,6 @@ func (s *Sandbox) GetCustomNetworkPolicyName() string {
 	return s.Name + "-custom-netpol"
 }
 
-// todo benl: for now, not storing sandbox pod or snapshotter pod info anywhere in the sandbox CRD
 // SandboxStatus defines the observed state of Sandbox.
 type SandboxStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
@@ -172,6 +171,11 @@ type SandboxStatus struct {
 	// It is set by the controller (derived from template timeout + chosen start time).
 	// +optional
 	TimeoutAt *metav1.Time `json:"timeoutAt,omitempty"`
+
+	// PodIP is the IP address of the sandbox pod.
+	// Used by the gateway to communicate directly with the agent, avoiding DNS caching issues.
+	// +optional
+	PodIP string `json:"podIP,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/charts/isola-operator/crds/sandbox.isola.run_rootfssnapshots.yaml
+++ b/charts/isola-operator/crds/sandbox.isola.run_rootfssnapshots.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: rootfssnapshots.sandbox.isola.run
 spec:
   group: sandbox.isola.run

--- a/charts/isola-operator/crds/sandbox.isola.run_sandboxes.yaml
+++ b/charts/isola-operator/crds/sandbox.isola.run_sandboxes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: sandboxes.sandbox.isola.run
 spec:
   group: sandbox.isola.run
@@ -161,7 +161,9 @@ spec:
                                 minimum: 1
                                 type: integer
                               protocol:
-                                default: TCP
+                                allOf:
+                                - default: TCP
+                                - default: TCP
                                 description: Protocol (TCP or UDP). Defaults to TCP.
                                 enum:
                                 - TCP
@@ -277,6 +279,11 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              podIP:
+                description: |-
+                  PodIP is the IP address of the sandbox pod.
+                  Used by the gateway to communicate directly with the agent, avoiding DNS caching issues.
+                type: string
               timeoutAt:
                 description: |-
                   TimeoutAt is the absolute time at which the sandbox should be considered timed out.

--- a/charts/isola-operator/crds/sandbox.isola.run_sandboxtemplates.yaml
+++ b/charts/isola-operator/crds/sandbox.isola.run_sandboxtemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: sandboxtemplates.sandbox.isola.run
 spec:
   group: sandbox.isola.run

--- a/charts/isola-operator/templates/clusterrole.yaml
+++ b/charts/isola-operator/templates/clusterrole.yaml
@@ -7,13 +7,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - pods
   verbs:
   - create
@@ -35,6 +28,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/config/crd/bases/sandbox.isola.run_rootfssnapshots.yaml
+++ b/config/crd/bases/sandbox.isola.run_rootfssnapshots.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: rootfssnapshots.sandbox.isola.run
 spec:
   group: sandbox.isola.run

--- a/config/crd/bases/sandbox.isola.run_sandboxes.yaml
+++ b/config/crd/bases/sandbox.isola.run_sandboxes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: sandboxes.sandbox.isola.run
 spec:
   group: sandbox.isola.run
@@ -161,7 +161,9 @@ spec:
                                 minimum: 1
                                 type: integer
                               protocol:
-                                default: TCP
+                                allOf:
+                                - default: TCP
+                                - default: TCP
                                 description: Protocol (TCP or UDP). Defaults to TCP.
                                 enum:
                                 - TCP
@@ -277,6 +279,11 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              podIP:
+                description: |-
+                  PodIP is the IP address of the sandbox pod.
+                  Used by the gateway to communicate directly with the agent, avoiding DNS caching issues.
+                type: string
               timeoutAt:
                 description: |-
                   TimeoutAt is the absolute time at which the sandbox should be considered timed out.

--- a/config/crd/bases/sandbox.isola.run_sandboxtemplates.yaml
+++ b/config/crd/bases/sandbox.isola.run_sandboxtemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: sandboxtemplates.sandbox.isola.run
 spec:
   group: sandbox.isola.run

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,13 +7,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - pods
   verbs:
   - create
@@ -35,6 +28,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/internal/gateway/kubernetes/manager.go
+++ b/internal/gateway/kubernetes/manager.go
@@ -306,8 +306,6 @@ func (m *Manager) DeleteSandboxCR(ctx context.Context, sandboxID string) error {
 	return nil
 }
 
-const agentServiceName = "sandbox-agents"
-
 type SandboxStatus struct {
 	State        models.SandboxState
 	ErrorReason  *string
@@ -333,8 +331,8 @@ func (m *Manager) GetSandboxStatus(ctx context.Context, sandboxID string) (*Sand
 	// Parse state from CR conditions
 	state, errorReason := m.parseStateFromConditions(sandbox)
 
-	// Construct DNS address for the agent
-	agentAddress := m.getAgentAddress(sandboxID)
+	// Get agent address from PodIP in status (avoids DNS caching issues)
+	agentAddress := m.getAgentAddressFromStatus(sandbox)
 
 	return &SandboxStatus{
 		State:        state,
@@ -343,12 +341,16 @@ func (m *Manager) GetSandboxStatus(ctx context.Context, sandboxID string) (*Sand
 	}, nil
 }
 
-// getAgentAddress constructs the DNS-resolvable address for the sandbox agent.
-// Format: <pod-name>.<headless-service>.<namespace>.svc.cluster.local
-func (m *Manager) getAgentAddress(sandboxID string) string {
-	sandboxName := fmt.Sprintf("sandbox-%s", sandboxID[:min(8, len(sandboxID))])
-	podName := sandboxName + "-pod"
-	return fmt.Sprintf("%s.%s.%s.svc.cluster.local", podName, agentServiceName, m.namespace)
+// getAgentAddressFromStatus reads the PodIP from the Sandbox CR status.
+// Using the pod IP directly avoids DNS caching issues that could cause
+// requests to be sent to a wrong pod after sandbox recreation.
+func (m *Manager) getAgentAddressFromStatus(sandbox *unstructured.Unstructured) string {
+	status, found, _ := unstructured.NestedMap(sandbox.Object, "status")
+	if !found {
+		return ""
+	}
+	podIP, _, _ := unstructured.NestedString(status, "podIP")
+	return podIP
 }
 
 // parseStateFromConditions derives the SandboxState from the Sandbox CR conditions.

--- a/internal/operator/controller/sandbox_controller.go
+++ b/internal/operator/controller/sandbox_controller.go
@@ -580,6 +580,12 @@ func (r *SandboxReconciler) reconcileSandboxStatus(
 	readyCondition := r.determineReadyCondition(sandbox, sandboxPod)
 	conditions = append(conditions, readyCondition)
 
+	// Update PodIP from the sandbox pod status.
+	// Used by gateway to communicate directly with agent, avoiding DNS caching issues.
+	if sandboxPod != nil && sandboxPod.Status.PodIP != "" {
+		sandbox.Status.PodIP = sandboxPod.Status.PodIP
+	}
+
 	return r.patchStatus(ctx, baseSandbox, sandbox, conditions)
 }
 


### PR DESCRIPTION
Avoids stale DNS issues when communicating with sandbox agents.
Previously, the gateway constructed DNS addresses for sandbox agents
using the headless service. This could cause requests to be sent to
wrong pods if DNS was cached after sandbox recreation.

Changes:
- Add PodIP field to Sandbox CR status
- Operator populates PodIP from pod status during reconciliation
- Gateway reads PodIP from Sandbox status instead of constructing DNS