### PR TITLE
Add filesystem operations: list, stat, mkdir, rename, remove

### DIFF
--- a/internal/api-gateway/filesystem/filesystem.go
+++ b/internal/api-gateway/filesystem/filesystem.go
@@ -57,6 +57,73 @@ type FilesystemReadInput struct {
 	Container string `query:"container,omitempty" doc:"Container name. Defaults to the only container if there is one, otherwise it's required."`
 }
 
+type FileInfo struct {
+	Name  string `json:"name" example:"file.txt" doc:"Base name of the file or directory"`
+	Path  string `json:"path" example:"/workspace/file.txt" doc:"Absolute path"`
+	IsDir bool   `json:"isDir" doc:"True if the entry is a directory"`
+	Size  int64  `json:"size" example:"1024" doc:"Size in bytes (0 for directories)"`
+	Mode  string `json:"mode" example:"-rw-r--r--" doc:"Unix file mode string"`
+}
+
+type FilesystemListInput struct {
+	ID        string `path:"id" doc:"Sandbox identifier"`
+	Path      string `query:"path" required:"true" minLength:"1" doc:"Directory path (absolute or relative to container cwd)"`
+	Container string `query:"container,omitempty" doc:"Container name. Defaults to the only container if there is one, otherwise it's required."`
+}
+
+type FilesystemListResponse struct {
+	Entries []FileInfo `json:"entries" doc:"List of directory entries"`
+}
+
+type FilesystemListOutput struct {
+	Body FilesystemListResponse
+}
+
+type FilesystemStatInput struct {
+	ID        string `path:"id" doc:"Sandbox identifier"`
+	Path      string `query:"path" required:"true" minLength:"1" doc:"Path to stat (absolute or relative to container cwd)"`
+	Container string `query:"container,omitempty" doc:"Container name. Defaults to the only container if there is one, otherwise it's required."`
+}
+
+type FilesystemStatOutput struct {
+	Body FileInfo
+}
+
+type FilesystemMkdirInput struct {
+	ID        string `path:"id" doc:"Sandbox identifier"`
+	Path      string `query:"path" required:"true" minLength:"1" doc:"Directory path to create (absolute or relative to container cwd)"`
+	Container string `query:"container,omitempty" doc:"Container name. Defaults to the only container if there is one, otherwise it's required."`
+}
+
+type FilesystemMkdirResponse struct {
+	AbsolutePath string `json:"absolutePath" example:"/workspace/new-dir" doc:"Absolute path of created directory"`
+}
+
+type FilesystemMkdirOutput struct {
+	Body FilesystemMkdirResponse
+}
+
+type FilesystemRenameInput struct {
+	ID        string `path:"id" doc:"Sandbox identifier"`
+	Path      string `query:"path" required:"true" minLength:"1" doc:"Source path (absolute or relative to container cwd)"`
+	NewPath   string `query:"newPath" required:"true" minLength:"1" doc:"Destination path (absolute or relative to container cwd)"`
+	Container string `query:"container,omitempty" doc:"Container name. Defaults to the only container if there is one, otherwise it's required."`
+}
+
+type FilesystemRenameResponse struct {
+	AbsolutePath string `json:"absolutePath" example:"/workspace/new-name.txt" doc:"New absolute path after rename"`
+}
+
+type FilesystemRenameOutput struct {
+	Body FilesystemRenameResponse
+}
+
+type FilesystemRemoveInput struct {
+	ID        string `path:"id" doc:"Sandbox identifier"`
+	Path      string `query:"path" required:"true" minLength:"1" doc:"Path to remove (absolute or relative to container cwd)"`
+	Container string `query:"container,omitempty" doc:"Container name. Defaults to the only container if there is one, otherwise it's required."`
+}
+
 // --- Handlers ---
 
 type Handlers struct {
@@ -184,6 +251,172 @@ func (h *Handlers) GetFilesystem(ctx context.Context, input *FilesystemReadInput
 	}, nil
 }
 
+func (h *Handlers) sidecarURL(podIP, sidecarPath string, params url.Values) string {
+	return fmt.Sprintf("http://%s:%d%s?%s", podIP, h.sidecarPort, sidecarPath, params.Encode())
+}
+
+func filesystemParams(path, container string) url.Values {
+	params := url.Values{}
+	params.Set("path", path)
+	if container != "" {
+		params.Set("container", container)
+	}
+	return params
+}
+
+// proxyJSONGet proxies a GET request to the sidecar and decodes a JSON response.
+func (h *Handlers) proxyJSONGet(ctx context.Context, sandboxID, sidecarURL string, dest any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, sidecarURL, nil)
+	if err != nil {
+		h.logger.Error("failed to build sidecar request", "error", err)
+		return huma.Error500InternalServerError("failed to build sidecar request")
+	}
+
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		h.logger.Error("sidecar request failed", "error", err, "id", sandboxID)
+		return huma.Error502BadGateway("failed to reach sidecar")
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 {
+		return apigateway.HandleSidecarError(resp, sandboxID, h.logger)
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(dest); err != nil {
+		h.logger.Error("failed to decode sidecar response", "error", err, "id", sandboxID, "status", resp.StatusCode)
+		return huma.Error502BadGateway("invalid sidecar response")
+	}
+	return nil
+}
+
+// proxySimple proxies a request with no body to the sidecar and decodes an optional JSON response.
+func (h *Handlers) proxySimple(ctx context.Context, method, sandboxID, sidecarURL string, dest any) error {
+	req, err := http.NewRequestWithContext(ctx, method, sidecarURL, nil)
+	if err != nil {
+		h.logger.Error("failed to build sidecar request", "error", err)
+		return huma.Error500InternalServerError("failed to build sidecar request")
+	}
+
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		h.logger.Error("sidecar request failed", "error", err, "id", sandboxID)
+		return huma.Error502BadGateway("failed to reach sidecar")
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 {
+		return apigateway.HandleSidecarError(resp, sandboxID, h.logger)
+	}
+
+	if dest != nil {
+		if err := json.NewDecoder(resp.Body).Decode(dest); err != nil {
+			h.logger.Error("failed to decode sidecar response", "error", err, "id", sandboxID, "status", resp.StatusCode)
+			return huma.Error502BadGateway("invalid sidecar response")
+		}
+	}
+	return nil
+}
+
+func (h *Handlers) ListFilesystem(ctx context.Context, input *FilesystemListInput) (*FilesystemListOutput, error) {
+	sb, err := apigateway.GetReadySandbox(ctx, h.k8sClient, h.sandboxNamespace, input.ID, h.logger)
+	if err != nil {
+		return nil, err
+	}
+
+	u := h.sidecarURL(sb.Status.PodIP, "/filesystem/list", filesystemParams(input.Path, input.Container))
+
+	_ = sidecarapi.FilesystemListResponse(FilesystemListResponse{}) // assert field compatibility
+	var sidecarResp sidecarapi.FilesystemListResponse
+	if err := h.proxyJSONGet(ctx, input.ID, u, &sidecarResp); err != nil {
+		return nil, err
+	}
+
+	entries := make([]FileInfo, len(sidecarResp.Entries))
+	for i, e := range sidecarResp.Entries {
+		_ = sidecarapi.FileInfo(FileInfo{}) // assert field compatibility
+		entries[i] = FileInfo(e)
+	}
+
+	return &FilesystemListOutput{
+		Body: FilesystemListResponse{Entries: entries},
+	}, nil
+}
+
+func (h *Handlers) StatFilesystem(ctx context.Context, input *FilesystemStatInput) (*FilesystemStatOutput, error) {
+	sb, err := apigateway.GetReadySandbox(ctx, h.k8sClient, h.sandboxNamespace, input.ID, h.logger)
+	if err != nil {
+		return nil, err
+	}
+
+	u := h.sidecarURL(sb.Status.PodIP, "/filesystem/stat", filesystemParams(input.Path, input.Container))
+
+	_ = sidecarapi.FileInfo(FileInfo{}) // assert field compatibility
+	var sidecarResp sidecarapi.FileInfo
+	if err := h.proxyJSONGet(ctx, input.ID, u, &sidecarResp); err != nil {
+		return nil, err
+	}
+
+	return &FilesystemStatOutput{
+		Body: FileInfo(sidecarResp),
+	}, nil
+}
+
+func (h *Handlers) MkdirFilesystem(ctx context.Context, input *FilesystemMkdirInput) (*FilesystemMkdirOutput, error) {
+	sb, err := apigateway.GetReadySandbox(ctx, h.k8sClient, h.sandboxNamespace, input.ID, h.logger)
+	if err != nil {
+		return nil, err
+	}
+
+	u := h.sidecarURL(sb.Status.PodIP, "/filesystem/mkdir", filesystemParams(input.Path, input.Container))
+
+	_ = sidecarapi.FilesystemMkdirResponse(FilesystemMkdirResponse{}) // assert field compatibility
+	var sidecarResp sidecarapi.FilesystemMkdirResponse
+	if err := h.proxySimple(ctx, http.MethodPost, input.ID, u, &sidecarResp); err != nil {
+		return nil, err
+	}
+
+	return &FilesystemMkdirOutput{
+		Body: FilesystemMkdirResponse{AbsolutePath: sidecarResp.AbsolutePath},
+	}, nil
+}
+
+func (h *Handlers) RenameFilesystem(ctx context.Context, input *FilesystemRenameInput) (*FilesystemRenameOutput, error) {
+	sb, err := apigateway.GetReadySandbox(ctx, h.k8sClient, h.sandboxNamespace, input.ID, h.logger)
+	if err != nil {
+		return nil, err
+	}
+
+	params := filesystemParams(input.Path, input.Container)
+	params.Set("newPath", input.NewPath)
+	u := h.sidecarURL(sb.Status.PodIP, "/filesystem/rename", params)
+
+	_ = sidecarapi.FilesystemRenameResponse(FilesystemRenameResponse{}) // assert field compatibility
+	var sidecarResp sidecarapi.FilesystemRenameResponse
+	if err := h.proxySimple(ctx, http.MethodPost, input.ID, u, &sidecarResp); err != nil {
+		return nil, err
+	}
+
+	return &FilesystemRenameOutput{
+		Body: FilesystemRenameResponse{AbsolutePath: sidecarResp.AbsolutePath},
+	}, nil
+}
+
+func (h *Handlers) RemoveFilesystem(ctx context.Context, input *FilesystemRemoveInput) (*struct{}, error) {
+	sb, err := apigateway.GetReadySandbox(ctx, h.k8sClient, h.sandboxNamespace, input.ID, h.logger)
+	if err != nil {
+		return nil, err
+	}
+
+	u := h.sidecarURL(sb.Status.PodIP, "/filesystem", filesystemParams(input.Path, input.Container))
+
+	if err := h.proxySimple(ctx, http.MethodDelete, input.ID, u, nil); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
 func Register(api huma.API, h *Handlers) {
 	huma.Register(api, huma.Operation{
 		OperationID: "writeSandboxFilesystem",
@@ -225,4 +458,56 @@ func Register(api huma.API, h *Handlers) {
 		},
 		Errors: []int{http.StatusBadRequest, http.StatusNotFound, http.StatusConflict, http.StatusBadGateway},
 	}, h.GetFilesystem)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "listSandboxFilesystem",
+		Method:      http.MethodGet,
+		Path:        "/sandboxes/{id}/filesystem/list",
+		Summary:     "List directory contents",
+		Description: "Lists files and directories at the specified path in the sandbox container",
+		Tags:        []string{"sandboxes", "filesystem"},
+		Errors:      []int{http.StatusBadRequest, http.StatusNotFound, http.StatusConflict, http.StatusBadGateway},
+	}, h.ListFilesystem)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "statSandboxFilesystem",
+		Method:      http.MethodGet,
+		Path:        "/sandboxes/{id}/filesystem/stat",
+		Summary:     "Get file or directory info",
+		Description: "Returns metadata about a file or directory in the sandbox container",
+		Tags:        []string{"sandboxes", "filesystem"},
+		Errors:      []int{http.StatusBadRequest, http.StatusNotFound, http.StatusConflict, http.StatusBadGateway},
+	}, h.StatFilesystem)
+
+	huma.Register(api, huma.Operation{
+		OperationID:   "mkdirSandboxFilesystem",
+		Method:        http.MethodPost,
+		Path:          "/sandboxes/{id}/filesystem/mkdir",
+		Summary:       "Create a directory",
+		Description:   "Creates a directory and all parent directories at the specified path in the sandbox container",
+		Tags:          []string{"sandboxes", "filesystem"},
+		DefaultStatus: http.StatusCreated,
+		Errors:        []int{http.StatusBadRequest, http.StatusNotFound, http.StatusConflict, http.StatusBadGateway},
+	}, h.MkdirFilesystem)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "renameSandboxFilesystem",
+		Method:      http.MethodPost,
+		Path:        "/sandboxes/{id}/filesystem/rename",
+		Summary:     "Rename or move a file or directory",
+		Description: "Renames or moves a file or directory within the sandbox container",
+		Tags:        []string{"sandboxes", "filesystem"},
+		Errors:      []int{http.StatusBadRequest, http.StatusNotFound, http.StatusConflict, http.StatusBadGateway},
+	}, h.RenameFilesystem)
+
+	huma.Register(api, huma.Operation{
+		OperationID:   "removeSandboxFilesystem",
+		Method:        http.MethodDelete,
+		Path:          "/sandboxes/{id}/filesystem",
+		Summary:       "Remove a file or directory",
+		Description:   "Removes a file or directory (recursively) from the sandbox container",
+		Tags:          []string{"sandboxes", "filesystem"},
+		DefaultStatus: http.StatusNoContent,
+		Errors:        []int{http.StatusBadRequest, http.StatusNotFound, http.StatusConflict, http.StatusBadGateway},
+	}, h.RemoveFilesystem)
 }

--- a/internal/api-gateway/filesystem/filesystem.go
+++ b/internal/api-gateway/filesystem/filesystem.go
@@ -326,7 +326,7 @@ func (h *Handlers) ListFilesystem(ctx context.Context, input *FilesystemListInpu
 
 	u := h.sidecarURL(sb.Status.PodIP, "/filesystem/list", filesystemParams(input.Path, input.Container))
 
-	_ = sidecarapi.FilesystemListResponse(FilesystemListResponse{}) // assert field compatibility
+	_ = sidecarapi.FileInfo(FileInfo{}) // assert field compatibility
 	var sidecarResp sidecarapi.FilesystemListResponse
 	if err := h.proxyJSONGet(ctx, input.ID, u, &sidecarResp); err != nil {
 		return nil, err
@@ -334,7 +334,6 @@ func (h *Handlers) ListFilesystem(ctx context.Context, input *FilesystemListInpu
 
 	entries := make([]FileInfo, len(sidecarResp.Entries))
 	for i, e := range sidecarResp.Entries {
-		_ = sidecarapi.FileInfo(FileInfo{}) // assert field compatibility
 		entries[i] = FileInfo(e)
 	}
 

--- a/internal/api-gateway/filesystem/filesystem_test.go
+++ b/internal/api-gateway/filesystem/filesystem_test.go
@@ -452,4 +452,169 @@ var _ = Describe("Filesystem Proxy", func() {
 			Expect(resp.Code).To(Equal(http.StatusBadGateway))
 		})
 	})
+
+	Describe("GET /sandboxes/{id}/filesystem/list", func() {
+		It("proxies list request and returns entries", func() {
+			var capturedPath string
+			mockSidecar := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedPath = r.URL.Query().Get("path")
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(sidecarapi.FilesystemListResponse{
+					Entries: []sidecarapi.FileInfo{
+						{Name: "a.txt", Path: "/workspace/a.txt", IsDir: false, Size: 10, Mode: "-rw-r--r--"},
+						{Name: "subdir", Path: "/workspace/subdir", IsDir: true, Size: 0, Mode: "drwxr-xr-x"},
+					},
+				})
+			}))
+			defer mockSidecar.Close()
+
+			port := mockSidecar.Listener.Addr().(*net.TCPAddr).Port
+			api := newFilesystemTestAPI(&http.Client{}, port)
+			sbName := createRunningSandboxCR()
+
+			resp := api.Get(fmt.Sprintf("/sandboxes/%s/filesystem/list?path=/workspace", sbName))
+
+			Expect(resp.Code).To(Equal(http.StatusOK))
+			Expect(capturedPath).To(Equal("/workspace"))
+
+			var body FilesystemListResponse
+			Expect(json.NewDecoder(resp.Body).Decode(&body)).To(Succeed())
+			Expect(body.Entries).To(HaveLen(2))
+			Expect(body.Entries[0].Name).To(Equal("a.txt"))
+			Expect(body.Entries[1].IsDir).To(BeTrue())
+		})
+
+		It("returns 404 for nonexistent sandbox", func() {
+			api := newFilesystemTestAPI(&http.Client{}, 0)
+			resp := api.Get("/sandboxes/nonexistent/filesystem/list?path=/tmp")
+			Expect(resp.Code).To(Equal(http.StatusNotFound))
+		})
+	})
+
+	Describe("GET /sandboxes/{id}/filesystem/stat", func() {
+		It("proxies stat request and returns file info", func() {
+			mockSidecar := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(sidecarapi.FileInfo{
+					Name: "test.txt", Path: "/tmp/test.txt", IsDir: false, Size: 42, Mode: "-rw-r--r--",
+				})
+			}))
+			defer mockSidecar.Close()
+
+			port := mockSidecar.Listener.Addr().(*net.TCPAddr).Port
+			api := newFilesystemTestAPI(&http.Client{}, port)
+			sbName := createRunningSandboxCR()
+
+			resp := api.Get(fmt.Sprintf("/sandboxes/%s/filesystem/stat?path=/tmp/test.txt", sbName))
+
+			Expect(resp.Code).To(Equal(http.StatusOK))
+			var body FileInfo
+			Expect(json.NewDecoder(resp.Body).Decode(&body)).To(Succeed())
+			Expect(body.Name).To(Equal("test.txt"))
+			Expect(body.Size).To(Equal(int64(42)))
+		})
+	})
+
+	Describe("POST /sandboxes/{id}/filesystem/mkdir", func() {
+		It("proxies mkdir request and returns created path", func() {
+			var capturedPath string
+			mockSidecar := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedPath = r.URL.Query().Get("path")
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				_ = json.NewEncoder(w).Encode(sidecarapi.FilesystemMkdirResponse{
+					AbsolutePath: "/workspace/newdir",
+				})
+			}))
+			defer mockSidecar.Close()
+
+			port := mockSidecar.Listener.Addr().(*net.TCPAddr).Port
+			api := newFilesystemTestAPI(&http.Client{}, port)
+			sbName := createRunningSandboxCR()
+
+			resp := api.Post(fmt.Sprintf("/sandboxes/%s/filesystem/mkdir?path=/workspace/newdir", sbName), "", nil)
+
+			Expect(resp.Code).To(Equal(http.StatusCreated))
+			Expect(capturedPath).To(Equal("/workspace/newdir"))
+
+			var body FilesystemMkdirResponse
+			Expect(json.NewDecoder(resp.Body).Decode(&body)).To(Succeed())
+			Expect(body.AbsolutePath).To(Equal("/workspace/newdir"))
+		})
+	})
+
+	Describe("POST /sandboxes/{id}/filesystem/rename", func() {
+		It("proxies rename request with both paths", func() {
+			var capturedPath, capturedNewPath string
+			mockSidecar := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedPath = r.URL.Query().Get("path")
+				capturedNewPath = r.URL.Query().Get("newPath")
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(sidecarapi.FilesystemRenameResponse{
+					AbsolutePath: "/workspace/new-name.txt",
+				})
+			}))
+			defer mockSidecar.Close()
+
+			port := mockSidecar.Listener.Addr().(*net.TCPAddr).Port
+			api := newFilesystemTestAPI(&http.Client{}, port)
+			sbName := createRunningSandboxCR()
+
+			resp := api.Post(fmt.Sprintf("/sandboxes/%s/filesystem/rename?path=/workspace/old.txt&newPath=/workspace/new-name.txt", sbName), "", nil)
+
+			Expect(resp.Code).To(Equal(http.StatusOK))
+			Expect(capturedPath).To(Equal("/workspace/old.txt"))
+			Expect(capturedNewPath).To(Equal("/workspace/new-name.txt"))
+		})
+	})
+
+	Describe("DELETE /sandboxes/{id}/filesystem", func() {
+		It("proxies remove request", func() {
+			var capturedPath string
+			var capturedMethod string
+			mockSidecar := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedPath = r.URL.Query().Get("path")
+				capturedMethod = r.Method
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer mockSidecar.Close()
+
+			port := mockSidecar.Listener.Addr().(*net.TCPAddr).Port
+			api := newFilesystemTestAPI(&http.Client{}, port)
+			sbName := createRunningSandboxCR()
+
+			resp := api.Delete(fmt.Sprintf("/sandboxes/%s/filesystem?path=/workspace/remove-me.txt", sbName))
+
+			Expect(resp.Code).To(Equal(http.StatusNoContent))
+			Expect(capturedPath).To(Equal("/workspace/remove-me.txt"))
+			Expect(capturedMethod).To(Equal(http.MethodDelete))
+		})
+
+		It("returns 404 for nonexistent sandbox", func() {
+			api := newFilesystemTestAPI(&http.Client{}, 0)
+			resp := api.Delete("/sandboxes/nonexistent/filesystem?path=/tmp/test.txt")
+			Expect(resp.Code).To(Equal(http.StatusNotFound))
+		})
+
+		It("forwards sidecar 404 errors", func() {
+			mockSidecar := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusNotFound)
+				_ = json.NewEncoder(w).Encode(map[string]string{
+					"detail": "path not found: /tmp/missing.txt",
+				})
+			}))
+			defer mockSidecar.Close()
+
+			port := mockSidecar.Listener.Addr().(*net.TCPAddr).Port
+			api := newFilesystemTestAPI(&http.Client{}, port)
+			sbName := createRunningSandboxCR()
+
+			resp := api.Delete(fmt.Sprintf("/sandboxes/%s/filesystem?path=/tmp/missing.txt", sbName))
+			Expect(resp.Code).To(Equal(http.StatusNotFound))
+		})
+	})
 })

--- a/internal/sandbox-sidecar/filesystem/filesystem.go
+++ b/internal/sandbox-sidecar/filesystem/filesystem.go
@@ -387,20 +387,22 @@ func (h *Handlers) MkdirFilesystem(_ context.Context, input *FilesystemMkdirInpu
 }
 
 func (h *Handlers) RenameFilesystem(_ context.Context, input *FilesystemRenameInput) (*FilesystemRenameOutput, error) {
-	srcHost, _, err := h.resolveHostPath(input.Path, input.Container)
+	pid, err := h.resolveContainerPID(input.Container)
 	if err != nil {
 		return nil, err
 	}
 
-	// Resolve destination path using same container
-	pid, pidErr := h.resolveContainerPID(input.Container)
-	if pidErr != nil {
-		return nil, pidErr
+	srcResolvedPath, srcErr := h.resolveAbsolutePath(input.Path, pid)
+	if srcErr != nil {
+		h.logger.Error("failed to resolve source path", "error", srcErr, "path", input.Path)
+		return nil, srcErr
 	}
-	newResolvedPath, resolveErr := h.resolveAbsolutePath(input.NewPath, pid)
-	if resolveErr != nil {
-		h.logger.Error("failed to resolve new path", "error", resolveErr, "path", input.NewPath)
-		return nil, resolveErr
+	srcHost := filepath.Join(h.procFS.GetRoot(pid), srcResolvedPath)
+
+	newResolvedPath, dstErr := h.resolveAbsolutePath(input.NewPath, pid)
+	if dstErr != nil {
+		h.logger.Error("failed to resolve new path", "error", dstErr, "path", input.NewPath)
+		return nil, dstErr
 	}
 	dstHost := filepath.Join(h.procFS.GetRoot(pid), newResolvedPath)
 
@@ -412,7 +414,6 @@ func (h *Handlers) RenameFilesystem(_ context.Context, input *FilesystemRenameIn
 		return nil, huma.Error500InternalServerError("failed to stat source path")
 	}
 
-	// Ensure parent of destination exists
 	uid, gid, err := h.procFS.GetUIDGID(pid)
 	if err != nil {
 		h.logger.Error("failed to get container uid/gid", "error", err, "pid", pid)
@@ -434,11 +435,16 @@ func (h *Handlers) RenameFilesystem(_ context.Context, input *FilesystemRenameIn
 }
 
 func (h *Handlers) RemoveFilesystem(_ context.Context, input *FilesystemRemoveInput) (*struct{}, error) {
-	targetPath, _, err := h.resolveHostPath(input.Path, input.Container)
+	targetPath, resolvedPath, err := h.resolveHostPath(input.Path, input.Container)
 	if err != nil {
 		return nil, err
 	}
 
+	if resolvedPath == "/" {
+		return nil, huma.Error400BadRequest("cannot remove root directory")
+	}
+
+	// Lstat so we can detect and remove symlinks without following them
 	if _, err := os.Lstat(targetPath); err != nil { //nolint:gosec
 		if os.IsNotExist(err) {
 			return nil, huma.Error404NotFound(fmt.Sprintf("path not found: %s", input.Path))

--- a/internal/sandbox-sidecar/filesystem/filesystem.go
+++ b/internal/sandbox-sidecar/filesystem/filesystem.go
@@ -46,6 +46,48 @@ type FilesystemReadInput struct {
 	Container string `query:"container,omitempty" doc:"Container name. Defaults to the only container if there is one, otherwise it's required."`
 }
 
+type FilesystemListInput struct {
+	Path      string `query:"path" required:"true" minLength:"1" doc:"Directory path (absolute or relative to container cwd)"`
+	Container string `query:"container,omitempty" doc:"Container name. Defaults to the only container if there is one, otherwise it's required."`
+}
+
+type FilesystemListOutput struct {
+	Body sidecarapi.FilesystemListResponse
+}
+
+type FilesystemStatInput struct {
+	Path      string `query:"path" required:"true" minLength:"1" doc:"Path to stat (absolute or relative to container cwd)"`
+	Container string `query:"container,omitempty" doc:"Container name. Defaults to the only container if there is one, otherwise it's required."`
+}
+
+type FilesystemStatOutput struct {
+	Body sidecarapi.FilesystemStatResponse
+}
+
+type FilesystemMkdirInput struct {
+	Path      string `query:"path" required:"true" minLength:"1" doc:"Directory path to create (absolute or relative to container cwd)"`
+	Container string `query:"container,omitempty" doc:"Container name. Defaults to the only container if there is one, otherwise it's required."`
+}
+
+type FilesystemMkdirOutput struct {
+	Body sidecarapi.FilesystemMkdirResponse
+}
+
+type FilesystemRenameInput struct {
+	Path      string `query:"path" required:"true" minLength:"1" doc:"Source path (absolute or relative to container cwd)"`
+	NewPath   string `query:"newPath" required:"true" minLength:"1" doc:"Destination path (absolute or relative to container cwd)"`
+	Container string `query:"container,omitempty" doc:"Container name. Defaults to the only container if there is one, otherwise it's required."`
+}
+
+type FilesystemRenameOutput struct {
+	Body sidecarapi.FilesystemRenameResponse
+}
+
+type FilesystemRemoveInput struct {
+	Path      string `query:"path" required:"true" minLength:"1" doc:"Path to remove (absolute or relative to container cwd)"`
+	Container string `query:"container,omitempty" doc:"Container name. Defaults to the only container if there is one, otherwise it's required."`
+}
+
 type Handlers struct {
 	logger      *slog.Logger
 	procFS      proc.ProcFS
@@ -108,18 +150,46 @@ func mkdirAllChown(path string, uid, gid int) error {
 	return os.Chown(path, uid, gid)
 }
 
+func (h *Handlers) resolveContainerPID(container string) (int, error) {
+	pid, err := h.pidResolver.FindCachedContainerPID(container)
+	if err != nil {
+		h.logger.Warn("failed to determine container pid", "error", err, "container", container)
+		return 0, huma.Error400BadRequest("failed to determine container pid")
+	}
+	return pid, nil
+}
+
+// resolveHostPath resolves a user-provided path to a host path via /proc/<pid>/root.
+func (h *Handlers) resolveHostPath(path, container string) (hostPath, absPath string, err error) {
+	pid, pidErr := h.resolveContainerPID(container)
+	if pidErr != nil {
+		return "", "", pidErr
+	}
+	resolvedPath, resolveErr := h.resolveAbsolutePath(path, pid)
+	if resolveErr != nil {
+		h.logger.Error("failed to resolve path", "error", resolveErr, "path", path, "container", container)
+		return "", "", resolveErr
+	}
+	return filepath.Join(h.procFS.GetRoot(pid), resolvedPath), resolvedPath, nil
+}
+
+func fileInfoFromOS(info os.FileInfo, absPath string) sidecarapi.FileInfo {
+	return sidecarapi.FileInfo{
+		Name:  info.Name(),
+		Path:  absPath,
+		IsDir: info.IsDir(),
+		Size:  info.Size(),
+		Mode:  info.Mode().String(),
+	}
+}
+
 func (h *Handlers) PostFilesystem(_ context.Context, input *FilesystemWriteInput) (*FilesystemWriteOutput, error) {
 	path := input.Path
 	container := input.Container
 
-	pid, err := h.pidResolver.FindCachedContainerPID(container)
+	pid, err := h.resolveContainerPID(container)
 	if err != nil {
-		if container == "" {
-			h.logger.Warn("failed to determine container pid", "error", err)
-			return nil, huma.Error400BadRequest("failed to determine container pid")
-		}
-		h.logger.Warn("failed to determine container pid", "error", err, "container", container)
-		return nil, huma.Error400BadRequest("failed to determine container pid")
+		return nil, err
 	}
 
 	resolvedPath, err := h.resolveAbsolutePath(path, pid)
@@ -177,41 +247,24 @@ func (h *Handlers) PostFilesystem(_ context.Context, input *FilesystemWriteInput
 }
 
 func (h *Handlers) GetFilesystem(_ context.Context, input *FilesystemReadInput) (*huma.StreamResponse, error) {
-	path := input.Path
-	container := input.Container
-
-	pid, err := h.pidResolver.FindCachedContainerPID(container)
+	targetPath, _, err := h.resolveHostPath(input.Path, input.Container)
 	if err != nil {
-		if container == "" {
-			h.logger.Warn("failed to determine container pid", "error", err)
-			return nil, huma.Error400BadRequest("failed to determine container pid")
-		}
-		h.logger.Warn("failed to determine container pid", "error", err, "container", container)
-		return nil, huma.Error400BadRequest("failed to determine container pid")
-	}
-
-	resolvedPath, err := h.resolveAbsolutePath(path, pid)
-	if err != nil {
-		h.logger.Error("failed to resolve path", "error", err, "path", path, "container", container)
 		return nil, err
 	}
-
-	// Build the host path via /proc/<pid>/root
-	targetPath := filepath.Join(h.procFS.GetRoot(pid), resolvedPath)
 
 	// Stat before Open to reject non-regular files (FIFOs, devices, sockets)
 	// without blocking — os.Open on a FIFO blocks until a writer connects.
 	info, err := os.Stat(targetPath) //nolint:gosec // path is within container root via /proc/<pid>/root
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, huma.Error404NotFound(fmt.Sprintf("file not found: %s", path))
+			return nil, huma.Error404NotFound(fmt.Sprintf("file not found: %s", input.Path))
 		}
 		h.logger.Error("failed to stat file", "error", err, "path", targetPath)
 		return nil, huma.Error500InternalServerError("failed to stat file")
 	}
 
 	if !info.Mode().IsRegular() {
-		return nil, huma.Error400BadRequest(fmt.Sprintf("not a regular file: %s", path))
+		return nil, huma.Error400BadRequest(fmt.Sprintf("not a regular file: %s", input.Path))
 	}
 
 	f, err := os.Open(targetPath) //nolint:gosec // path is within container root via /proc/<pid>/root
@@ -241,6 +294,165 @@ func (h *Handlers) GetFilesystem(_ context.Context, input *FilesystemReadInput) 
 			}
 		},
 	}, nil
+}
+
+func (h *Handlers) ListFilesystem(_ context.Context, input *FilesystemListInput) (*FilesystemListOutput, error) {
+	targetPath, resolvedPath, err := h.resolveHostPath(input.Path, input.Container)
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := os.Stat(targetPath) //nolint:gosec
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, huma.Error404NotFound(fmt.Sprintf("directory not found: %s", input.Path))
+		}
+		h.logger.Error("failed to stat directory", "error", err, "path", targetPath)
+		return nil, huma.Error500InternalServerError("failed to stat directory")
+	}
+
+	if !info.IsDir() {
+		return nil, huma.Error400BadRequest(fmt.Sprintf("not a directory: %s", input.Path))
+	}
+
+	dirEntries, err := os.ReadDir(targetPath) //nolint:gosec
+	if err != nil {
+		h.logger.Error("failed to read directory", "error", err, "path", targetPath)
+		return nil, huma.Error500InternalServerError("failed to read directory")
+	}
+
+	entries := make([]sidecarapi.FileInfo, 0, len(dirEntries))
+	for _, de := range dirEntries {
+		fi, err := de.Info()
+		if err != nil {
+			h.logger.Warn("failed to stat directory entry, skipping", "error", err, "name", de.Name())
+			continue
+		}
+		entryAbsPath := filepath.Join(resolvedPath, de.Name())
+		entries = append(entries, fileInfoFromOS(fi, entryAbsPath))
+	}
+
+	return &FilesystemListOutput{
+		Body: sidecarapi.FilesystemListResponse{Entries: entries},
+	}, nil
+}
+
+func (h *Handlers) StatFilesystem(_ context.Context, input *FilesystemStatInput) (*FilesystemStatOutput, error) {
+	targetPath, resolvedPath, err := h.resolveHostPath(input.Path, input.Container)
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := os.Stat(targetPath) //nolint:gosec
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, huma.Error404NotFound(fmt.Sprintf("path not found: %s", input.Path))
+		}
+		h.logger.Error("failed to stat path", "error", err, "path", targetPath)
+		return nil, huma.Error500InternalServerError("failed to stat path")
+	}
+
+	return &FilesystemStatOutput{
+		Body: fileInfoFromOS(info, resolvedPath),
+	}, nil
+}
+
+func (h *Handlers) MkdirFilesystem(_ context.Context, input *FilesystemMkdirInput) (*FilesystemMkdirOutput, error) {
+	pid, err := h.resolveContainerPID(input.Container)
+	if err != nil {
+		return nil, err
+	}
+
+	resolvedPath, resolveErr := h.resolveAbsolutePath(input.Path, pid)
+	if resolveErr != nil {
+		h.logger.Error("failed to resolve path", "error", resolveErr, "path", input.Path)
+		return nil, resolveErr
+	}
+
+	uid, gid, err := h.procFS.GetUIDGID(pid)
+	if err != nil {
+		h.logger.Error("failed to get container uid/gid", "error", err, "pid", pid)
+		return nil, huma.Error500InternalServerError("failed to get container uid/gid")
+	}
+
+	targetPath := filepath.Join(h.procFS.GetRoot(pid), resolvedPath)
+	if err := mkdirAllChown(targetPath, uid, gid); err != nil {
+		h.logger.Error("failed to create directory", "error", err, "path", targetPath)
+		return nil, huma.Error500InternalServerError("failed to create directory")
+	}
+
+	return &FilesystemMkdirOutput{
+		Body: sidecarapi.FilesystemMkdirResponse{AbsolutePath: resolvedPath},
+	}, nil
+}
+
+func (h *Handlers) RenameFilesystem(_ context.Context, input *FilesystemRenameInput) (*FilesystemRenameOutput, error) {
+	srcHost, _, err := h.resolveHostPath(input.Path, input.Container)
+	if err != nil {
+		return nil, err
+	}
+
+	// Resolve destination path using same container
+	pid, pidErr := h.resolveContainerPID(input.Container)
+	if pidErr != nil {
+		return nil, pidErr
+	}
+	newResolvedPath, resolveErr := h.resolveAbsolutePath(input.NewPath, pid)
+	if resolveErr != nil {
+		h.logger.Error("failed to resolve new path", "error", resolveErr, "path", input.NewPath)
+		return nil, resolveErr
+	}
+	dstHost := filepath.Join(h.procFS.GetRoot(pid), newResolvedPath)
+
+	if _, err := os.Stat(srcHost); err != nil { //nolint:gosec
+		if os.IsNotExist(err) {
+			return nil, huma.Error404NotFound(fmt.Sprintf("path not found: %s", input.Path))
+		}
+		h.logger.Error("failed to stat source path", "error", err, "path", srcHost)
+		return nil, huma.Error500InternalServerError("failed to stat source path")
+	}
+
+	// Ensure parent of destination exists
+	uid, gid, err := h.procFS.GetUIDGID(pid)
+	if err != nil {
+		h.logger.Error("failed to get container uid/gid", "error", err, "pid", pid)
+		return nil, huma.Error500InternalServerError("failed to get container uid/gid")
+	}
+	if err := mkdirAllChown(filepath.Dir(dstHost), uid, gid); err != nil {
+		h.logger.Error("failed to create parent directories", "error", err, "path", filepath.Dir(dstHost))
+		return nil, huma.Error500InternalServerError("failed to create parent directories")
+	}
+
+	if err := os.Rename(srcHost, dstHost); err != nil {
+		h.logger.Error("failed to rename", "error", err, "from", srcHost, "to", dstHost)
+		return nil, huma.Error500InternalServerError("failed to rename")
+	}
+
+	return &FilesystemRenameOutput{
+		Body: sidecarapi.FilesystemRenameResponse{AbsolutePath: newResolvedPath},
+	}, nil
+}
+
+func (h *Handlers) RemoveFilesystem(_ context.Context, input *FilesystemRemoveInput) (*struct{}, error) {
+	targetPath, _, err := h.resolveHostPath(input.Path, input.Container)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := os.Lstat(targetPath); err != nil { //nolint:gosec
+		if os.IsNotExist(err) {
+			return nil, huma.Error404NotFound(fmt.Sprintf("path not found: %s", input.Path))
+		}
+		h.logger.Error("failed to stat path", "error", err, "path", targetPath)
+		return nil, huma.Error500InternalServerError("failed to stat path")
+	}
+
+	if err := os.RemoveAll(targetPath); err != nil {
+		h.logger.Error("failed to remove", "error", err, "path", targetPath)
+		return nil, huma.Error500InternalServerError("failed to remove")
+	}
+
+	return nil, nil
 }
 
 func Register(api huma.API, h *Handlers) {
@@ -284,4 +496,56 @@ func Register(api huma.API, h *Handlers) {
 		},
 		Errors: []int{http.StatusBadRequest, http.StatusNotFound},
 	}, h.GetFilesystem)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "listFilesystem",
+		Method:      http.MethodGet,
+		Path:        "/filesystem/list",
+		Summary:     "List directory contents",
+		Description: "Lists files and directories at the specified path in the sandbox container",
+		Tags:        []string{"filesystem"},
+		Errors:      []int{http.StatusBadRequest, http.StatusNotFound},
+	}, h.ListFilesystem)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "statFilesystem",
+		Method:      http.MethodGet,
+		Path:        "/filesystem/stat",
+		Summary:     "Get file or directory info",
+		Description: "Returns metadata about a file or directory in the sandbox container",
+		Tags:        []string{"filesystem"},
+		Errors:      []int{http.StatusBadRequest, http.StatusNotFound},
+	}, h.StatFilesystem)
+
+	huma.Register(api, huma.Operation{
+		OperationID:   "mkdirFilesystem",
+		Method:        http.MethodPost,
+		Path:          "/filesystem/mkdir",
+		Summary:       "Create a directory",
+		Description:   "Creates a directory and all parent directories at the specified path",
+		Tags:          []string{"filesystem"},
+		DefaultStatus: http.StatusCreated,
+		Errors:        []int{http.StatusBadRequest},
+	}, h.MkdirFilesystem)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "renameFilesystem",
+		Method:      http.MethodPost,
+		Path:        "/filesystem/rename",
+		Summary:     "Rename or move a file or directory",
+		Description: "Renames or moves a file or directory within the sandbox container",
+		Tags:        []string{"filesystem"},
+		Errors:      []int{http.StatusBadRequest, http.StatusNotFound},
+	}, h.RenameFilesystem)
+
+	huma.Register(api, huma.Operation{
+		OperationID:   "removeFilesystem",
+		Method:        http.MethodDelete,
+		Path:          "/filesystem",
+		Summary:       "Remove a file or directory",
+		Description:   "Removes a file or directory (recursively) from the sandbox container",
+		Tags:          []string{"filesystem"},
+		DefaultStatus: http.StatusNoContent,
+		Errors:        []int{http.StatusBadRequest, http.StatusNotFound},
+	}, h.RemoveFilesystem)
 }

--- a/internal/sandbox-sidecar/filesystem/filesystem_test.go
+++ b/internal/sandbox-sidecar/filesystem/filesystem_test.go
@@ -311,7 +311,6 @@ var _ = Describe("Filesystem", func() {
 			Expect(resp.Code).To(Equal(http.StatusInternalServerError))
 		})
 	})
-})
 
 	Describe("GET /filesystem/list", func() {
 		It("lists directory contents", func() {

--- a/internal/sandbox-sidecar/filesystem/filesystem_test.go
+++ b/internal/sandbox-sidecar/filesystem/filesystem_test.go
@@ -313,6 +313,245 @@ var _ = Describe("Filesystem", func() {
 	})
 })
 
+	Describe("GET /filesystem/list", func() {
+		It("lists directory contents", func() {
+			dir := filepath.Join(testRootDir, "/tmp/listdir")
+			Expect(os.MkdirAll(dir, 0750)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(dir, "a.txt"), []byte("aaa"), 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(dir, "b.txt"), []byte("bb"), 0600)).To(Succeed())
+			Expect(os.Mkdir(filepath.Join(dir, "subdir"), 0750)).To(Succeed())
+
+			resp := doGet("/filesystem/list?path=/tmp/listdir")
+
+			Expect(resp.Code).To(Equal(http.StatusOK))
+			var body sidecarapi.FilesystemListResponse
+			Expect(json.NewDecoder(resp.Body).Decode(&body)).To(Succeed())
+			Expect(body.Entries).To(HaveLen(3))
+
+			names := make([]string, len(body.Entries))
+			for i, e := range body.Entries {
+				names[i] = e.Name
+			}
+			Expect(names).To(ContainElements("a.txt", "b.txt", "subdir"))
+		})
+
+		It("returns entries with correct metadata", func() {
+			dir := filepath.Join(testRootDir, "/tmp/listmeta")
+			Expect(os.MkdirAll(dir, 0750)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(dir, "file.txt"), []byte("hello"), 0600)).To(Succeed())
+			Expect(os.Mkdir(filepath.Join(dir, "dir"), 0750)).To(Succeed())
+
+			resp := doGet("/filesystem/list?path=/tmp/listmeta")
+
+			Expect(resp.Code).To(Equal(http.StatusOK))
+			var body sidecarapi.FilesystemListResponse
+			Expect(json.NewDecoder(resp.Body).Decode(&body)).To(Succeed())
+
+			for _, e := range body.Entries {
+				if e.Name == "file.txt" {
+					Expect(e.IsDir).To(BeFalse())
+					Expect(e.Size).To(Equal(int64(5)))
+					Expect(e.Path).To(Equal("/tmp/listmeta/file.txt"))
+				}
+				if e.Name == "dir" {
+					Expect(e.IsDir).To(BeTrue())
+					Expect(e.Path).To(Equal("/tmp/listmeta/dir"))
+				}
+			}
+		})
+
+		It("returns empty list for empty directory", func() {
+			dir := filepath.Join(testRootDir, "/tmp/emptydir")
+			Expect(os.MkdirAll(dir, 0750)).To(Succeed())
+
+			resp := doGet("/filesystem/list?path=/tmp/emptydir")
+
+			Expect(resp.Code).To(Equal(http.StatusOK))
+			var body sidecarapi.FilesystemListResponse
+			Expect(json.NewDecoder(resp.Body).Decode(&body)).To(Succeed())
+			Expect(body.Entries).To(BeEmpty())
+		})
+
+		It("returns 404 for nonexistent directory", func() {
+			resp := doGet("/filesystem/list?path=/tmp/nonexistent-dir")
+			Expect(resp.Code).To(Equal(http.StatusNotFound))
+		})
+
+		It("returns 400 when path is a file", func() {
+			hostPath := filepath.Join(testRootDir, "/tmp/list-not-dir.txt")
+			Expect(os.MkdirAll(filepath.Dir(hostPath), 0750)).To(Succeed())
+			Expect(os.WriteFile(hostPath, []byte("content"), 0600)).To(Succeed())
+
+			resp := doGet("/filesystem/list?path=/tmp/list-not-dir.txt")
+			Expect(resp.Code).To(Equal(http.StatusBadRequest))
+		})
+
+		It("supports relative paths", func() {
+			dir := filepath.Join(testRootDir, testCwd, "rellistdir")
+			Expect(os.MkdirAll(dir, 0750)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(dir, "rel.txt"), []byte("r"), 0600)).To(Succeed())
+
+			resp := doGet("/filesystem/list?path=rellistdir")
+
+			Expect(resp.Code).To(Equal(http.StatusOK))
+			var body sidecarapi.FilesystemListResponse
+			Expect(json.NewDecoder(resp.Body).Decode(&body)).To(Succeed())
+			Expect(body.Entries).To(HaveLen(1))
+			Expect(body.Entries[0].Name).To(Equal("rel.txt"))
+		})
+	})
+
+	Describe("GET /filesystem/stat", func() {
+		It("returns info for a regular file", func() {
+			hostPath := filepath.Join(testRootDir, "/tmp/statfile.txt")
+			Expect(os.MkdirAll(filepath.Dir(hostPath), 0750)).To(Succeed())
+			Expect(os.WriteFile(hostPath, []byte("stat content"), 0600)).To(Succeed())
+
+			resp := doGet("/filesystem/stat?path=/tmp/statfile.txt")
+
+			Expect(resp.Code).To(Equal(http.StatusOK))
+			var body sidecarapi.FileInfo
+			Expect(json.NewDecoder(resp.Body).Decode(&body)).To(Succeed())
+			Expect(body.Name).To(Equal("statfile.txt"))
+			Expect(body.Path).To(Equal("/tmp/statfile.txt"))
+			Expect(body.IsDir).To(BeFalse())
+			Expect(body.Size).To(Equal(int64(12)))
+		})
+
+		It("returns info for a directory", func() {
+			dir := filepath.Join(testRootDir, "/tmp/statdir")
+			Expect(os.MkdirAll(dir, 0750)).To(Succeed())
+
+			resp := doGet("/filesystem/stat?path=/tmp/statdir")
+
+			Expect(resp.Code).To(Equal(http.StatusOK))
+			var body sidecarapi.FileInfo
+			Expect(json.NewDecoder(resp.Body).Decode(&body)).To(Succeed())
+			Expect(body.Name).To(Equal("statdir"))
+			Expect(body.IsDir).To(BeTrue())
+		})
+
+		It("returns 404 for nonexistent path", func() {
+			resp := doGet("/filesystem/stat?path=/tmp/nonexistent-stat")
+			Expect(resp.Code).To(Equal(http.StatusNotFound))
+		})
+	})
+
+	Describe("POST /filesystem/mkdir", func() {
+		It("creates a new directory", func() {
+			resp := doPost("/filesystem/mkdir?path=/tmp/newmkdir", nil)
+
+			Expect(resp.Code).To(Equal(http.StatusCreated))
+			var body sidecarapi.FilesystemMkdirResponse
+			Expect(json.NewDecoder(resp.Body).Decode(&body)).To(Succeed())
+			Expect(body.AbsolutePath).To(Equal("/tmp/newmkdir"))
+
+			hostPath := filepath.Join(testRootDir, "/tmp/newmkdir")
+			info, err := os.Stat(hostPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(info.IsDir()).To(BeTrue())
+		})
+
+		It("creates nested directories", func() {
+			resp := doPost("/filesystem/mkdir?path=/tmp/nested/deep/dir", nil)
+
+			Expect(resp.Code).To(Equal(http.StatusCreated))
+
+			hostPath := filepath.Join(testRootDir, "/tmp/nested/deep/dir")
+			info, err := os.Stat(hostPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(info.IsDir()).To(BeTrue())
+		})
+
+		It("succeeds if directory already exists", func() {
+			dir := filepath.Join(testRootDir, "/tmp/existing-mkdir")
+			Expect(os.MkdirAll(dir, 0750)).To(Succeed())
+
+			resp := doPost("/filesystem/mkdir?path=/tmp/existing-mkdir", nil)
+			Expect(resp.Code).To(Equal(http.StatusCreated))
+		})
+	})
+
+	Describe("POST /filesystem/rename", func() {
+		It("renames a file", func() {
+			hostPath := filepath.Join(testRootDir, "/tmp/rename-src.txt")
+			Expect(os.MkdirAll(filepath.Dir(hostPath), 0750)).To(Succeed())
+			Expect(os.WriteFile(hostPath, []byte("rename me"), 0600)).To(Succeed())
+
+			resp := doPost("/filesystem/rename?path=/tmp/rename-src.txt&newPath=/tmp/rename-dst.txt", nil)
+
+			Expect(resp.Code).To(Equal(http.StatusOK))
+			var body sidecarapi.FilesystemRenameResponse
+			Expect(json.NewDecoder(resp.Body).Decode(&body)).To(Succeed())
+			Expect(body.AbsolutePath).To(Equal("/tmp/rename-dst.txt"))
+
+			// Old path should not exist
+			_, err := os.Stat(hostPath)
+			Expect(os.IsNotExist(err)).To(BeTrue())
+
+			// New path should exist
+			dstPath := filepath.Join(testRootDir, "/tmp/rename-dst.txt")
+			content, err := os.ReadFile(dstPath) //nolint:gosec
+			Expect(err).NotTo(HaveOccurred())
+			Expect(content).To(Equal([]byte("rename me")))
+		})
+
+		It("moves a file to a new directory", func() {
+			srcPath := filepath.Join(testRootDir, "/tmp/move-file.txt")
+			Expect(os.MkdirAll(filepath.Dir(srcPath), 0750)).To(Succeed())
+			Expect(os.WriteFile(srcPath, []byte("move me"), 0600)).To(Succeed())
+
+			resp := doPost("/filesystem/rename?path=/tmp/move-file.txt&newPath=/tmp/move-dest/file.txt", nil)
+
+			Expect(resp.Code).To(Equal(http.StatusOK))
+
+			dstPath := filepath.Join(testRootDir, "/tmp/move-dest/file.txt")
+			content, err := os.ReadFile(dstPath) //nolint:gosec
+			Expect(err).NotTo(HaveOccurred())
+			Expect(content).To(Equal([]byte("move me")))
+		})
+
+		It("returns 404 for nonexistent source", func() {
+			resp := doPost("/filesystem/rename?path=/tmp/nonexistent-rename.txt&newPath=/tmp/dest.txt", nil)
+			Expect(resp.Code).To(Equal(http.StatusNotFound))
+		})
+	})
+
+	Describe("DELETE /filesystem", func() {
+		It("removes a file", func() {
+			hostPath := filepath.Join(testRootDir, "/tmp/remove-file.txt")
+			Expect(os.MkdirAll(filepath.Dir(hostPath), 0750)).To(Succeed())
+			Expect(os.WriteFile(hostPath, []byte("remove me"), 0600)).To(Succeed())
+
+			resp := testAPI.Delete("/filesystem?path=/tmp/remove-file.txt")
+
+			Expect(resp.Code).To(Equal(http.StatusNoContent))
+
+			_, err := os.Stat(hostPath)
+			Expect(os.IsNotExist(err)).To(BeTrue())
+		})
+
+		It("removes a directory recursively", func() {
+			dir := filepath.Join(testRootDir, "/tmp/remove-dir")
+			Expect(os.MkdirAll(filepath.Join(dir, "subdir"), 0750)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(dir, "file.txt"), []byte("content"), 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(dir, "subdir/nested.txt"), []byte("nested"), 0600)).To(Succeed())
+
+			resp := testAPI.Delete("/filesystem?path=/tmp/remove-dir")
+
+			Expect(resp.Code).To(Equal(http.StatusNoContent))
+
+			_, err := os.Stat(dir)
+			Expect(os.IsNotExist(err)).To(BeTrue())
+		})
+
+		It("returns 404 for nonexistent path", func() {
+			resp := testAPI.Delete("/filesystem?path=/tmp/nonexistent-remove")
+			Expect(resp.Code).To(Equal(http.StatusNotFound))
+		})
+	})
+})
+
 // errorMockProcFS returns errors for FindMarkedPID.
 type errorMockProcFS struct {
 	findPIDError error

--- a/internal/sidecar-api/types.go
+++ b/internal/sidecar-api/types.go
@@ -36,3 +36,26 @@ type CreateCommandResponse struct {
 type CommandStatusResponse struct {
 	ExitCode *int `json:"exitCode" doc:"Process exit code, null if still running"`
 }
+
+// FileInfo represents metadata about a file or directory.
+type FileInfo struct {
+	Name  string `json:"name" example:"file.txt" doc:"Base name of the file or directory"`
+	Path  string `json:"path" example:"/workspace/file.txt" doc:"Absolute path"`
+	IsDir bool   `json:"isDir" doc:"True if the entry is a directory"`
+	Size  int64  `json:"size" example:"1024" doc:"Size in bytes (0 for directories)"`
+	Mode  string `json:"mode" example:"-rw-r--r--" doc:"Unix file mode string"`
+}
+
+type FilesystemListResponse struct {
+	Entries []FileInfo `json:"entries" doc:"List of directory entries"`
+}
+
+type FilesystemStatResponse = FileInfo
+
+type FilesystemMkdirResponse struct {
+	AbsolutePath string `json:"absolutePath" example:"/workspace/new-dir" doc:"Absolute path of created directory"`
+}
+
+type FilesystemRenameResponse struct {
+	AbsolutePath string `json:"absolutePath" example:"/workspace/new-name.txt" doc:"New absolute path after rename"`
+}

--- a/internal/sidecar-api/types.go
+++ b/internal/sidecar-api/types.go
@@ -42,7 +42,7 @@ type FileInfo struct {
 	Name  string `json:"name" example:"file.txt" doc:"Base name of the file or directory"`
 	Path  string `json:"path" example:"/workspace/file.txt" doc:"Absolute path"`
 	IsDir bool   `json:"isDir" doc:"True if the entry is a directory"`
-	Size  int64  `json:"size" example:"1024" doc:"Size in bytes (0 for directories)"`
+	Size  int64  `json:"size" example:"1024" doc:"Size in bytes"`
 	Mode  string `json:"mode" example:"-rw-r--r--" doc:"Unix file mode string"`
 }
 

--- a/sdks/python/src/isola/__init__.py
+++ b/sdks/python/src/isola/__init__.py
@@ -26,7 +26,16 @@ from ._exceptions import (
     ValidationError,
 )
 from ._filesystem import AsyncFilesystem, Filesystem
-from ._models import FileWriteResult, NetworkSpec, SandboxStatus, SandboxSummary
+from ._models import (
+    FileInfo,
+    FileListResult,
+    FileWriteResult,
+    MkdirResult,
+    NetworkSpec,
+    RenameResult,
+    SandboxStatus,
+    SandboxSummary,
+)
 from ._sandbox import AsyncSandbox, Sandbox
 from ._streaming import AsyncCommandOutputStream, CommandOutputStream
 
@@ -44,7 +53,11 @@ __all__ = [
     "NetworkSpec",
     "CommandOutputStream",
     "AsyncCommandOutputStream",
+    "FileInfo",
+    "FileListResult",
     "FileWriteResult",
+    "MkdirResult",
+    "RenameResult",
     "IsolaError",
     "BadRequestError",
     "NotFoundError",

--- a/sdks/python/src/isola/_filesystem.py
+++ b/sdks/python/src/isola/_filesystem.py
@@ -114,9 +114,7 @@ class AsyncFilesystem:
         )
 
     async def read(self, path: str, *, container: str | None = None) -> bytes:
-        return await self._api.request_bytes(
-            "GET", _filesystem_path(self._sandbox_id), params=_params(path, container)
-        )
+        return await self._api.request_bytes("GET", _filesystem_path(self._sandbox_id), params=_params(path, container))
 
     async def list(self, path: str, *, container: str | None = None) -> list[FileInfo]:
         result = await self._api.request_model(

--- a/sdks/python/src/isola/_filesystem.py
+++ b/sdks/python/src/isola/_filesystem.py
@@ -18,11 +18,18 @@ from typing import BinaryIO
 from urllib.parse import quote
 
 from ._client import _AsyncAPI, _SyncAPI
-from ._models import FileWriteResult
+from ._models import FileInfo, FileListResult, FileWriteResult, MkdirResult, RenameResult
 
 
 def _filesystem_path(sandbox_id: str) -> str:
     return f"/sandboxes/{quote(sandbox_id, safe='')}/filesystem"
+
+
+def _params(path: str, container: str | None = None) -> dict[str, str]:
+    params: dict[str, str] = {"path": path}
+    if container:
+        params["container"] = container
+    return params
 
 
 class Filesystem:
@@ -31,26 +38,64 @@ class Filesystem:
         self._sandbox_id = sandbox_id
 
     def write(self, path: str, data: bytes | BinaryIO, *, container: str | None = None) -> FileWriteResult:
-        params = {"path": path}
-        if container:
-            params["container"] = container
-
-        result = self._api.request_model(
+        return self._api.request_model(
             "POST",
             _filesystem_path(self._sandbox_id),
             FileWriteResult,
-            params=params,
+            params=_params(path, container),
             content=data,
             headers={"Content-Type": "application/octet-stream"},
         )
-        return result
 
     def read(self, path: str, *, container: str | None = None) -> bytes:
-        params = {"path": path}
-        if container:
-            params["container"] = container
+        return self._api.request_bytes("GET", _filesystem_path(self._sandbox_id), params=_params(path, container))
 
-        return self._api.request_bytes("GET", _filesystem_path(self._sandbox_id), params=params)
+    def list(self, path: str, *, container: str | None = None) -> list[FileInfo]:
+        result = self._api.request_model(
+            "GET",
+            _filesystem_path(self._sandbox_id) + "/list",
+            FileListResult,
+            params=_params(path, container),
+        )
+        return result.entries
+
+    def stat(self, path: str, *, container: str | None = None) -> FileInfo:
+        return self._api.request_model(
+            "GET",
+            _filesystem_path(self._sandbox_id) + "/stat",
+            FileInfo,
+            params=_params(path, container),
+        )
+
+    def exists(self, path: str, *, container: str | None = None) -> bool:
+        from ._exceptions import NotFoundError
+
+        try:
+            self.stat(path, container=container)
+            return True
+        except NotFoundError:
+            return False
+
+    def mkdir(self, path: str, *, container: str | None = None) -> MkdirResult:
+        return self._api.request_model(
+            "POST",
+            _filesystem_path(self._sandbox_id) + "/mkdir",
+            MkdirResult,
+            params=_params(path, container),
+        )
+
+    def rename(self, path: str, new_path: str, *, container: str | None = None) -> RenameResult:
+        params = _params(path, container)
+        params["newPath"] = new_path
+        return self._api.request_model(
+            "POST",
+            _filesystem_path(self._sandbox_id) + "/rename",
+            RenameResult,
+            params=params,
+        )
+
+    def remove(self, path: str, *, container: str | None = None) -> None:
+        self._api.request_no_content("DELETE", _filesystem_path(self._sandbox_id), params=_params(path, container))
 
 
 class AsyncFilesystem:
@@ -59,23 +104,65 @@ class AsyncFilesystem:
         self._sandbox_id = sandbox_id
 
     async def write(self, path: str, data: bytes | BinaryIO, *, container: str | None = None) -> FileWriteResult:
-        params = {"path": path}
-        if container:
-            params["container"] = container
-
-        result = await self._api.request_model(
+        return await self._api.request_model(
             "POST",
             _filesystem_path(self._sandbox_id),
             FileWriteResult,
-            params=params,
+            params=_params(path, container),
             content=data,
             headers={"Content-Type": "application/octet-stream"},
         )
-        return result
 
     async def read(self, path: str, *, container: str | None = None) -> bytes:
-        params = {"path": path}
-        if container:
-            params["container"] = container
+        return await self._api.request_bytes(
+            "GET", _filesystem_path(self._sandbox_id), params=_params(path, container)
+        )
 
-        return await self._api.request_bytes("GET", _filesystem_path(self._sandbox_id), params=params)
+    async def list(self, path: str, *, container: str | None = None) -> list[FileInfo]:
+        result = await self._api.request_model(
+            "GET",
+            _filesystem_path(self._sandbox_id) + "/list",
+            FileListResult,
+            params=_params(path, container),
+        )
+        return result.entries
+
+    async def stat(self, path: str, *, container: str | None = None) -> FileInfo:
+        return await self._api.request_model(
+            "GET",
+            _filesystem_path(self._sandbox_id) + "/stat",
+            FileInfo,
+            params=_params(path, container),
+        )
+
+    async def exists(self, path: str, *, container: str | None = None) -> bool:
+        from ._exceptions import NotFoundError
+
+        try:
+            await self.stat(path, container=container)
+            return True
+        except NotFoundError:
+            return False
+
+    async def mkdir(self, path: str, *, container: str | None = None) -> MkdirResult:
+        return await self._api.request_model(
+            "POST",
+            _filesystem_path(self._sandbox_id) + "/mkdir",
+            MkdirResult,
+            params=_params(path, container),
+        )
+
+    async def rename(self, path: str, new_path: str, *, container: str | None = None) -> RenameResult:
+        params = _params(path, container)
+        params["newPath"] = new_path
+        return await self._api.request_model(
+            "POST",
+            _filesystem_path(self._sandbox_id) + "/rename",
+            RenameResult,
+            params=params,
+        )
+
+    async def remove(self, path: str, *, container: str | None = None) -> None:
+        await self._api.request_no_content(
+            "DELETE", _filesystem_path(self._sandbox_id), params=_params(path, container)
+        )

--- a/sdks/python/src/isola/_models.py
+++ b/sdks/python/src/isola/_models.py
@@ -122,3 +122,23 @@ class CommandStatus(IsolaModel):
 class FileWriteResult(IsolaModel):
     absolute_path: str
     bytes_written: int
+
+
+class FileInfo(IsolaModel):
+    name: str
+    path: str
+    is_dir: bool
+    size: int
+    mode: str
+
+
+class FileListResult(IsolaModel):
+    entries: list[FileInfo]
+
+
+class MkdirResult(IsolaModel):
+    absolute_path: str
+
+
+class RenameResult(IsolaModel):
+    absolute_path: str

--- a/sdks/python/tests/test_filesystem.py
+++ b/sdks/python/tests/test_filesystem.py
@@ -143,8 +143,7 @@ class _ChunkedReadValidator(io.RawIOBase):
     def read(self, size: int = -1) -> bytes:  # type: ignore[override]
         if size is None or size < 0:
             raise AssertionError(
-                f"read() called without a bounded size (got {size!r}), "
-                "which would load the entire file into memory"
+                f"read() called without a bounded size (got {size!r}), which would load the entire file into memory"
             )
         assert size <= self._max_read_size, f"read({size}) exceeds max {self._max_read_size}"
         return self._buf.read(size)
@@ -394,9 +393,7 @@ async def test_async_filesystem_remove(sandbox_response_copy: dict[str, object])
     respx.get("http://localhost:8080/sandboxes/sandbox-123").mock(
         return_value=httpx.Response(200, json=sandbox_response_copy)
     )
-    respx.delete("http://localhost:8080/sandboxes/sandbox-123/filesystem").mock(
-        return_value=httpx.Response(204)
-    )
+    respx.delete("http://localhost:8080/sandboxes/sandbox-123/filesystem").mock(return_value=httpx.Response(204))
 
     async with AsyncIsola(base_url="http://localhost:8080") as client:
         sandbox = await client.sandboxes.get("sandbox-123")

--- a/sdks/python/tests/test_filesystem.py
+++ b/sdks/python/tests/test_filesystem.py
@@ -215,3 +215,189 @@ def test_filesystem_download_to_real_file(sandbox_response_copy: dict[str, objec
     dest.write_bytes(data)
 
     assert dest.read_bytes() == b"downloaded content"
+
+
+@respx.mock
+def test_filesystem_list(sandbox_response_copy: dict[str, object]) -> None:
+    respx.get("http://localhost:8080/sandboxes/sandbox-123").mock(
+        return_value=httpx.Response(200, json=sandbox_response_copy)
+    )
+    list_route = respx.get("http://localhost:8080/sandboxes/sandbox-123/filesystem/list").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "entries": [
+                    {"name": "a.txt", "path": "/workspace/a.txt", "isDir": False, "size": 10, "mode": "-rw-r--r--"},
+                    {"name": "subdir", "path": "/workspace/subdir", "isDir": True, "size": 0, "mode": "drwxr-xr-x"},
+                ]
+            },
+        )
+    )
+
+    with Isola(base_url="http://localhost:8080") as client:
+        sandbox = client.sandboxes.get("sandbox-123")
+        entries = sandbox.filesystem.list("/workspace")
+
+    assert len(entries) == 2
+    assert entries[0].name == "a.txt"
+    assert entries[0].is_dir is False
+    assert entries[0].size == 10
+    assert entries[1].name == "subdir"
+    assert entries[1].is_dir is True
+    assert list_route.calls[0].request.url.params["path"] == "/workspace"
+
+
+@respx.mock
+def test_filesystem_stat(sandbox_response_copy: dict[str, object]) -> None:
+    respx.get("http://localhost:8080/sandboxes/sandbox-123").mock(
+        return_value=httpx.Response(200, json=sandbox_response_copy)
+    )
+    stat_route = respx.get("http://localhost:8080/sandboxes/sandbox-123/filesystem/stat").mock(
+        return_value=httpx.Response(
+            200,
+            json={"name": "file.txt", "path": "/workspace/file.txt", "isDir": False, "size": 42, "mode": "-rw-r--r--"},
+        )
+    )
+
+    with Isola(base_url="http://localhost:8080") as client:
+        sandbox = client.sandboxes.get("sandbox-123")
+        info = sandbox.filesystem.stat("/workspace/file.txt")
+
+    assert info.name == "file.txt"
+    assert info.path == "/workspace/file.txt"
+    assert info.size == 42
+    assert info.is_dir is False
+    assert stat_route.calls[0].request.url.params["path"] == "/workspace/file.txt"
+
+
+@respx.mock
+def test_filesystem_exists_true(sandbox_response_copy: dict[str, object]) -> None:
+    respx.get("http://localhost:8080/sandboxes/sandbox-123").mock(
+        return_value=httpx.Response(200, json=sandbox_response_copy)
+    )
+    respx.get("http://localhost:8080/sandboxes/sandbox-123/filesystem/stat").mock(
+        return_value=httpx.Response(
+            200,
+            json={"name": "file.txt", "path": "/workspace/file.txt", "isDir": False, "size": 1, "mode": "-rw-r--r--"},
+        )
+    )
+
+    with Isola(base_url="http://localhost:8080") as client:
+        sandbox = client.sandboxes.get("sandbox-123")
+        assert sandbox.filesystem.exists("/workspace/file.txt") is True
+
+
+@respx.mock
+def test_filesystem_exists_false(sandbox_response_copy: dict[str, object]) -> None:
+    respx.get("http://localhost:8080/sandboxes/sandbox-123").mock(
+        return_value=httpx.Response(200, json=sandbox_response_copy)
+    )
+    respx.get("http://localhost:8080/sandboxes/sandbox-123/filesystem/stat").mock(
+        return_value=httpx.Response(404, json={"status": 404, "detail": "path not found"})
+    )
+
+    with Isola(base_url="http://localhost:8080") as client:
+        sandbox = client.sandboxes.get("sandbox-123")
+        assert sandbox.filesystem.exists("/workspace/nope.txt") is False
+
+
+@respx.mock
+def test_filesystem_mkdir(sandbox_response_copy: dict[str, object]) -> None:
+    respx.get("http://localhost:8080/sandboxes/sandbox-123").mock(
+        return_value=httpx.Response(200, json=sandbox_response_copy)
+    )
+    mkdir_route = respx.post("http://localhost:8080/sandboxes/sandbox-123/filesystem/mkdir").mock(
+        return_value=httpx.Response(201, json={"absolutePath": "/workspace/newdir"})
+    )
+
+    with Isola(base_url="http://localhost:8080") as client:
+        sandbox = client.sandboxes.get("sandbox-123")
+        result = sandbox.filesystem.mkdir("/workspace/newdir")
+
+    assert result.absolute_path == "/workspace/newdir"
+    assert mkdir_route.calls[0].request.url.params["path"] == "/workspace/newdir"
+
+
+@respx.mock
+def test_filesystem_rename(sandbox_response_copy: dict[str, object]) -> None:
+    respx.get("http://localhost:8080/sandboxes/sandbox-123").mock(
+        return_value=httpx.Response(200, json=sandbox_response_copy)
+    )
+    rename_route = respx.post("http://localhost:8080/sandboxes/sandbox-123/filesystem/rename").mock(
+        return_value=httpx.Response(200, json={"absolutePath": "/workspace/new-name.txt"})
+    )
+
+    with Isola(base_url="http://localhost:8080") as client:
+        sandbox = client.sandboxes.get("sandbox-123")
+        result = sandbox.filesystem.rename("/workspace/old.txt", "/workspace/new-name.txt")
+
+    assert result.absolute_path == "/workspace/new-name.txt"
+    assert rename_route.calls[0].request.url.params["path"] == "/workspace/old.txt"
+    assert rename_route.calls[0].request.url.params["newPath"] == "/workspace/new-name.txt"
+
+
+@respx.mock
+def test_filesystem_remove(sandbox_response_copy: dict[str, object]) -> None:
+    respx.get("http://localhost:8080/sandboxes/sandbox-123").mock(
+        return_value=httpx.Response(200, json=sandbox_response_copy)
+    )
+    remove_route = respx.delete("http://localhost:8080/sandboxes/sandbox-123/filesystem").mock(
+        return_value=httpx.Response(204)
+    )
+
+    with Isola(base_url="http://localhost:8080") as client:
+        sandbox = client.sandboxes.get("sandbox-123")
+        sandbox.filesystem.remove("/workspace/remove-me.txt")
+
+    assert remove_route.calls[0].request.url.params["path"] == "/workspace/remove-me.txt"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_async_filesystem_list(sandbox_response_copy: dict[str, object]) -> None:
+    respx.get("http://localhost:8080/sandboxes/sandbox-123").mock(
+        return_value=httpx.Response(200, json=sandbox_response_copy)
+    )
+    respx.get("http://localhost:8080/sandboxes/sandbox-123/filesystem/list").mock(
+        return_value=httpx.Response(
+            200,
+            json={"entries": [{"name": "f.txt", "path": "/f.txt", "isDir": False, "size": 5, "mode": "-rw-r--r--"}]},
+        )
+    )
+
+    async with AsyncIsola(base_url="http://localhost:8080") as client:
+        sandbox = await client.sandboxes.get("sandbox-123")
+        entries = await sandbox.filesystem.list("/")
+
+    assert len(entries) == 1
+    assert entries[0].name == "f.txt"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_async_filesystem_exists(sandbox_response_copy: dict[str, object]) -> None:
+    respx.get("http://localhost:8080/sandboxes/sandbox-123").mock(
+        return_value=httpx.Response(200, json=sandbox_response_copy)
+    )
+    respx.get("http://localhost:8080/sandboxes/sandbox-123/filesystem/stat").mock(
+        return_value=httpx.Response(404, json={"status": 404, "detail": "not found"})
+    )
+
+    async with AsyncIsola(base_url="http://localhost:8080") as client:
+        sandbox = await client.sandboxes.get("sandbox-123")
+        assert await sandbox.filesystem.exists("/nope") is False
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_async_filesystem_remove(sandbox_response_copy: dict[str, object]) -> None:
+    respx.get("http://localhost:8080/sandboxes/sandbox-123").mock(
+        return_value=httpx.Response(200, json=sandbox_response_copy)
+    )
+    respx.delete("http://localhost:8080/sandboxes/sandbox-123/filesystem").mock(
+        return_value=httpx.Response(204)
+    )
+
+    async with AsyncIsola(base_url="http://localhost:8080") as client:
+        sandbox = await client.sandboxes.get("sandbox-123")
+        await sandbox.filesystem.remove("/tmp/gone")


### PR DESCRIPTION
Implement the consensus file operations from e2b, daytona, and modal
sandbox SDKs across all three layers of the stack:

Sidecar API types (internal/sidecar-api/):
- FileInfo, FilesystemListResponse, FilesystemStatResponse,
  FilesystemMkdirResponse, FilesystemRenameResponse

Sandbox sidecar (internal/sandbox-sidecar/filesystem/):
- GET /filesystem/list - list directory contents with metadata
- GET /filesystem/stat - get file/directory info (name, path, size, mode)
- POST /filesystem/mkdir - create directory with parents (like mkdir -p)
- POST /filesystem/rename - rename/move files and directories
- DELETE /filesystem - remove files/directories recursively
- Extract resolveContainerPID and resolveHostPath helpers to reduce
  duplication in existing read/write handlers

API gateway (internal/api-gateway/filesystem/):
- Proxy handlers for all five new operations
- Extract sidecarURL, filesystemParams, proxyJSONGet, proxySimple
  helpers to reduce boilerplate in proxy code
- Compile-time type assertions for sidecar-api compatibility

Python SDK (sdks/python/):
- Filesystem.list(), stat(), exists(), mkdir(), rename(), remove()
- AsyncFilesystem mirrors with async variants
- FileInfo, FileListResult, MkdirResult, RenameResult models
- exists() is a convenience method built on stat() + NotFoundError

Tests at all layers with comprehensive coverage.

https://claude.ai/code/session_017rfk2H4p5BjzW5MgD1xeNM