### PR TITLE
Add standardized event recording for Sandbox and RootfsSnapshot controllers

### DIFF
--- a/internal/operator/controller/rootfssnapshot_controller.go
+++ b/internal/operator/controller/rootfssnapshot_controller.go
@@ -53,6 +53,18 @@ const (
 	LabelSandboxName = "sandbox.isola.run/sandbox-name"
 )
 
+// Event reasons for RootfsSnapshot controller.
+// Following K8s conventions: PascalCase, past tense for completed actions.
+const (
+	EventReasonSnapshotRequested       = "SnapshotRequested"
+	EventReasonSnapshotJobCreated      = "JobCreated"
+	EventReasonSnapshotComplete        = "SnapshotComplete"
+	EventReasonSnapshotJobFailed       = "SnapshotFailed"
+	EventReasonTerminationLogFailed    = "TerminationLogReadFailed"
+	EventReasonSnapshotTTLExpired      = "TTLExpired"
+	EventReasonSnapshotStorageNotReady = "StorageNotConfigured"
+)
+
 // defaultSnapshotSizeLimit is used when the container has no ephemeral storage limit.
 var defaultSnapshotSizeLimit = resource.MustParse("1Gi")
 
@@ -166,6 +178,9 @@ func (r *RootfsSnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	if isComplete {
 		ttlLeft := r.ttlLeft(snap)
 		if ttlLeft <= 0 {
+			log.Info("Deleting RootfsSnapshot after TTL expired", "ttl", getTTLSeconds(snap))
+			r.Recorder.Event(snap, corev1.EventTypeNormal, EventReasonSnapshotTTLExpired,
+				fmt.Sprintf("Snapshot TTL expired after %s; deleting", getTTLSeconds(snap)))
 			if err := r.Delete(ctx, snap); err != nil && !apierrors.IsNotFound(err) {
 				log.Error(err, "Failed to delete RootfsSnapshot after TTL")
 				return ctrl.Result{}, err
@@ -178,7 +193,15 @@ func (r *RootfsSnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	if r.BucketURL == "" {
 		log.Info("Snapshot storage not configured: ISOLA_SNAPSHOT_BUCKET_URL is required")
+		r.Recorder.Event(snap, corev1.EventTypeWarning, EventReasonSnapshotStorageNotReady,
+			"Snapshot storage not configured: ISOLA_SNAPSHOT_BUCKET_URL is required")
 		return r.setFailed(ctx, baseSnap, snap, "Snapshot storage not configured: ISOLA_SNAPSHOT_BUCKET_URL is required")
+	}
+
+	// Emit SnapshotRequested event on first reconcile (when StartedAt is not set)
+	if snap.Status.StartedAt == nil {
+		r.Recorder.Event(snap, corev1.EventTypeNormal, EventReasonSnapshotRequested,
+			fmt.Sprintf("Snapshot requested for sandbox %q", snap.Spec.SandboxName))
 	}
 
 	sandboxPodName := podutil.GetSandboxPodName(snap.Spec.SandboxName)
@@ -240,7 +263,7 @@ func (r *RootfsSnapshotReconciler) reconcileSnapshotJob(
 		}
 
 		log.Info("Created snapshot job", "job", jobName)
-		r.Recorder.Event(snap, corev1.EventTypeNormal, "JobCreated", fmt.Sprintf("Created snapshot job for container %s", containerName))
+		r.Recorder.Event(snap, corev1.EventTypeNormal, EventReasonSnapshotJobCreated, fmt.Sprintf("Created snapshot job for container %s", containerName))
 
 		return r.setInProgress(ctx, baseSnap, snap, containerName, containerID)
 	}
@@ -256,12 +279,12 @@ func (r *RootfsSnapshotReconciler) reconcileSnapshotJob(
 		result, err := r.getUploadResult(ctx, job)
 		if err != nil {
 			log.Error(err, "Failed to read upload result from termination message")
-			r.Recorder.Event(snap, corev1.EventTypeWarning, "TerminationLogReadFailed", err.Error())
+			r.Recorder.Event(snap, corev1.EventTypeWarning, EventReasonTerminationLogFailed, err.Error())
 			r.deleteJob(ctx, job)
 			return r.setFailed(ctx, baseSnap, snap, fmt.Sprintf("Failed to read upload result: %v", err))
 		}
 
-		r.Recorder.Event(snap, corev1.EventTypeNormal, "SnapshotComplete", "Snapshot completed successfully")
+		r.Recorder.Event(snap, corev1.EventTypeNormal, EventReasonSnapshotComplete, "Snapshot completed successfully")
 
 		// Delete the job now that we've read the results
 		r.deleteJob(ctx, job)
@@ -275,7 +298,7 @@ func (r *RootfsSnapshotReconciler) reconcileSnapshotJob(
 			message = fmt.Sprintf("Snapshot job failed: %s", condMsg)
 		}
 		log.Info(message, "job", jobName)
-		r.Recorder.Event(snap, corev1.EventTypeWarning, "SnapshotFailed", message)
+		r.Recorder.Event(snap, corev1.EventTypeWarning, EventReasonSnapshotJobFailed, message)
 
 		// Delete the job - no point keeping failed jobs until we hit to snapshotter TTL
 		r.deleteJob(ctx, job)
@@ -588,7 +611,7 @@ func (r *RootfsSnapshotReconciler) setFailed(ctx context.Context, base, snap *sa
 	now := metav1.NewTime(r.clock().Now())
 	snap.Status.CompletedAt = &now
 
-	r.Recorder.Event(snap, corev1.EventTypeWarning, "SnapshotFailed", message)
+	r.Recorder.Event(snap, corev1.EventTypeWarning, EventReasonSnapshotJobFailed, message)
 	if err := r.patchStatus(ctx, base, snap, []metav1.Condition{
 		{
 			Type:               string(sandboxv1alpha1.RootfsSnapshotComplete),

--- a/internal/operator/controller/sandbox_controller.go
+++ b/internal/operator/controller/sandbox_controller.go
@@ -54,6 +54,38 @@ const (
 	SandboxRootfsSnapshotCondition = "RootfsSnapshot"
 )
 
+// Event reasons for Sandbox controller.
+// Following K8s conventions: PascalCase, past tense for completed actions.
+const (
+	// Lifecycle events
+	EventReasonSandboxCreated  = "SandboxCreated"
+	EventReasonSandboxDeleting = "SandboxDeleting"
+	EventReasonSandboxTimedOut = "SandboxTimedOut"
+
+	// Pod events
+	EventReasonPodCreated        = "PodCreated"
+	EventReasonPodCreationFailed = "PodCreationFailed"
+	EventReasonPodNotReady       = "PodNotReady"
+
+	// Template events
+	EventReasonTemplateResolved = "TemplateResolved"
+	EventReasonTemplateNotFound = "TemplateNotFound"
+
+	// Finalizer events
+	EventReasonFinalizerAdded   = "FinalizerAdded"
+	EventReasonFinalizerRemoved = "FinalizerRemoved"
+
+	// Network events
+	EventReasonNetworkPolicyCreated = "NetworkPolicyCreated"
+	EventReasonNetworkPolicyFailed  = "NetworkPolicyFailed"
+
+	// Snapshot events (on Sandbox resource)
+	EventReasonRootfsSnapshotCreated = "RootfsSnapshotCreated"
+	EventReasonSnapshotSucceeded     = "SnapshotSucceeded"
+	EventReasonSnapshotFailed        = "SnapshotFailed"
+	EventReasonRuntimeNotSupported   = "RuntimeNotSupported"
+)
+
 const (
 	CondReasonTemplateNotFound = "TemplateNotFound"
 	CondReasonTemplateResolved = "TemplateResolved"
@@ -265,6 +297,8 @@ func (r *SandboxReconciler) CreateSandboxPod(ctx context.Context, sandbox *sandb
 
 	if err := r.Create(ctx, sandboxPod); err != nil {
 		log.Error(err, "Failed creating Pod")
+		r.Recorder.Event(sandbox, corev1.EventTypeWarning, EventReasonPodCreationFailed,
+			fmt.Sprintf("Failed to create pod: %v", err))
 
 		// Best effort status patch - log but don't override the original create error
 		if patchErr := r.patchStatus(ctx, baseSandbox, sandbox, []metav1.Condition{
@@ -289,9 +323,7 @@ func (r *SandboxReconciler) CreateSandboxPod(ctx context.Context, sandbox *sandb
 	}
 
 	log.Info("Pod created")
-
-	// todo benl: this doesn't print anything - rbac issues?
-	r.Recorder.Event(sandbox, corev1.EventTypeNormal, "PodCreated", "Sandbox Pod created")
+	r.Recorder.Event(sandbox, corev1.EventTypeNormal, EventReasonPodCreated, "Sandbox pod created")
 
 	if err := r.patchStatus(ctx, baseSandbox, sandbox, []metav1.Condition{
 		{
@@ -400,6 +432,8 @@ func (r *SandboxReconciler) EnsureTemplate(ctx context.Context, sandbox *sandbox
 
 	if err := r.Get(ctx, types.NamespacedName{Name: sandbox.Spec.TemplateRef.Name, Namespace: sandbox.Namespace}, template); err != nil {
 		if apierrors.IsNotFound(err) {
+			r.Recorder.Event(sandbox, corev1.EventTypeWarning, EventReasonTemplateNotFound,
+				fmt.Sprintf("Template %q not found", sandbox.Spec.TemplateRef.Name))
 
 			if err := r.patchStatus(
 				ctx,
@@ -432,6 +466,13 @@ func (r *SandboxReconciler) EnsureTemplate(ctx context.Context, sandbox *sandbox
 		}
 		log.Error(err, "Failed to get Sandbox template")
 		return nil, ctrl.Result{}, err
+	}
+
+	// Only emit event on first resolution (when condition doesn't exist or was false)
+	existingCond := meta.FindStatusCondition(sandbox.Status.Conditions, SandboxTemplateReadyCondition)
+	if existingCond == nil || existingCond.Status != metav1.ConditionTrue {
+		r.Recorder.Event(sandbox, corev1.EventTypeNormal, EventReasonTemplateResolved,
+			fmt.Sprintf("Template %q resolved", template.Name))
 	}
 
 	if err := r.patchStatus(ctx, baseSandbox, sandbox, []metav1.Condition{
@@ -511,10 +552,14 @@ func (r *SandboxReconciler) ensureCustomNetworkPolicy(
 			return nil
 		}
 		log.Error(err, "Failed to create custom NetworkPolicy")
+		r.Recorder.Event(sandbox, corev1.EventTypeWarning, EventReasonNetworkPolicyFailed,
+			fmt.Sprintf("Failed to create NetworkPolicy %q: %v", policyName, err))
 		return err
 	}
 
 	log.Info("Custom NetworkPolicy created")
+	r.Recorder.Event(sandbox, corev1.EventTypeNormal, EventReasonNetworkPolicyCreated,
+		fmt.Sprintf("NetworkPolicy %q created", policyName))
 	return nil
 }
 
@@ -789,6 +834,8 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			log.Error(err, "Failed to add finalizer")
 			return ctrl.Result{}, err
 		}
+		r.Recorder.Event(sandbox, corev1.EventTypeNormal, EventReasonFinalizerAdded, "Finalizer added to sandbox")
+		r.Recorder.Event(sandbox, corev1.EventTypeNormal, EventReasonSandboxCreated, "Sandbox created and initialized")
 		// Update baseSandbox to reflect the finalizer change for subsequent patches
 		baseSandbox = sandbox.DeepCopy()
 	}
@@ -799,6 +846,8 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	if sandboxDeleted && !noFinalizer {
+		r.Recorder.Event(sandbox, corev1.EventTypeNormal, EventReasonSandboxDeleting, "Sandbox deletion initiated")
+
 		if template == nil {
 			// Template not found during deletion - can't determine shutdown policy
 			// Remove finalizer and allow deletion to proceed
@@ -807,6 +856,7 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			if err := r.Update(ctx, sandbox); err != nil {
 				return ctrl.Result{}, err
 			}
+			r.Recorder.Event(sandbox, corev1.EventTypeNormal, EventReasonFinalizerRemoved, "Finalizer removed; sandbox will be deleted")
 			return ctrl.Result{}, nil
 		}
 
@@ -836,6 +886,8 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	if optionalTimeoutAt != nil && r.clock().Now().After(optionalTimeoutAt.Time) {
 		log.Info("Sandbox timed out")
+		r.Recorder.Event(sandbox, corev1.EventTypeWarning, EventReasonSandboxTimedOut,
+			fmt.Sprintf("Sandbox timed out after %s", optionalTimeoutAt.Time.Sub(sandbox.CreationTimestamp.Time).Round(time.Second)))
 
 		res, cleanupDone, err := r.finalizeSandbox(ctx, sandbox, baseSandbox, template)
 		if err != nil {
@@ -917,6 +969,7 @@ func (r *SandboxReconciler) finalizeSandbox(
 		log.Error(err, "Failed to remove finalizer")
 		return ctrl.Result{}, false, err
 	}
+	r.Recorder.Event(sandbox, corev1.EventTypeNormal, EventReasonFinalizerRemoved, "Finalizer removed; sandbox will be deleted")
 
 	return ctrl.Result{}, true, nil
 }
@@ -1039,7 +1092,7 @@ func (r *SandboxReconciler) handleRootfsSnapshot(
 
 	if !podutil.IsPodReady(sandboxPod) {
 		log.Info("Unable to perform rootfs snapshot: pod not ready")
-		r.Recorder.Event(sandbox, corev1.EventTypeWarning, "PodNotReady", "Unable to perform rootfs snapshot: pod not ready")
+		r.Recorder.Event(sandbox, corev1.EventTypeWarning, EventReasonPodNotReady, "Unable to perform rootfs snapshot: pod not ready")
 
 		if err := r.patchStatus(ctx, baseSandbox, sandbox, []metav1.Condition{
 			{
@@ -1063,7 +1116,7 @@ func (r *SandboxReconciler) handleRootfsSnapshot(
 
 	if !supported {
 		log.Info("Unable to perform rootfs snapshot: runtime not supported")
-		r.Recorder.Event(sandbox, corev1.EventTypeWarning, "RuntimeNotSupported", "Unable to perform rootfs snapshot")
+		r.Recorder.Event(sandbox, corev1.EventTypeWarning, EventReasonRuntimeNotSupported, "Unable to perform rootfs snapshot: runtime not supported")
 
 		if err := r.patchStatus(ctx, baseSandbox, sandbox, []metav1.Condition{
 			{
@@ -1115,7 +1168,7 @@ func (r *SandboxReconciler) handleRootfsSnapshot(
 	readyCond := meta.FindStatusCondition(snap.Status.Conditions, string(sandboxv1alpha1.RootfsSnapshotComplete))
 	if readyCond != nil && readyCond.Status == metav1.ConditionTrue {
 		log.Info("Snapshot completed successfully", "snapshot", snapshotName)
-		r.Recorder.Event(sandbox, corev1.EventTypeNormal, "SnapshotSucceeded", fmt.Sprintf("Snapshot %q completed", snapshotName))
+		r.Recorder.Event(sandbox, corev1.EventTypeNormal, EventReasonSnapshotSucceeded, fmt.Sprintf("Snapshot %q completed", snapshotName))
 		if err := r.patchStatus(ctx, baseSandbox, sandbox, []metav1.Condition{
 			{
 				Type:               SandboxRootfsSnapshotCondition,
@@ -1136,7 +1189,7 @@ func (r *SandboxReconciler) handleRootfsSnapshot(
 		message = readyCond.Message
 	}
 	log.Info("Snapshot failed, proceeding with deletion", "snapshot", snapshotName)
-	r.Recorder.Event(sandbox, corev1.EventTypeWarning, "SnapshotFailed", message)
+	r.Recorder.Event(sandbox, corev1.EventTypeWarning, EventReasonSnapshotFailed, fmt.Sprintf("Snapshot %q failed: %s", snapshotName, message))
 	if err := r.patchStatus(ctx, baseSandbox, sandbox, []metav1.Condition{
 		{
 			Type:               SandboxRootfsSnapshotCondition,
@@ -1191,7 +1244,7 @@ func (r *SandboxReconciler) createShutdownSnapshot(
 	}
 
 	log.Info("Created shutdown RootfsSnapshot", "name", rootfsSnapshot.Name)
-	r.Recorder.Event(sandbox, corev1.EventTypeNormal, "RootfsSnapshotCreated", fmt.Sprintf("Created RootfsSnapshot %q", rootfsSnapshot.Name))
+	r.Recorder.Event(sandbox, corev1.EventTypeNormal, EventReasonRootfsSnapshotCreated, fmt.Sprintf("Created RootfsSnapshot %q", rootfsSnapshot.Name))
 
 	if err := r.patchStatus(ctx, baseSandbox, sandbox, []metav1.Condition{
 		{

--- a/internal/operator/controller/sandbox_controller_events_test.go
+++ b/internal/operator/controller/sandbox_controller_events_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Sandbox Controller", func() {
 			reconciler = newTestReconcilerWithRecorder(fakeClock, recorder)
 		})
 
-		It("should record PodCreated event when pod is created", func() {
+		It("should record SandboxCreated, FinalizerAdded, TemplateResolved, and PodCreated events when sandbox is created", func() {
 			sandboxName := "sandbox-event-pod-created"
 			templateName := "template-event-pod-created"
 
@@ -62,8 +62,69 @@ var _ = Describe("Sandbox Controller", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			// Check for PodCreated event
-			Eventually(recorder.Events).Should(Receive(Equal("Normal PodCreated Sandbox Pod created")))
+			// Check for lifecycle events in order
+			Eventually(recorder.Events).Should(Receive(Equal("Normal FinalizerAdded Finalizer added to sandbox")))
+			Eventually(recorder.Events).Should(Receive(Equal("Normal SandboxCreated Sandbox created and initialized")))
+			Eventually(recorder.Events).Should(Receive(ContainSubstring("Normal TemplateResolved Template")))
+			Eventually(recorder.Events).Should(Receive(Equal("Normal PodCreated Sandbox pod created")))
+		})
+
+		It("should record TemplateNotFound event when template is missing", func() {
+			sandboxName := "sandbox-event-template-missing"
+			templateName := "nonexistent-template"
+
+			createSandbox(ctx, sandboxName, templateName)
+			defer deleteSandbox(ctx, sandboxName)
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: sandboxName, Namespace: testNamespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Drain initial events
+			Eventually(recorder.Events).Should(Receive(ContainSubstring("FinalizerAdded")))
+			Eventually(recorder.Events).Should(Receive(ContainSubstring("SandboxCreated")))
+			// Check for TemplateNotFound event
+			Eventually(recorder.Events).Should(Receive(ContainSubstring("Warning TemplateNotFound")))
+		})
+
+		It("should record SandboxTimedOut event when sandbox times out", func() {
+			sandboxName := "sandbox-event-timeout"
+			templateName := "template-event-timeout"
+
+			timeout := int64(1)
+			createTemplate(ctx, templateName, func(t *sandboxv1alpha1.SandboxTemplate) {
+				t.Spec.TimeoutSeconds = &timeout
+			})
+			defer deleteTemplate(ctx, templateName)
+
+			createSandbox(ctx, sandboxName, templateName)
+			defer deleteSandbox(ctx, sandboxName)
+			defer deletePod(ctx, sandboxName+"-pod")
+
+			// First reconcile to create pod
+			_, _ = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: sandboxName, Namespace: testNamespace},
+			})
+
+			// Drain initial events
+		drainInitialEvents:
+			for {
+				select {
+				case <-recorder.Events:
+				default:
+					break drainInitialEvents
+				}
+			}
+
+			// Advance clock past timeout
+			fakeClock.Advance(2 * time.Second)
+			_, _ = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: sandboxName, Namespace: testNamespace},
+			})
+
+			// Check for SandboxTimedOut event
+			Eventually(recorder.Events).Should(Receive(ContainSubstring("Warning SandboxTimedOut")))
 		})
 
 		It("should record RootfsSnapshotCreated event", func() {


### PR DESCRIPTION
## Summary
This PR introduces standardized event recording across the Sandbox and RootfsSnapshot controllers by defining event reason constants and emitting events at key lifecycle points. This improves observability and follows Kubernetes conventions for event naming.

## Key Changes

**Event Reason Constants**
- Added `EventReason*` constants to both `sandbox_controller.go` and `rootfssnapshot_controller.go` following K8s conventions (PascalCase, past tense for completed actions)
- Organized constants by category (Lifecycle, Pod, Template, Finalizer, Network, Snapshot events)

**RootfsSnapshot Controller Events**
- Added `SnapshotRequested` event on first reconcile (when `StartedAt` is not set)
- Added `StorageNotConfigured` event when bucket URL is not configured
- Added `TTLExpired` event when snapshot is deleted after TTL expiration
- Replaced hardcoded event reason strings with constants for consistency

**Sandbox Controller Events**
- Added `SandboxCreated` and `FinalizerAdded` events during sandbox initialization
- Added `TemplateNotFound` event when template reference cannot be resolved
- Added `TemplateResolved` event on first successful template resolution (only when condition transitions to true)
- Added `PodCreationFailed` event when pod creation fails
- Added `NetworkPolicyCreated` and `NetworkPolicyFailed` events for custom network policy operations
- Added `SandboxDeleting` and `FinalizerRemoved` events during deletion flow
- Added `SandboxTimedOut` event when sandbox exceeds configured timeout
- Replaced hardcoded event reason strings with constants throughout
- Improved event messages for clarity (e.g., "Sandbox pod created" instead of "Sandbox Pod created")

**Test Updates**
- Updated `sandbox_controller_events_test.go` to verify new events are recorded in correct order
- Added tests for `TemplateNotFound`, `SandboxTimedOut`, and other new event scenarios

## Implementation Details
- Events are emitted at appropriate points in the reconciliation lifecycle
- Conditional events (like `TemplateResolved`) are only emitted on state transitions to avoid duplicate events
- Event messages include relevant context (sandbox name, template name, timeout duration, etc.)
- All event reasons follow Kubernetes naming conventions and are documented with comments

https://claude.ai/code/session_01PPQ6bSNUTW8jpCm8aZ7zLY