### PR TITLE
Fix crash container PID discovery with retry and distinct errors

### DIFF
--- a/internal/sandbox-sidecar/handlers/command.go
+++ b/internal/sandbox-sidecar/handlers/command.go
@@ -109,10 +109,13 @@ func NewCommandHandlers(logger *slog.Logger, procFS proc.ProcFS, pidResolver *PI
 	}
 }
 
-func (h *CommandHandlers) PostCommand(_ context.Context, input *CreateCommandInput) (*CreateCommandOutput, error) {
-	pid, err := h.pidResolver.FindCachedContainerPID(input.Container)
+func (h *CommandHandlers) PostCommand(ctx context.Context, input *CreateCommandInput) (*CreateCommandOutput, error) {
+	pid, err := h.pidResolver.FindCachedContainerPID(ctx, input.Container)
 	if err != nil {
 		h.logger.Warn("failed to determine container pid", "error", err, "container", input.Container)
+		if errors.Is(err, ErrContainerNotRunning) {
+			return nil, huma.Error503ServiceUnavailable("container is not running (crashed or restarting)")
+		}
 		return nil, huma.Error400BadRequest("failed to determine container pid")
 	}
 

--- a/internal/sandbox-sidecar/handlers/filesystem.go
+++ b/internal/sandbox-sidecar/handlers/filesystem.go
@@ -77,17 +77,16 @@ func mkdirAllChown(path string, uid, gid int) error {
 	return os.Chown(path, uid, gid)
 }
 
-func (h *FilesystemHandlers) PostFilesystem(_ context.Context, input *FilesystemWriteInput) (*FilesystemWriteOutput, error) {
+func (h *FilesystemHandlers) PostFilesystem(ctx context.Context, input *FilesystemWriteInput) (*FilesystemWriteOutput, error) {
 	path := input.Path
 	container := input.Container
 
-	pid, err := h.pidResolver.FindCachedContainerPID(container)
+	pid, err := h.pidResolver.FindCachedContainerPID(ctx, container)
 	if err != nil {
-		if container == "" {
-			h.logger.Warn("failed to determine container pid", "error", err)
-			return nil, huma.Error400BadRequest("failed to determine container pid")
-		}
 		h.logger.Warn("failed to determine container pid", "error", err, "container", container)
+		if errors.Is(err, ErrContainerNotRunning) {
+			return nil, huma.Error503ServiceUnavailable("container is not running (crashed or restarting)")
+		}
 		return nil, huma.Error400BadRequest("failed to determine container pid")
 	}
 
@@ -145,17 +144,16 @@ func (h *FilesystemHandlers) PostFilesystem(_ context.Context, input *Filesystem
 	}, nil
 }
 
-func (h *FilesystemHandlers) GetFilesystem(_ context.Context, input *FilesystemReadInput) (*huma.StreamResponse, error) {
+func (h *FilesystemHandlers) GetFilesystem(ctx context.Context, input *FilesystemReadInput) (*huma.StreamResponse, error) {
 	path := input.Path
 	container := input.Container
 
-	pid, err := h.pidResolver.FindCachedContainerPID(container)
+	pid, err := h.pidResolver.FindCachedContainerPID(ctx, container)
 	if err != nil {
-		if container == "" {
-			h.logger.Warn("failed to determine container pid", "error", err)
-			return nil, huma.Error400BadRequest("failed to determine container pid")
-		}
 		h.logger.Warn("failed to determine container pid", "error", err, "container", container)
+		if errors.Is(err, ErrContainerNotRunning) {
+			return nil, huma.Error503ServiceUnavailable("container is not running (crashed or restarting)")
+		}
 		return nil, huma.Error400BadRequest("failed to determine container pid")
 	}
 

--- a/internal/sandbox-sidecar/handlers/filesystem_errors_test.go
+++ b/internal/sandbox-sidecar/handlers/filesystem_errors_test.go
@@ -23,6 +23,10 @@ func (m *errorMockProcFS) FindMarkedPID(containerName string) (int, error) {
 	return 0, m.findPIDError
 }
 
+func (m *errorMockProcFS) GetContainerName(pid int) (string, bool) {
+	return "", false
+}
+
 func (m *errorMockProcFS) GetCwd(pid int) (string, error) {
 	return "/workspace", nil
 }

--- a/internal/sandbox-sidecar/handlers/pid_resolver.go
+++ b/internal/sandbox-sidecar/handlers/pid_resolver.go
@@ -1,45 +1,103 @@
 package handlers
 
 import (
+	"context"
+	"errors"
 	"sync"
+	"time"
 
 	"github.com/isola-ai/isola-sb/internal/sandbox-sidecar/proc"
 )
 
+// ErrContainerNotRunning indicates the container was previously running but can no longer be found.
+// This typically happens when a container crashes and hasn't restarted yet (e.g. CrashLoopBackOff).
+var ErrContainerNotRunning = errors.New("container not running")
+
+const (
+	defaultMaxRetries = 10
+	defaultRetryDelay = 200 * time.Millisecond
+)
+
 // PIDResolver caches container PID lookups to avoid repeated /proc scans.
+// When a cached PID goes stale (container crashed), it retries discovery
+// to bridge the gap during container restarts.
 // Shared across handler types so the cache is unified.
 type PIDResolver struct {
 	procFS     proc.ProcFS
 	pidMu      sync.RWMutex
 	cachedPIDs map[string]int
+
+	// Retry parameters for crash recovery. Configurable for testing.
+	maxRetries int
+	retryDelay time.Duration
 }
 
 func NewPIDResolver(procFS proc.ProcFS) *PIDResolver {
 	return &PIDResolver{
 		procFS:     procFS,
 		cachedPIDs: make(map[string]int),
+		maxRetries: defaultMaxRetries,
+		retryDelay: defaultRetryDelay,
 	}
 }
 
-func (r *PIDResolver) FindCachedContainerPID(containerName string) (int, error) {
+// FindCachedContainerPID resolves a container name to its PID, using a cache for repeated lookups.
+//
+// When a previously-cached PID goes stale (container crashed) and a fresh /proc scan also fails,
+// it retries with short delays to bridge the window during container restarts. If the container
+// was never seen before, it fails immediately without retries.
+//
+// Returns ErrContainerNotRunning when a previously-known container can't be found after retries
+// (distinguishing crashed containers from containers that never existed).
+func (r *PIDResolver) FindCachedContainerPID(ctx context.Context, containerName string) (int, error) {
 	r.pidMu.RLock()
-	pid, ok := r.cachedPIDs[containerName]
+	cachedPID, wasCached := r.cachedPIDs[containerName]
 	r.pidMu.RUnlock()
 
-	if ok {
-		if name, found := proc.GetContainerName(pid); found && (containerName == "" || name == containerName) {
-			return pid, nil
+	if wasCached {
+		if name, found := r.procFS.GetContainerName(cachedPID); found && (containerName == "" || name == containerName) {
+			return cachedPID, nil
 		}
 	}
 
+	// Fresh scan
 	newPID, err := r.procFS.FindMarkedPID(containerName)
-	if err != nil {
-		return 0, err
+	if err == nil {
+		r.pidMu.Lock()
+		r.cachedPIDs[containerName] = newPID
+		r.pidMu.Unlock()
+		return newPID, nil
 	}
 
-	r.pidMu.Lock()
-	r.cachedPIDs[containerName] = newPID
-	r.pidMu.Unlock()
+	// If we had a cached PID but the container is gone, it likely crashed and may
+	// be restarting. Retry a few times to bridge the restart window.
+	if wasCached && errors.Is(err, proc.ErrContainerNotFound) {
+		return r.retryFindPID(ctx, containerName)
+	}
 
-	return newPID, nil
+	return 0, err
+}
+
+// retryFindPID retries /proc scanning with delays for crash recovery.
+func (r *PIDResolver) retryFindPID(ctx context.Context, containerName string) (int, error) {
+	for range r.maxRetries {
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		case <-time.After(r.retryDelay):
+		}
+
+		newPID, err := r.procFS.FindMarkedPID(containerName)
+		if err == nil {
+			r.pidMu.Lock()
+			r.cachedPIDs[containerName] = newPID
+			r.pidMu.Unlock()
+			return newPID, nil
+		}
+		if !errors.Is(err, proc.ErrContainerNotFound) {
+			return 0, err
+		}
+	}
+
+	return 0, ErrContainerNotRunning
 }

--- a/internal/sandbox-sidecar/handlers/pid_resolver_test.go
+++ b/internal/sandbox-sidecar/handlers/pid_resolver_test.go
@@ -1,0 +1,255 @@
+package handlers
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/isola-ai/isola-sb/internal/sandbox-sidecar/proc"
+)
+
+// dynamicProcMock simulates container processes that can crash and restart with new PIDs.
+type dynamicProcMock struct {
+	mu       sync.Mutex
+	livePIDs map[int]string // PID -> container name for live processes
+
+	rootDir string
+	cwd     string
+	uid     int
+	gid     int
+
+	// findMarkedCalls tracks the number of FindMarkedPID invocations.
+	findMarkedCalls atomic.Int32
+}
+
+func newDynamicProcMock() *dynamicProcMock {
+	return &dynamicProcMock{
+		livePIDs: make(map[int]string),
+		rootDir:  "/tmp/mock-root",
+		cwd:      "/workspace",
+	}
+}
+
+func (m *dynamicProcMock) addPID(pid int, containerName string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.livePIDs[pid] = containerName
+}
+
+func (m *dynamicProcMock) removePID(pid int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.livePIDs, pid)
+}
+
+func (m *dynamicProcMock) FindMarkedPID(containerName string) (int, error) {
+	m.findMarkedCalls.Add(1)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if containerName != "" {
+		for pid, name := range m.livePIDs {
+			if name == containerName {
+				return pid, nil
+			}
+		}
+		return 0, proc.ErrContainerNotFound
+	}
+
+	// No container name: need exactly one
+	if len(m.livePIDs) == 1 {
+		for pid := range m.livePIDs {
+			return pid, nil
+		}
+	}
+	return 0, proc.ErrContainerNotFound
+}
+
+func (m *dynamicProcMock) GetContainerName(pid int) (string, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	name, ok := m.livePIDs[pid]
+	return name, ok
+}
+
+func (m *dynamicProcMock) GetCwd(pid int) (string, error) { return m.cwd, nil }
+func (m *dynamicProcMock) GetRoot(pid int) string          { return m.rootDir }
+func (m *dynamicProcMock) GetUIDGID(pid int) (int, int, error) {
+	return m.uid, m.gid, nil
+}
+func (m *dynamicProcMock) GetEnviron(pid int) ([]string, error) {
+	return []string{"PATH=/usr/bin:/bin"}, nil
+}
+
+var _ = Describe("PIDResolver", func() {
+	var (
+		mock     *dynamicProcMock
+		resolver *PIDResolver
+	)
+
+	BeforeEach(func() {
+		mock = newDynamicProcMock()
+		resolver = NewPIDResolver(mock)
+		resolver.retryDelay = 5 * time.Millisecond // fast retries for tests
+	})
+
+	Describe("FindCachedContainerPID", func() {
+		It("returns PID from fresh scan on first call", func() {
+			mock.addPID(100, "main")
+
+			pid, err := resolver.FindCachedContainerPID(context.Background(), "main")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pid).To(Equal(100))
+		})
+
+		It("returns cached PID when still valid", func() {
+			mock.addPID(100, "main")
+
+			// First call populates cache
+			pid, err := resolver.FindCachedContainerPID(context.Background(), "main")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pid).To(Equal(100))
+
+			callsBefore := mock.findMarkedCalls.Load()
+
+			// Second call should use cache (validated via GetContainerName)
+			pid, err = resolver.FindCachedContainerPID(context.Background(), "main")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pid).To(Equal(100))
+
+			// FindMarkedPID should not have been called again
+			Expect(mock.findMarkedCalls.Load()).To(Equal(callsBefore))
+		})
+
+		It("detects stale PID and finds new one after container restart", func() {
+			mock.addPID(100, "main")
+
+			// First call caches PID 100
+			pid, err := resolver.FindCachedContainerPID(context.Background(), "main")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pid).To(Equal(100))
+
+			// Simulate restart: PID 100 gone, PID 200 appears
+			mock.removePID(100)
+			mock.addPID(200, "main")
+
+			// Should detect stale cache, scan again, find PID 200
+			pid, err = resolver.FindCachedContainerPID(context.Background(), "main")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pid).To(Equal(200))
+		})
+
+		It("retries when container is temporarily down after crash", func() {
+			mock.addPID(100, "main")
+
+			// Cache PID 100
+			pid, err := resolver.FindCachedContainerPID(context.Background(), "main")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pid).To(Equal(100))
+
+			// Container crashes
+			mock.removePID(100)
+
+			// Container restarts with new PID after a brief delay
+			go func() {
+				time.Sleep(30 * time.Millisecond)
+				mock.addPID(200, "main")
+			}()
+
+			// Should retry and eventually find PID 200
+			pid, err = resolver.FindCachedContainerPID(context.Background(), "main")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pid).To(Equal(200))
+		})
+
+		It("returns ErrContainerNotRunning when container stays down after retries", func() {
+			mock.addPID(100, "main")
+			resolver.maxRetries = 3
+
+			// Cache PID 100
+			pid, err := resolver.FindCachedContainerPID(context.Background(), "main")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pid).To(Equal(100))
+
+			// Container crashes and doesn't come back
+			mock.removePID(100)
+
+			_, err = resolver.FindCachedContainerPID(context.Background(), "main")
+			Expect(err).To(MatchError(ErrContainerNotRunning))
+		})
+
+		It("returns ErrContainerNotFound immediately when container was never seen", func() {
+			// No PID in cache, no PID in proc — should fail immediately without retries
+			callsBefore := mock.findMarkedCalls.Load()
+
+			_, err := resolver.FindCachedContainerPID(context.Background(), "nonexistent")
+			Expect(err).To(MatchError(proc.ErrContainerNotFound))
+
+			// Should have called FindMarkedPID exactly once (no retries)
+			Expect(mock.findMarkedCalls.Load()).To(Equal(callsBefore + 1))
+		})
+
+		It("respects context cancellation during retry", func() {
+			mock.addPID(100, "main")
+			resolver.maxRetries = 100 // many retries so it doesn't exhaust before cancel
+
+			// Cache PID 100
+			_, err := resolver.FindCachedContainerPID(context.Background(), "main")
+			Expect(err).NotTo(HaveOccurred())
+
+			// Container crashes
+			mock.removePID(100)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			// Cancel quickly
+			go func() {
+				time.Sleep(20 * time.Millisecond)
+				cancel()
+			}()
+
+			_, err = resolver.FindCachedContainerPID(ctx, "main")
+			Expect(err).To(MatchError(context.Canceled))
+		})
+
+		It("works with empty container name (single container)", func() {
+			mock.addPID(100, "main")
+
+			pid, err := resolver.FindCachedContainerPID(context.Background(), "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pid).To(Equal(100))
+
+			// Restart with new PID
+			mock.removePID(100)
+			mock.addPID(200, "main")
+
+			pid, err = resolver.FindCachedContainerPID(context.Background(), "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pid).To(Equal(200))
+		})
+
+		It("retries with empty container name after crash", func() {
+			mock.addPID(100, "main")
+
+			// Cache
+			_, err := resolver.FindCachedContainerPID(context.Background(), "")
+			Expect(err).NotTo(HaveOccurred())
+
+			// Crash
+			mock.removePID(100)
+
+			// Restart after delay
+			go func() {
+				time.Sleep(30 * time.Millisecond)
+				mock.addPID(200, "main")
+			}()
+
+			pid, err := resolver.FindCachedContainerPID(context.Background(), "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pid).To(Equal(200))
+		})
+	})
+})

--- a/internal/sandbox-sidecar/handlers/suite_test.go
+++ b/internal/sandbox-sidecar/handlers/suite_test.go
@@ -58,6 +58,10 @@ func (m *MockProcFS) FindMarkedPID(containerName string) (int, error) {
 	return 1, nil
 }
 
+func (m *MockProcFS) GetContainerName(pid int) (string, bool) {
+	return "", false
+}
+
 func (m *MockProcFS) GetCwd(pid int) (string, error) {
 	return m.cwd, nil
 }

--- a/internal/sandbox-sidecar/proc/procfs.go
+++ b/internal/sandbox-sidecar/proc/procfs.go
@@ -24,6 +24,9 @@ type ProcFS interface {
 	// If containerName is empty and there is only one container, it will return the PID of that container.
 	// Otherwise, return an error.
 	FindMarkedPID(containerName string) (int, error)
+	// GetContainerName returns the ISOLA_CONTAINER_NAME value if present in the process environment.
+	// Used by PIDResolver to validate cached PIDs are still alive.
+	GetContainerName(pid int) (string, bool)
 	// GetCwd reads the /proc/<pid>/cwd symlink to get the process working directory.
 	GetCwd(pid int) (string, error)
 	// GetRoot returns the path to /proc/<pid>/root for the given PID.
@@ -87,6 +90,11 @@ func (r *RealProcFS) FindMarkedPID(containerName string) (int, error) {
 
 	// if no container name is specified and only one container is found, return that container's PID
 	return foundPID, nil
+}
+
+// GetContainerName on RealProcFS delegates to the package-level GetContainerName function.
+func (r *RealProcFS) GetContainerName(pid int) (string, bool) {
+	return GetContainerName(pid)
 }
 
 // GetContainerName returns the ISOLA_CONTAINER_NAME value if present in the process environment.


### PR DESCRIPTION
When a container crashes and restarts, its PID changes. Previously, the
sidecar returned a generic 400 error during the restart window. This
change adds:

- Retry logic in PIDResolver: when a previously-cached PID goes stale
  and /proc scanning fails, retry with short delays (10x200ms = 2s max)
  to bridge the container restart window
- Distinct error type (ErrContainerNotRunning): distinguishes crashed
  containers (503 Service Unavailable) from containers that never
  existed (400 Bad Request), giving callers actionable retry signals
- GetContainerName on ProcFS interface: makes PID cache validation
  testable through mocks instead of calling the package-level function
  directly
- Comprehensive PID resolver tests covering: cache hit, PID change after
  restart, temporary unavailability with retry success, permanent
  unavailability, never-existed containers, and context cancellation

https://claude.ai/code/session_01JLQNK4phm8xhaTpR6FrBWr