### PR TITLE
allow container entrypoint override with sleep to avoid the sandbox t…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,8 @@ REST types are separate from CRD types with explicit conversion in `convert.go`.
 
 **Env vars are write-only:** Request types accept env vars but response types intentionally omit them to avoid leaking secrets. `ContainerSpec` (request) has `Env`; `ContainerInfo` (response) does not.
 
+**Default command:** Containers with no `command` get `["sleep", "infinity"]` injected by the operator so sandboxes stay alive by default. The gateway passes `command` through as-is (nil when omitted); the operator applies the default at pod creation time.
+
 ## Sharp Edges
 
 **Two-client pattern in operator tests:** `suite_test.go` uses both `k8sClient` (direct, no cache delay for test writes) and `k8sCache` (cached, required for field index queries). Use the direct client for test assertions. The api-gateway tests use a single cached client from the manager.

--- a/api/openapi/api-gateway.yaml
+++ b/api/openapi/api-gateway.yaml
@@ -3,6 +3,13 @@ components:
     ContainerInfo:
       additionalProperties: false
       properties:
+        command:
+          description: Container entrypoint override
+          items:
+            type: string
+          type:
+            - array
+            - "null"
         image:
           description: Container image
           type: string
@@ -15,6 +22,13 @@ components:
     ContainerSpec:
       additionalProperties: false
       properties:
+        command:
+          description: Override the container entrypoint. Defaults to sleep infinity if omitted.
+          items:
+            type: string
+          type:
+            - array
+            - "null"
         env:
           additionalProperties:
             type: string

--- a/internal/api-gateway/handlers/convert.go
+++ b/internal/api-gateway/handlers/convert.go
@@ -26,6 +26,7 @@ func sandboxToResponse(sb *sandboxv1alpha1.Sandbox) SandboxResponse {
 	if len(sb.Spec.PodTemplate.Spec.Containers) > 0 {
 		c := sb.Spec.PodTemplate.Spec.Containers[0]
 		resp.PodTemplate.Container.Image = c.Image
+		resp.PodTemplate.Container.Command = c.Command
 		resp.PodTemplate.Container.Resources = containerResourcesToSpec(c.Resources)
 	}
 
@@ -143,8 +144,9 @@ func crdNetworkToREST(n *sandboxv1alpha1.NetworkSpec) *NetworkSpec {
 func requestToSandboxCR(req CreateSandboxRequest, name, namespace string) (*sandboxv1alpha1.Sandbox, error) {
 	c := req.PodTemplate.Container
 	container := corev1.Container{
-		Name:  containerName,
-		Image: c.Image,
+		Name:    containerName,
+		Image:   c.Image,
+		Command: c.Command,
 	}
 
 	if c.Resources != nil {

--- a/internal/api-gateway/handlers/convert_test.go
+++ b/internal/api-gateway/handlers/convert_test.go
@@ -13,6 +13,76 @@ import (
 
 var _ = Describe("Conversion functions", func() {
 
+	Describe("requestToSandboxCR", func() {
+		It("passes command through to the container", func() {
+			req := CreateSandboxRequest{
+				PodTemplate: PodTemplate{
+					Container: ContainerSpec{
+						Image:   "python:3.12",
+						Command: []string{"python", "-c", "print('hello')"},
+					},
+				},
+			}
+			sb, err := requestToSandboxCR(req, "test-sb", "default")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sb.Spec.PodTemplate.Spec.Containers[0].Command).To(Equal([]string{"python", "-c", "print('hello')"}))
+		})
+
+		It("leaves command nil when not specified", func() {
+			req := CreateSandboxRequest{
+				PodTemplate: PodTemplate{
+					Container: ContainerSpec{
+						Image: "alpine:latest",
+					},
+				},
+			}
+			sb, err := requestToSandboxCR(req, "test-sb", "default")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sb.Spec.PodTemplate.Spec.Containers[0].Command).To(BeNil())
+		})
+	})
+
+	Describe("sandboxToResponse", func() {
+		It("returns command from the CRD container", func() {
+			sb := &sandboxv1alpha1.Sandbox{
+				Spec: sandboxv1alpha1.SandboxSpec{
+					PodTemplate: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:    "sandbox",
+									Image:   "python:3.12",
+									Command: []string{"python", "-c", "print('hello')"},
+								},
+							},
+						},
+					},
+				},
+			}
+			resp := sandboxToResponse(sb)
+			Expect(resp.PodTemplate.Container.Command).To(Equal([]string{"python", "-c", "print('hello')"}))
+		})
+
+		It("returns nil command when not set on container", func() {
+			sb := &sandboxv1alpha1.Sandbox{
+				Spec: sandboxv1alpha1.SandboxSpec{
+					PodTemplate: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "sandbox",
+									Image: "alpine:latest",
+								},
+							},
+						},
+					},
+				},
+			}
+			resp := sandboxToResponse(sb)
+			Expect(resp.PodTemplate.Container.Command).To(BeNil())
+		})
+	})
+
 	Describe("containerResourcesToSpec", func() {
 		It("returns nil for empty ResourceRequirements", func() {
 			Expect(containerResourcesToSpec(corev1.ResourceRequirements{})).To(BeNil())

--- a/internal/api-gateway/handlers/sandbox_test.go
+++ b/internal/api-gateway/handlers/sandbox_test.go
@@ -103,6 +103,43 @@ var _ = Describe("Sandbox Endpoints", func() {
 			Expect(getContainer).NotTo(HaveKey("env"))
 		})
 
+		It("round-trips command through create and get", func() {
+			reqBody := `{"podTemplate":{"container":{"image":"python:3.12","command":["python","-c","print('hello')"]}}}`
+			resp := testAPI.Post("/sandboxes", strings.NewReader(reqBody))
+			Expect(resp.Code).To(Equal(201))
+
+			var body SandboxResponse
+			Expect(json.NewDecoder(resp.Body).Decode(&body)).To(Succeed())
+			Expect(body.PodTemplate.Container.Command).To(Equal([]string{"python", "-c", "print('hello')"}))
+
+			// Verify via GET read-back
+			Eventually(func() int {
+				return testAPI.Get(fmt.Sprintf("/sandboxes/%s", body.ID)).Code
+			}).Should(Equal(200))
+			getResp := testAPI.Get(fmt.Sprintf("/sandboxes/%s", body.ID))
+			var got SandboxResponse
+			Expect(json.NewDecoder(getResp.Body).Decode(&got)).To(Succeed())
+			Expect(got.PodTemplate.Container.Command).To(Equal([]string{"python", "-c", "print('hello')"}))
+		})
+
+		It("omits command from response when not specified", func() {
+			resp := testAPI.Post("/sandboxes", strings.NewReader(`{"podTemplate":{"container":{"image":"alpine:latest"}}}`))
+			Expect(resp.Code).To(Equal(201))
+
+			var body SandboxResponse
+			Expect(json.NewDecoder(resp.Body).Decode(&body)).To(Succeed())
+			Expect(body.PodTemplate.Container.Command).To(BeNil())
+
+			// Verify via GET read-back
+			Eventually(func() int {
+				return testAPI.Get(fmt.Sprintf("/sandboxes/%s", body.ID)).Code
+			}).Should(Equal(200))
+			getResp := testAPI.Get(fmt.Sprintf("/sandboxes/%s", body.ID))
+			var got SandboxResponse
+			Expect(json.NewDecoder(getResp.Body).Decode(&got)).To(Succeed())
+			Expect(got.PodTemplate.Container.Command).To(BeNil())
+		})
+
 		It("rejects missing podTemplate with 422", func() {
 			resp := testAPI.Post("/sandboxes", strings.NewReader(`{}`))
 			Expect(resp.Code).To(Equal(422))

--- a/internal/api-gateway/handlers/types.go
+++ b/internal/api-gateway/handlers/types.go
@@ -16,6 +16,7 @@ type CreateSandboxInput struct {
 
 type ContainerSpec struct {
 	Image     string            `json:"image" required:"true" doc:"Container image"`
+	Command   []string          `json:"command,omitempty" doc:"Override the container entrypoint. Defaults to sleep infinity if omitted."`
 	Env       map[string]string `json:"env,omitempty" doc:"Environment variables"`
 	Resources *ResourcesSpec    `json:"resources,omitempty" doc:"Resource requests and limits"`
 }
@@ -61,6 +62,7 @@ type DeleteSandboxInput struct {
 
 type ContainerInfo struct {
 	Image     string         `json:"image" doc:"Container image"`
+	Command   []string       `json:"command,omitempty" doc:"Container entrypoint override"`
 	Resources *ResourcesSpec `json:"resources,omitempty" doc:"Resource requests and limits"`
 }
 

--- a/internal/operator/controller/sandbox_controller.go
+++ b/internal/operator/controller/sandbox_controller.go
@@ -220,6 +220,13 @@ func (r *SandboxReconciler) CreateSandboxPod(ctx context.Context, sandbox *sandb
 		sandboxPod.Spec.PriorityClassName = r.PriorityClassName
 	}
 
+	// Default to sleep infinity so sandbox containers stay alive
+	for i := range sandboxPod.Spec.Containers {
+		if len(sandboxPod.Spec.Containers[i].Command) == 0 {
+			sandboxPod.Spec.Containers[i].Command = []string{"sleep", "infinity"}
+		}
+	}
+
 	configureDNS(sandboxPod, sandbox.Spec.Network)
 
 	markContainers(sandboxPod)

--- a/internal/operator/controller/sandbox_controller_pod_test.go
+++ b/internal/operator/controller/sandbox_controller_pod_test.go
@@ -179,6 +179,56 @@ var _ = Describe("Sandbox Controller", func() {
 			Expect(pod.Annotations).NotTo(HaveKey("dev.gvisor.flag.overlay2"))
 		})
 
+		It("should inject sleep infinity when no command is specified", func() {
+			sandboxName := "sandbox-default-cmd"
+
+			createSandbox(ctx, sandboxName, func(s *sandboxv1alpha1.Sandbox) {
+				s.Spec.PodTemplate.Spec.Containers = []corev1.Container{
+					{
+						Name:  "sandbox",
+						Image: "ubuntu:22.04",
+					},
+				}
+			})
+			defer deleteSandbox(ctx, sandboxName)
+
+			podName := sandboxName + "-pod"
+			defer deletePod(ctx, podName)
+
+			_, err := doReconcile(ctx, reconciler, sandboxName)
+			Expect(err).NotTo(HaveOccurred())
+
+			pod := getPod(ctx, podName)
+			Expect(pod).NotTo(BeNil())
+			Expect(pod.Spec.Containers).To(HaveLen(1))
+			Expect(pod.Spec.Containers[0].Command).To(Equal([]string{"sleep", "infinity"}))
+		})
+
+		It("should preserve explicit command and not inject sleep infinity", func() {
+			sandboxName := "sandbox-explicit-cmd"
+
+			createSandbox(ctx, sandboxName, func(s *sandboxv1alpha1.Sandbox) {
+				s.Spec.PodTemplate.Spec.Containers = []corev1.Container{
+					{
+						Name:    "sandbox",
+						Image:   "python:3.11",
+						Command: []string{"python", "-c", "import time; time.sleep(3600)"},
+					},
+				}
+			})
+			defer deleteSandbox(ctx, sandboxName)
+
+			podName := sandboxName + "-pod"
+			defer deletePod(ctx, podName)
+
+			_, err := doReconcile(ctx, reconciler, sandboxName)
+			Expect(err).NotTo(HaveOccurred())
+
+			pod := getPod(ctx, podName)
+			Expect(pod).NotTo(BeNil())
+			Expect(pod.Spec.Containers[0].Command).To(Equal([]string{"python", "-c", "import time; time.sleep(3600)"}))
+		})
+
 		It("should preserve sandbox init containers when injecting sidecar", func() {
 			sandboxName := "sandbox-preserve-init"
 


### PR DESCRIPTION
…earing down upon startup do to a command/entrypoint finishing immediately in the used OCI image (e.g. ubuntu:22.04 stops execution immediately)