### PR TITLE
Pin controller-gen version in codegen workflow

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -21,7 +21,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Install controller-gen
-        run: go install sigs.k8s.io/controller-tools/cmd/controller-gen@latest
+        run: go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.20.0
 
       - name: Verify API codegen is in sync
         run: make check-api-codegen


### PR DESCRIPTION
Pin controller-gen to v0.20.0 to match hack/setup.sh, ensuring
consistent codegen behavior between local development and CI.

https://claude.ai/code/session_01CqQpMKoVdn2UkmubeXkxwX