### PR TITLE
Stream SSE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,7 @@ CI runs `make check-openapi` to verify generated specs are in sync.
 - `internal/snapshot/` - Shared types used by both operator and uploader
 - `internal/sandbox-sidecar/proc/` - Procfs abstraction for container PID discovery and filesystem access via `/proc/<pid>/root`
 - `internal/httputil/` - Deadline/timeout protection for streaming I/O (per-operation write/read deadlines via `http.ResponseController`)
+- `internal/sseutil/` - SSE (Server-Sent Events) writer for streaming command stdout/stderr with UTF-8 encoding, keepalive, and offset-based resume via `id:` fields
 
 **Default namespaces:** `isola-system` (operator), `isola-sandboxes` (sandbox pods)
 
@@ -102,7 +103,7 @@ CI runs `make check-openapi` to verify generated specs are in sync.
 
 **Pydantic models (`_models.py`):** All models extend `IsolaModel` which uses `to_camel` alias generator for Python snake_case ↔ API camelCase. Models accept both forms (`validate_by_name=True, validate_by_alias=True`). `extra="ignore"` so the server can add fields without breaking the client. `NetworkSpec` has manual `Field(alias=...)` overrides for acronyms (`allowClusterDNS`, `allowedEgressCIDRs`) that `to_camel` can't handle.
 
-**Streaming (`_streaming.py`):** `StreamReader`/`AsyncStreamReader` wrap byte streams with auto-reconnect (exponential backoff, offset-based resume, max 5 reconnects). UTF-8 incremental decoding. Iterable (`for chunk in cmd.stdout`) or bulk read (`cmd.stdout.read()`).
+**Streaming (`_streaming.py`):** `StreamReader`/`AsyncStreamReader` consume SSE streams (via `httpx-sse`) with auto-reconnect (exponential backoff, offset-based resume via `Last-Event-ID` header, max 5 reconnects). Iterable (`for chunk in cmd.stdout`) or bulk read (`cmd.stdout.read()`).
 
 **Error hierarchy:** `IsolaError` base → `APIError` → status-specific subclasses (`BadRequestError`, `NotFoundError`, `ConflictError`, `ValidationError`, `InternalError`, `BadGatewayError`) mapped from HTTP status codes. `APIConnectionError` for transport failures. `is_transient()` helper identifies retryable errors.
 
@@ -133,8 +134,8 @@ The api-gateway is a thin passthrough to K8s — it validates input structure bu
 - `GET /sandboxes/{id}/filesystem` — file download (proxied to sidecar)
 - `POST /sandboxes/{id}/commands` — start command (proxied to sidecar, 202 Accepted). Request body uses `args` (not `cmd`): `args[0]` is executable, `args[1:]` are arguments. Optional `timeout` (seconds), `env`, `cwd`.
 - `GET /sandboxes/{id}/commands/{cmdId}/status` — exit code (null if running). Supports long-polling via `?waitSeconds=N` (max 25 at gateway, max 30 at sidecar).
-- `GET /sandboxes/{id}/commands/{cmdId}/stdout` — stream stdout (?offset=N for resume)
-- `GET /sandboxes/{id}/commands/{cmdId}/stderr` — stream stderr (?offset=N for resume)
+- `GET /sandboxes/{id}/commands/{cmdId}/stdout` — SSE stream of stdout (`text/event-stream`). Resume via `Last-Event-ID` header (byte offset).
+- `GET /sandboxes/{id}/commands/{cmdId}/stderr` — SSE stream of stderr (`text/event-stream`). Resume via `Last-Event-ID` header (byte offset).
 - `POST /sandboxes/{id}/commands/{cmdId}/stdin` — write to stdin
 - `POST /sandboxes/{id}/commands/{cmdId}/stdin/close` — close stdin pipe
 - `DELETE /sandboxes/{id}/commands/{cmdId}` — kill command (idempotent)
@@ -179,6 +180,7 @@ REST types are separate from CRD types with explicit conversion in `sandbox/conv
 - Per-command `timeout` (seconds): enforced via `context.WithTimeout` → SIGKILL on expiration (exit code -1).
 - Command stdout/stderr are stored on the container's ephemeral storage (counts against resource limits).
 - Command state is in-memory in the sidecar — all running/completed commands are lost on sidecar restart.
+- Stdout/stderr are streamed as SSE (`text/event-stream`). The sidecar produces SSE via `internal/sseutil/` (UTF-8 sanitization, `id:` fields for byte-offset resume, 15s keepalive comments). The gateway proxies SSE transparently. The Python SDK consumes SSE via `httpx-sse` and resumes with `Last-Event-ID` header. Non-UTF-8 bytes in output are replaced with U+FFFD; for binary content, redirect to a file and download via the filesystem API.
 - Streaming I/O uses per-operation deadline protection (10s via `internal/httputil`) to detect stalled connections.
 - Gateway command handlers use compile-time type assertions (`_ = sidecarapi.CreateCommandRequest(CreateCommandRequest{})`) to enforce structural compatibility with `sidecar-api` contract types. Do not remove these.
 

--- a/api/openapi/api-gateway.yaml
+++ b/api/openapi/api-gateway.yaml
@@ -812,7 +812,7 @@ paths:
         - commands
   /sandboxes/{id}/commands/{cmdId}/stderr:
     get:
-      description: Streams the command's stderr as raw bytes. The connection remains open until the command exits. Supports resuming via ?offset=N query parameter.
+      description: Streams the command's stderr as Server-Sent Events. The connection remains open until the command exits. Supports resuming via Last-Event-ID header.
       operationId: getSandboxCommandStderr
       parameters:
         - description: Sandbox identifier
@@ -830,22 +830,17 @@ paths:
             description: Command identifier
             pattern: ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$
             type: string
-        - description: Byte offset to resume from (default 0)
-          explode: false
-          in: query
-          name: offset
+        - description: Byte offset to resume from (SSE Last-Event-ID)
+          in: header
+          name: Last-Event-ID
           schema:
-            description: Byte offset to resume from (default 0)
-            format: int64
-            minimum: 0
-            type: integer
+            description: Byte offset to resume from (SSE Last-Event-ID)
+            type: string
       responses:
         "200":
           content:
-            application/octet-stream:
+            text/event-stream:
               schema:
-                contentMediaType: application/octet-stream
-                format: binary
                 type: string
           description: Command stderr stream
         "404":
@@ -1006,7 +1001,7 @@ paths:
         - commands
   /sandboxes/{id}/commands/{cmdId}/stdout:
     get:
-      description: Streams the command's stdout as raw bytes. The connection remains open until the command exits. Supports resuming via ?offset=N query parameter.
+      description: Streams the command's stdout as Server-Sent Events. The connection remains open until the command exits. Supports resuming via Last-Event-ID header.
       operationId: getSandboxCommandStdout
       parameters:
         - description: Sandbox identifier
@@ -1024,22 +1019,17 @@ paths:
             description: Command identifier
             pattern: ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$
             type: string
-        - description: Byte offset to resume from (default 0)
-          explode: false
-          in: query
-          name: offset
+        - description: Byte offset to resume from (SSE Last-Event-ID)
+          in: header
+          name: Last-Event-ID
           schema:
-            description: Byte offset to resume from (default 0)
-            format: int64
-            minimum: 0
-            type: integer
+            description: Byte offset to resume from (SSE Last-Event-ID)
+            type: string
       responses:
         "200":
           content:
-            application/octet-stream:
+            text/event-stream:
               schema:
-                contentMediaType: application/octet-stream
-                format: binary
                 type: string
           description: Command stdout stream
         "404":

--- a/api/openapi/sandbox-sidecar.yaml
+++ b/api/openapi/sandbox-sidecar.yaml
@@ -313,7 +313,7 @@ paths:
         - commands
   /commands/{cmdId}/stderr:
     get:
-      description: Streams the command's stderr as raw bytes. The connection remains open until the command exits. Supports resuming via ?offset=N query parameter.
+      description: Streams the command's stderr as Server-Sent Events. The connection remains open until the command exits. Supports resuming via Last-Event-ID header.
       operationId: getCommandStderr
       parameters:
         - description: Command identifier
@@ -324,22 +324,17 @@ paths:
             description: Command identifier
             pattern: ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$
             type: string
-        - description: Byte offset to resume from (default 0)
-          explode: false
-          in: query
-          name: offset
+        - description: Byte offset to resume from (SSE Last-Event-ID)
+          in: header
+          name: Last-Event-ID
           schema:
-            description: Byte offset to resume from (default 0)
-            format: int64
-            minimum: 0
-            type: integer
+            description: Byte offset to resume from (SSE Last-Event-ID)
+            type: string
       responses:
         "200":
           content:
-            application/octet-stream:
+            text/event-stream:
               schema:
-                contentMediaType: application/octet-stream
-                format: binary
                 type: string
           description: Command stderr stream
         "404":
@@ -459,7 +454,7 @@ paths:
         - commands
   /commands/{cmdId}/stdout:
     get:
-      description: Streams the command's stdout as raw bytes. The connection remains open until the command exits. Supports resuming via ?offset=N query parameter.
+      description: Streams the command's stdout as Server-Sent Events. The connection remains open until the command exits. Supports resuming via Last-Event-ID header.
       operationId: getCommandStdout
       parameters:
         - description: Command identifier
@@ -470,22 +465,17 @@ paths:
             description: Command identifier
             pattern: ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$
             type: string
-        - description: Byte offset to resume from (default 0)
-          explode: false
-          in: query
-          name: offset
+        - description: Byte offset to resume from (SSE Last-Event-ID)
+          in: header
+          name: Last-Event-ID
           schema:
-            description: Byte offset to resume from (default 0)
-            format: int64
-            minimum: 0
-            type: integer
+            description: Byte offset to resume from (SSE Last-Event-ID)
+            type: string
       responses:
         "200":
           content:
-            application/octet-stream:
+            text/event-stream:
               schema:
-                contentMediaType: application/octet-stream
-                format: binary
                 type: string
           description: Command stdout stream
         "404":

--- a/internal/api-gateway/command/command.go
+++ b/internal/api-gateway/command/command.go
@@ -77,9 +77,9 @@ type GetSandboxCommandStatusOutput struct {
 }
 
 type GetSandboxCommandStreamInput struct {
-	ID     string `path:"id" doc:"Sandbox identifier"`
-	CmdID  string `path:"cmdId" pattern:"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$" doc:"Command identifier"`
-	Offset int64  `query:"offset,omitempty" minimum:"0" doc:"Byte offset to resume from (default 0)"`
+	ID          string `path:"id" doc:"Sandbox identifier"`
+	CmdID       string `path:"cmdId" pattern:"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$" doc:"Command identifier"`
+	LastEventID string `header:"Last-Event-ID" doc:"Byte offset to resume from (SSE Last-Event-ID)"`
 }
 
 type PostSandboxCommandStdinInput struct {
@@ -208,31 +208,30 @@ func (h *Handlers) GetCommandStatus(ctx context.Context, input *GetSandboxComman
 }
 
 func (h *Handlers) GetCommandStdout(ctx context.Context, input *GetSandboxCommandStreamInput) (*huma.StreamResponse, error) {
-	return h.proxyStream(ctx, input.ID, input.CmdID, "stdout", input.Offset)
+	return h.proxyStream(ctx, input.ID, input.CmdID, "stdout", input.LastEventID)
 }
 
 func (h *Handlers) GetCommandStderr(ctx context.Context, input *GetSandboxCommandStreamInput) (*huma.StreamResponse, error) {
-	return h.proxyStream(ctx, input.ID, input.CmdID, "stderr", input.Offset)
+	return h.proxyStream(ctx, input.ID, input.CmdID, "stderr", input.LastEventID)
 }
 
-func (h *Handlers) proxyStream(ctx context.Context, sandboxID, cmdID, stream string, offset int64) (*huma.StreamResponse, error) {
+func (h *Handlers) proxyStream(ctx context.Context, sandboxID, cmdID, stream, lastEventID string) (*huma.StreamResponse, error) {
 	sb, err := apigateway.GetReadySandbox(ctx, h.k8sClient, h.sandboxNamespace, sandboxID, h.logger)
 	if err != nil {
 		return nil, err
 	}
 
 	sidecarURL := fmt.Sprintf("http://%s:%d/commands/%s/%s", sb.Status.PodIP, h.sidecarPort, cmdID, stream)
-	if offset > 0 {
-		sidecarURL += fmt.Sprintf("?offset=%d", offset)
-	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, sidecarURL, nil)
 	if err != nil {
 		h.logger.Error("failed to build sidecar request", "error", err)
 		return nil, huma.Error500InternalServerError("failed to build sidecar request")
 	}
+	if lastEventID != "" {
+		req.Header.Set("Last-Event-ID", lastEventID)
+	}
 
-	// todo benl: can probably refactor the code around here to something like doSidecarRequest
 	resp, err := h.httpClient.Do(req) //nolint:bodyclose // closed in both error and streaming paths below
 	if err != nil {
 		h.logger.Error("sidecar request failed", "error", err, "id", sandboxID)
@@ -248,11 +247,8 @@ func (h *Handlers) proxyStream(ctx context.Context, sandboxID, cmdID, stream str
 		Body: func(ctx huma.Context) {
 			defer func() { _ = resp.Body.Close() }()
 
-			ctx.SetHeader("Content-Type", "application/octet-stream")
-			// no-cache, since the stream change over time
-			// private, since the stream is of a specific sandbox
+			ctx.SetHeader("Content-Type", "text/event-stream")
 			ctx.SetHeader("Cache-Control", "no-cache, private")
-			// X-Accel-Buffering: no, disable nginx buffering (serve immediately)
 			ctx.SetHeader("X-Accel-Buffering", "no")
 
 			rc := httputil.ResponseController(ctx)
@@ -385,14 +381,14 @@ func Register(api huma.API, h *Handlers) {
 		Method:      http.MethodGet,
 		Path:        "/sandboxes/{id}/commands/{cmdId}/stdout",
 		Summary:     "Stream command stdout",
-		Description: "Streams the command's stdout as raw bytes. The connection remains open until the command exits. Supports resuming via ?offset=N query parameter.",
+		Description: "Streams the command's stdout as Server-Sent Events. The connection remains open until the command exits. Supports resuming via Last-Event-ID header.",
 		Tags:        []string{"sandboxes", "commands"},
 		Responses: map[string]*huma.Response{
 			"200": {
 				Description: "Command stdout stream",
 				Content: map[string]*huma.MediaType{
-					"application/octet-stream": {
-						Schema: &huma.Schema{Type: "string", Format: "binary"},
+					"text/event-stream": {
+						Schema: &huma.Schema{Type: "string"},
 					},
 				},
 			},
@@ -405,14 +401,14 @@ func Register(api huma.API, h *Handlers) {
 		Method:      http.MethodGet,
 		Path:        "/sandboxes/{id}/commands/{cmdId}/stderr",
 		Summary:     "Stream command stderr",
-		Description: "Streams the command's stderr as raw bytes. The connection remains open until the command exits. Supports resuming via ?offset=N query parameter.",
+		Description: "Streams the command's stderr as Server-Sent Events. The connection remains open until the command exits. Supports resuming via Last-Event-ID header.",
 		Tags:        []string{"sandboxes", "commands"},
 		Responses: map[string]*huma.Response{
 			"200": {
 				Description: "Command stderr stream",
 				Content: map[string]*huma.MediaType{
-					"application/octet-stream": {
-						Schema: &huma.Schema{Type: "string", Format: "binary"},
+					"text/event-stream": {
+						Schema: &huma.Schema{Type: "string"},
 					},
 				},
 			},

--- a/internal/api-gateway/command/command.go
+++ b/internal/api-gateway/command/command.go
@@ -248,7 +248,10 @@ func (h *Handlers) proxyStream(ctx context.Context, sandboxID, cmdID, stream, la
 			defer func() { _ = resp.Body.Close() }()
 
 			ctx.SetHeader("Content-Type", "text/event-stream")
+			// no-cache, since the stream change over time
+			// private, since the stream is of a specific sandbox
 			ctx.SetHeader("Cache-Control", "no-cache, private")
+			// X-Accel-Buffering: no, disable nginx buffering (serve immediately)
 			ctx.SetHeader("X-Accel-Buffering", "no")
 
 			rc := httputil.ResponseController(ctx)

--- a/internal/api-gateway/command/command_test.go
+++ b/internal/api-gateway/command/command_test.go
@@ -303,9 +303,9 @@ var _ = Describe("Command Proxy", func() {
 
 	Describe("GET /sandboxes/{id}/commands/{cmdId}/stdout", func() {
 		It("proxies chunked byte stream", func() {
-			content := []byte("hello from command")
+			content := []byte("data: hello from command\nid: 17\n\n")
 			mockSidecar := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/octet-stream")
+				w.Header().Set("Content-Type", "text/event-stream")
 				w.Header().Set("Cache-Control", "no-cache")
 				w.Header().Set("X-Accel-Buffering", "no")
 				w.WriteHeader(http.StatusOK)
@@ -320,27 +320,40 @@ var _ = Describe("Command Proxy", func() {
 			resp := api.Get(fmt.Sprintf("/sandboxes/%s/commands/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/stdout", sbName))
 			Expect(resp.Code).To(Equal(http.StatusOK))
 			Expect(resp.Body.Bytes()).To(Equal(content))
-			Expect(resp.Header().Get("Content-Type")).To(Equal("application/octet-stream"))
+			Expect(resp.Header().Get("Content-Type")).To(Equal("text/event-stream"))
 			Expect(resp.Header().Get("X-Accel-Buffering")).To(Equal("no"))
 		})
 
-		It("forwards offset query param to sidecar", func() {
-			var capturedOffset string
+		It("forwards Last-Event-ID header to sidecar", func() {
+			var capturedLastEventID string
 			mockSidecar := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				capturedOffset = r.URL.Query().Get("offset")
-				w.Header().Set("Content-Type", "application/octet-stream")
+				capturedLastEventID = r.Header.Get("Last-Event-ID")
+				w.Header().Set("Content-Type", "text/event-stream")
 				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte("partial"))
+				_, _ = w.Write([]byte("data: partial\nid: 49\n\n"))
 			}))
 			defer mockSidecar.Close()
 
 			port := mockSidecar.Listener.Addr().(*net.TCPAddr).Port
-			api := newCommandTestAPI(&http.Client{}, port)
 			sbName := createRunningSandboxCR()
 
-			resp := api.Get(fmt.Sprintf("/sandboxes/%s/commands/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/stdout?offset=42", sbName))
-			Expect(resp.Code).To(Equal(http.StatusOK))
-			Expect(capturedOffset).To(Equal("42"))
+			handler, testAPI := humatest.New(GinkgoT(), huma.DefaultConfig("Test API", "0.1.0"))
+			h := New(
+				slog.New(slog.NewTextHandler(GinkgoWriter, nil)),
+				testNamespace,
+				k8sClient,
+				&http.Client{},
+			)
+			h.sidecarPort = port
+			Register(testAPI, h)
+
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/sandboxes/%s/commands/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/stdout", sbName), nil)
+			req.Header.Set("Last-Event-ID", "42")
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			Expect(capturedLastEventID).To(Equal("42"))
 		})
 	})
 
@@ -496,10 +509,10 @@ var _ = Describe("Command Proxy", func() {
 
 	Describe("GET /sandboxes/{id}/commands/{cmdId}/stderr", func() {
 		It("proxies stderr byte stream", func() {
-			content := []byte("error output here")
+			content := []byte("data: error output here\nid: 5\n\n")
 			mockSidecar := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				Expect(r.URL.Path).To(ContainSubstring("/stderr"))
-				w.Header().Set("Content-Type", "application/octet-stream")
+				w.Header().Set("Content-Type", "text/event-stream")
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write(content)
 			}))
@@ -514,23 +527,36 @@ var _ = Describe("Command Proxy", func() {
 			Expect(resp.Body.Bytes()).To(Equal(content))
 		})
 
-		It("forwards offset query param to sidecar", func() {
-			var capturedOffset string
+		It("forwards Last-Event-ID header to sidecar", func() {
+			var capturedLastEventID string
 			mockSidecar := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				capturedOffset = r.URL.Query().Get("offset")
-				w.Header().Set("Content-Type", "application/octet-stream")
+				capturedLastEventID = r.Header.Get("Last-Event-ID")
+				w.Header().Set("Content-Type", "text/event-stream")
 				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte("partial"))
+				_, _ = w.Write([]byte("data: partial\nid: 15\n\n"))
 			}))
 			defer mockSidecar.Close()
 
 			port := mockSidecar.Listener.Addr().(*net.TCPAddr).Port
-			api := newCommandTestAPI(&http.Client{}, port)
 			sbName := createRunningSandboxCR()
 
-			resp := api.Get(fmt.Sprintf("/sandboxes/%s/commands/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/stderr?offset=10", sbName))
-			Expect(resp.Code).To(Equal(http.StatusOK))
-			Expect(capturedOffset).To(Equal("10"))
+			handler, testAPI := humatest.New(GinkgoT(), huma.DefaultConfig("Test API", "0.1.0"))
+			h := New(
+				slog.New(slog.NewTextHandler(GinkgoWriter, nil)),
+				testNamespace,
+				k8sClient,
+				&http.Client{},
+			)
+			h.sidecarPort = port
+			Register(testAPI, h)
+
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/sandboxes/%s/commands/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/stderr", sbName), nil)
+			req.Header.Set("Last-Event-ID", "10")
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			Expect(capturedLastEventID).To(Equal("10"))
 		})
 	})
 

--- a/internal/sandbox-sidecar/command/command.go
+++ b/internal/sandbox-sidecar/command/command.go
@@ -47,7 +47,8 @@ import (
 const waitDelayGracePeriod = 5 * time.Second
 
 // sseKeepaliveInterval controls how often keepalive comments are sent on SSE streams
-// to prevent proxies from dropping idle connections.
+// to prevent proxies from dropping idle connections. 15s gives margin below typical
+// proxy idle timeouts (30-60s) while avoiding excessive overhead.
 const sseKeepaliveInterval = 15 * time.Second
 
 // CommandBuilder abstracts command construction for testability.

--- a/internal/sandbox-sidecar/command/command.go
+++ b/internal/sandbox-sidecar/command/command.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -37,12 +38,17 @@ import (
 	sandboxsidecar "github.com/isola-ai/isola/internal/sandbox-sidecar"
 	"github.com/isola-ai/isola/internal/sandbox-sidecar/proc"
 	sidecarapi "github.com/isola-ai/isola/internal/sidecar-api"
+	"github.com/isola-ai/isola/internal/sseutil"
 )
 
 // time cmd.Wait() has to drain before giving up
 // in our case, there should be nothing to drain
 // but it's a safety precaution for infinitely blocking after process kill
 const waitDelayGracePeriod = 5 * time.Second
+
+// sseKeepaliveInterval controls how often keepalive comments are sent on SSE streams
+// to prevent proxies from dropping idle connections.
+const sseKeepaliveInterval = 15 * time.Second
 
 // CommandBuilder abstracts command construction for testability.
 // The real implementation uses chroot via /proc/<pid>/root; tests use direct execution.
@@ -115,8 +121,8 @@ type GetCommandStatusOutput struct {
 }
 
 type GetCommandStreamInput struct {
-	CmdID  string `path:"cmdId" pattern:"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$" doc:"Command identifier"`
-	Offset int64  `query:"offset,omitempty" minimum:"0" doc:"Byte offset to resume from (default 0)"`
+	CmdID       string `path:"cmdId" pattern:"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$" doc:"Command identifier"`
+	LastEventID string `header:"Last-Event-ID" doc:"Byte offset to resume from (SSE Last-Event-ID)"`
 }
 
 type PostCommandStdinInput struct {
@@ -339,11 +345,33 @@ func (h *Handlers) GetCommandStatus(ctx context.Context, input *GetCommandStatus
 }
 
 func (h *Handlers) GetCommandStdout(_ context.Context, input *GetCommandStreamInput) (*huma.StreamResponse, error) {
-	return h.streamOutput(input.CmdID, input.Offset, "stdout")
+	offset, err := parseLastEventID(input.LastEventID)
+	if err != nil {
+		return nil, err
+	}
+	return h.streamOutput(input.CmdID, offset, "stdout")
 }
 
 func (h *Handlers) GetCommandStderr(_ context.Context, input *GetCommandStreamInput) (*huma.StreamResponse, error) {
-	return h.streamOutput(input.CmdID, input.Offset, "stderr")
+	offset, err := parseLastEventID(input.LastEventID)
+	if err != nil {
+		return nil, err
+	}
+	return h.streamOutput(input.CmdID, offset, "stderr")
+}
+
+func parseLastEventID(id string) (int64, error) {
+	if id == "" {
+		return 0, nil
+	}
+	offset, err := strconv.ParseInt(id, 10, 64)
+	if err != nil {
+		return 0, huma.Error400BadRequest(fmt.Sprintf("invalid Last-Event-ID header %q: %v", id, err))
+	}
+	if offset < 0 {
+		return 0, huma.Error400BadRequest(fmt.Sprintf("invalid Last-Event-ID header %q: must be non-negative", id))
+	}
+	return offset, nil
 }
 
 func (h *Handlers) streamOutput(cmdID string, offset int64, streamName string) (*huma.StreamResponse, error) {
@@ -356,8 +384,8 @@ func (h *Handlers) streamOutput(cmdID string, offset int64, streamName string) (
 
 	return &huma.StreamResponse{
 		Body: func(ctx huma.Context) {
-			ctx.SetHeader("Content-Type", "application/octet-stream")
-			// no-cache, since the stream change over time
+			ctx.SetHeader("Content-Type", "text/event-stream")
+			// no-cache, since the stream changes over time
 			// not ", private" in the context of the sandbox->api-gateway
 			ctx.SetHeader("Cache-Control", "no-cache")
 			// X-Accel-Buffering: no, disable nginx buffering (serve immediately)
@@ -382,44 +410,83 @@ func (h *Handlers) streamOutput(cmdID string, offset int64, streamName string) (
 			fw := httputil.NewTimedFlushWriter(dw, 100*time.Millisecond)
 			defer fw.Stop()
 
+			sse := sseutil.NewWriter(fw)
+			buf := make([]byte, 32*1024)
+			keepaliveTicker := time.NewTicker(sseKeepaliveInterval)
+			defer keepaliveTicker.Stop()
+
 			for {
-				written, err := io.Copy(fw, f)
-				if err != nil {
-					if isClientDisconnect(err) {
-						h.logger.Warn("client disconnected during command stream", "error", err, "cmdID", cmdID)
-					} else {
-						h.logger.Error("unexpected error streaming command output", "error", err, "cmdID", cmdID)
+				n, readErr := f.Read(buf)
+				if n > 0 {
+					offset += int64(n)
+					if werr := sse.WriteData(buf[:n], offset); werr != nil {
+						if isClientDisconnect(werr) {
+							h.logger.Warn("client disconnected during command stream", "error", werr, "cmdID", cmdID)
+						} else {
+							h.logger.Error("unexpected error streaming command output", "error", werr, "cmdID", cmdID)
+						}
+						return
 					}
-					return
-				}
-				eof := written == 0 && err == nil
-				if !eof {
+					keepaliveTicker.Reset(sseKeepaliveInterval)
 					continue
 				}
-				// EOF - check if process is done or wait for more data
+				if readErr != nil && readErr != io.EOF {
+					h.logger.Error("unexpected error reading command output", "error", readErr, "cmdID", cmdID)
+					return
+				}
+				// EOF — poll for more data or exit
 				select {
 				case <-entry.done:
-					// process exited; drain anything written between the read and the channel check
-					if _, err := io.Copy(fw, f); err != nil {
-						if isClientDisconnect(err) {
-							h.logger.Warn("client disconnected during command stream", "error", err, "cmdID", cmdID)
-						} else {
-							h.logger.Error("error during final drain of command output", "error", err, "cmdID", cmdID)
-						}
-					}
+					h.drainSSE(f, sse, buf, offset, cmdID)
 					return
 				case <-ctx.Context().Done():
 					h.logger.Warn("client disconnected during command stream", "cmdID", cmdID)
 					return
+				case <-keepaliveTicker.C:
+					if werr := sse.WriteKeepalive(); werr != nil {
+						if isClientDisconnect(werr) {
+							h.logger.Warn("client disconnected during command stream", "error", werr, "cmdID", cmdID)
+						} else {
+							h.logger.Error("unexpected error writing keepalive", "error", werr, "cmdID", cmdID)
+						}
+						return
+					}
 				default:
-					// we could have used inotify to watch writes to the file, but it would complicate the solution
-					// and introduce possible file descriptor saturation issues, and waking up a few times a second
-					// to poll the file isn't that bad nor we need ~0 latency on sudden writes to the file
 					time.Sleep(20 * time.Millisecond)
 				}
 			}
 		},
 	}, nil
+}
+
+// drainSSE reads remaining bytes from f after the process exits and writes them as SSE events.
+func (h *Handlers) drainSSE(f *os.File, sse *sseutil.Writer, buf []byte, offset int64, cmdID string) {
+	for {
+		n, readErr := f.Read(buf)
+		if n > 0 {
+			offset += int64(n)
+			if werr := sse.WriteData(buf[:n], offset); werr != nil {
+				if isClientDisconnect(werr) {
+					h.logger.Warn("client disconnected during command stream", "error", werr, "cmdID", cmdID)
+				} else {
+					h.logger.Error("error during final drain of command output", "error", werr, "cmdID", cmdID)
+				}
+				return
+			}
+		}
+		if readErr != nil {
+			if readErr != io.EOF {
+				h.logger.Error("error during final drain of command output", "error", readErr, "cmdID", cmdID)
+			}
+			// Flush any incomplete UTF-8 sequence
+			if ferr := sse.Flush(offset); ferr != nil {
+				if !isClientDisconnect(ferr) {
+					h.logger.Error("error flushing SSE writer", "error", ferr, "cmdID", cmdID)
+				}
+			}
+			return
+		}
+	}
 }
 
 func (h *Handlers) PostCommandStdin(_ context.Context, input *PostCommandStdinInput) (*struct{}, error) {
@@ -558,14 +625,14 @@ func Register(api huma.API, h *Handlers) {
 		Method:      http.MethodGet,
 		Path:        "/commands/{cmdId}/stdout",
 		Summary:     "Stream command stdout",
-		Description: "Streams the command's stdout as raw bytes. The connection remains open until the command exits. Supports resuming via ?offset=N query parameter.",
+		Description: "Streams the command's stdout as Server-Sent Events. The connection remains open until the command exits. Supports resuming via Last-Event-ID header.",
 		Tags:        []string{"commands"},
 		Responses: map[string]*huma.Response{
 			"200": {
 				Description: "Command stdout stream",
 				Content: map[string]*huma.MediaType{
-					"application/octet-stream": {
-						Schema: &huma.Schema{Type: "string", Format: "binary"},
+					"text/event-stream": {
+						Schema: &huma.Schema{Type: "string"},
 					},
 				},
 			},
@@ -578,14 +645,14 @@ func Register(api huma.API, h *Handlers) {
 		Method:      http.MethodGet,
 		Path:        "/commands/{cmdId}/stderr",
 		Summary:     "Stream command stderr",
-		Description: "Streams the command's stderr as raw bytes. The connection remains open until the command exits. Supports resuming via ?offset=N query parameter.",
+		Description: "Streams the command's stderr as Server-Sent Events. The connection remains open until the command exits. Supports resuming via Last-Event-ID header.",
 		Tags:        []string{"commands"},
 		Responses: map[string]*huma.Response{
 			"200": {
 				Description: "Command stderr stream",
 				Content: map[string]*huma.MediaType{
-					"application/octet-stream": {
-						Schema: &huma.Schema{Type: "string", Format: "binary"},
+					"text/event-stream": {
+						Schema: &huma.Schema{Type: "string"},
 					},
 				},
 			},

--- a/internal/sandbox-sidecar/command/command.go
+++ b/internal/sandbox-sidecar/command/command.go
@@ -477,7 +477,7 @@ func (h *Handlers) drainSSE(f *os.File, sse *sseutil.Writer, buf []byte, cmdID s
 			if readErr != io.EOF {
 				h.logger.Error("error during final drain of command output", "error", readErr, "cmdID", cmdID)
 			}
-			if ferr := sse.Flush(); ferr != nil {
+			if ferr := sse.Finish(); ferr != nil {
 				if !isClientDisconnect(ferr) {
 					h.logger.Error("error flushing SSE writer", "error", ferr, "cmdID", cmdID)
 				}

--- a/internal/sandbox-sidecar/command/command.go
+++ b/internal/sandbox-sidecar/command/command.go
@@ -411,7 +411,7 @@ func (h *Handlers) streamOutput(cmdID string, offset int64, streamName string) (
 			fw := httputil.NewTimedFlushWriter(dw, 100*time.Millisecond)
 			defer fw.Stop()
 
-			sse := sseutil.NewWriter(fw)
+			sse := sseutil.NewWriterAtOffset(fw, offset)
 			buf := make([]byte, 32*1024)
 			keepaliveTicker := time.NewTicker(sseKeepaliveInterval)
 			defer keepaliveTicker.Stop()
@@ -419,8 +419,7 @@ func (h *Handlers) streamOutput(cmdID string, offset int64, streamName string) (
 			for {
 				n, readErr := f.Read(buf)
 				if n > 0 {
-					offset += int64(n)
-					if werr := sse.WriteData(buf[:n], offset); werr != nil {
+					if werr := sse.WriteData(buf[:n]); werr != nil {
 						if isClientDisconnect(werr) {
 							h.logger.Warn("client disconnected during command stream", "error", werr, "cmdID", cmdID)
 						} else {
@@ -438,7 +437,7 @@ func (h *Handlers) streamOutput(cmdID string, offset int64, streamName string) (
 				// EOF — poll for more data or exit
 				select {
 				case <-entry.done:
-					h.drainSSE(f, sse, buf, offset, cmdID)
+					h.drainSSE(f, sse, buf, cmdID)
 					return
 				case <-ctx.Context().Done():
 					h.logger.Warn("client disconnected during command stream", "cmdID", cmdID)
@@ -461,12 +460,11 @@ func (h *Handlers) streamOutput(cmdID string, offset int64, streamName string) (
 }
 
 // drainSSE reads remaining bytes from f after the process exits and writes them as SSE events.
-func (h *Handlers) drainSSE(f *os.File, sse *sseutil.Writer, buf []byte, offset int64, cmdID string) {
+func (h *Handlers) drainSSE(f *os.File, sse *sseutil.Writer, buf []byte, cmdID string) {
 	for {
 		n, readErr := f.Read(buf)
 		if n > 0 {
-			offset += int64(n)
-			if werr := sse.WriteData(buf[:n], offset); werr != nil {
+			if werr := sse.WriteData(buf[:n]); werr != nil {
 				if isClientDisconnect(werr) {
 					h.logger.Warn("client disconnected during command stream", "error", werr, "cmdID", cmdID)
 				} else {
@@ -479,8 +477,7 @@ func (h *Handlers) drainSSE(f *os.File, sse *sseutil.Writer, buf []byte, offset 
 			if readErr != io.EOF {
 				h.logger.Error("error during final drain of command output", "error", readErr, "cmdID", cmdID)
 			}
-			// Flush any incomplete UTF-8 sequence
-			if ferr := sse.Flush(offset); ferr != nil {
+			if ferr := sse.Flush(); ferr != nil {
 				if !isClientDisconnect(ferr) {
 					h.logger.Error("error flushing SSE writer", "error", ferr, "cmdID", cmdID)
 				}

--- a/internal/sandbox-sidecar/command/command.go
+++ b/internal/sandbox-sidecar/command/command.go
@@ -416,6 +416,7 @@ func (h *Handlers) streamOutput(cmdID string, offset int64, streamName string) (
 			keepaliveTicker := time.NewTicker(sseKeepaliveInterval)
 			defer keepaliveTicker.Stop()
 
+			processDone := false
 			for {
 				n, readErr := f.Read(buf)
 				if n > 0 {
@@ -423,22 +424,34 @@ func (h *Handlers) streamOutput(cmdID string, offset int64, streamName string) (
 						if isClientDisconnect(werr) {
 							h.logger.Warn("client disconnected during command stream", "error", werr, "cmdID", cmdID)
 						} else {
-							h.logger.Error("unexpected error streaming command output", "error", werr, "cmdID", cmdID)
+							h.logger.Error("failed to write SSE data", "error", werr, "cmdID", cmdID)
 						}
 						return
 					}
 					keepaliveTicker.Reset(sseKeepaliveInterval)
-					continue
+					continue // tight loop while data is flowing
 				}
+
 				if readErr != nil && readErr != io.EOF {
-					h.logger.Error("unexpected error reading command output", "error", readErr, "cmdID", cmdID)
+					h.logger.Error("failed to read command output", "error", readErr, "cmdID", cmdID)
 					return
 				}
-				// EOF — poll for more data or exit
+
+				// EOF - no more data to read at this timee
+				if processDone {
+					if err := sse.Finish(); err != nil {
+						if isClientDisconnect(err) {
+							h.logger.Warn("client disconnected during command stream", "error", err, "cmdID", cmdID)
+						} else {
+							h.logger.Error("failed to finish SSE writer", "error", err, "cmdID", cmdID)
+						}
+					}
+					return
+				}
+
 				select {
 				case <-entry.done:
-					h.drainSSE(f, sse, buf, cmdID)
-					return
+					processDone = true
 				case <-ctx.Context().Done():
 					h.logger.Warn("client disconnected during command stream", "cmdID", cmdID)
 					return
@@ -447,7 +460,7 @@ func (h *Handlers) streamOutput(cmdID string, offset int64, streamName string) (
 						if isClientDisconnect(werr) {
 							h.logger.Warn("client disconnected during command stream", "error", werr, "cmdID", cmdID)
 						} else {
-							h.logger.Error("unexpected error writing keepalive", "error", werr, "cmdID", cmdID)
+							h.logger.Error("failed to write SSE keepalive", "error", werr, "cmdID", cmdID)
 						}
 						return
 					}
@@ -457,34 +470,6 @@ func (h *Handlers) streamOutput(cmdID string, offset int64, streamName string) (
 			}
 		},
 	}, nil
-}
-
-// drainSSE reads remaining bytes from f after the process exits and writes them as SSE events.
-func (h *Handlers) drainSSE(f *os.File, sse *sseutil.Writer, buf []byte, cmdID string) {
-	for {
-		n, readErr := f.Read(buf)
-		if n > 0 {
-			if werr := sse.WriteData(buf[:n]); werr != nil {
-				if isClientDisconnect(werr) {
-					h.logger.Warn("client disconnected during command stream", "error", werr, "cmdID", cmdID)
-				} else {
-					h.logger.Error("error during final drain of command output", "error", werr, "cmdID", cmdID)
-				}
-				return
-			}
-		}
-		if readErr != nil {
-			if readErr != io.EOF {
-				h.logger.Error("error during final drain of command output", "error", readErr, "cmdID", cmdID)
-			}
-			if ferr := sse.Finish(); ferr != nil {
-				if !isClientDisconnect(ferr) {
-					h.logger.Error("error flushing SSE writer", "error", ferr, "cmdID", cmdID)
-				}
-			}
-			return
-		}
-	}
 }
 
 func (h *Handlers) PostCommandStdin(_ context.Context, input *PostCommandStdinInput) (*struct{}, error) {

--- a/internal/sandbox-sidecar/command/command_test.go
+++ b/internal/sandbox-sidecar/command/command_test.go
@@ -37,6 +37,28 @@ import (
 	sidecarapi "github.com/isola-ai/isola/internal/sidecar-api"
 )
 
+// extractSSEData parses SSE events from a response body and returns the concatenated data.
+func extractSSEData(body string) string {
+	var result strings.Builder
+	var dataParts []string
+
+	for line := range strings.SplitSeq(body, "\n") {
+		switch {
+		case strings.HasPrefix(line, "data: "):
+			dataParts = append(dataParts, line[6:])
+		case line == "data:":
+			dataParts = append(dataParts, "")
+		case line == "":
+			if len(dataParts) > 0 {
+				result.WriteString(strings.Join(dataParts, "\n"))
+				dataParts = dataParts[:0]
+			}
+		}
+	}
+
+	return result.String()
+}
+
 var _ = Describe("Command Handlers", func() {
 	var (
 		commandAPI      humatest.TestAPI
@@ -214,7 +236,7 @@ var _ = Describe("Command Handlers", func() {
 
 			Eventually(func() string {
 				resp := commandAPI.Get(fmt.Sprintf("/commands/%s/stdout", result.CommandID))
-				return resp.Body.String()
+				return extractSSEData(resp.Body.String())
 			}).Should(Equal("hello world"))
 		})
 
@@ -224,36 +246,39 @@ var _ = Describe("Command Handlers", func() {
 
 			Eventually(func() string {
 				resp := commandAPI.Get(fmt.Sprintf("/commands/%s/stdout", result.CommandID))
-				return resp.Body.String()
+				return extractSSEData(resp.Body.String())
 			}).ShouldNot(BeEmpty())
 
 			resp := commandAPI.Get(fmt.Sprintf("/commands/%s/stdout", result.CommandID))
-			Expect(resp.Header().Get("Content-Type")).To(Equal("application/octet-stream"))
+			Expect(resp.Header().Get("Content-Type")).To(Equal("text/event-stream"))
 			Expect(resp.Header().Get("X-Accel-Buffering")).To(Equal("no"))
 			Expect(resp.Header().Get("Cache-Control")).To(Equal("no-cache"))
 		})
 
-		It("supports resume via offset", func() {
+		It("supports resume via Last-Event-ID", func() {
 			code, result := postCommand(`{"args": ["echo", "-n", "hello world"]}`)
 			Expect(code).To(Equal(http.StatusAccepted))
 
 			Eventually(func() string {
 				resp := commandAPI.Get(fmt.Sprintf("/commands/%s/stdout", result.CommandID))
-				return resp.Body.String()
+				return extractSSEData(resp.Body.String())
 			}).Should(Equal("hello world"))
 
-			resp := commandAPI.Get(fmt.Sprintf("/commands/%s/stdout?offset=6", result.CommandID))
-			Expect(resp.Body.String()).To(Equal("world"))
+			req := httptest.NewRequest("GET", fmt.Sprintf("/commands/%s/stdout", result.CommandID), nil)
+			req.Header.Set("Last-Event-ID", "6")
+			w := httptest.NewRecorder()
+			commandHandler.ServeHTTP(w, req)
+			Expect(extractSSEData(w.Body.String())).To(Equal("world"))
 		})
 
-		It("preserves binary data", func() {
-			code, result := postCommand(`{"args": ["/bin/sh", "-c", "printf 'a\\0b\\rc'"]}`)
+		It("replaces invalid UTF-8 with replacement character", func() {
+			code, result := postCommand(`{"args": ["/bin/sh", "-c", "printf 'a\\377b'"]}`)
 			Expect(code).To(Equal(http.StatusAccepted))
 
-			Eventually(func() []byte {
+			Eventually(func() string {
 				resp := commandAPI.Get(fmt.Sprintf("/commands/%s/stdout", result.CommandID))
-				return resp.Body.Bytes()
-			}).Should(Equal([]byte{'a', 0, 'b', '\r', 'c'}))
+				return extractSSEData(resp.Body.String())
+			}).Should(Equal("a\uFFFDb"))
 		})
 
 		It("returns 404 for unknown command", func() {
@@ -269,11 +294,11 @@ var _ = Describe("Command Handlers", func() {
 
 			Eventually(func() string {
 				resp := commandAPI.Get(fmt.Sprintf("/commands/%s/stderr", result.CommandID))
-				return resp.Body.String()
+				return extractSSEData(resp.Body.String())
 			}).Should(Equal("err"))
 
 			resp := commandAPI.Get(fmt.Sprintf("/commands/%s/stdout", result.CommandID))
-			Expect(resp.Body.String()).To(Equal("out"))
+			Expect(extractSSEData(resp.Body.String())).To(Equal("out"))
 		})
 	})
 
@@ -291,7 +316,7 @@ var _ = Describe("Command Handlers", func() {
 
 			Eventually(func() string {
 				resp := commandAPI.Get(fmt.Sprintf("/commands/%s/stdout", result.CommandID))
-				return resp.Body.String()
+				return extractSSEData(resp.Body.String())
 			}).Should(Equal("hello"))
 		})
 
@@ -335,7 +360,7 @@ var _ = Describe("Command Handlers", func() {
 
 			Eventually(func() string {
 				resp := commandAPI.Get(fmt.Sprintf("/commands/%s/stderr", result.CommandID))
-				return resp.Body.String()
+				return extractSSEData(resp.Body.String())
 			}).Should(Equal("ready"))
 
 			resp := commandAPI.Post(
@@ -400,7 +425,7 @@ var _ = Describe("Command Handlers", func() {
 
 			// Verify the data was echoed
 			resp = commandAPI.Get(fmt.Sprintf("/commands/%s/stdout", result.CommandID))
-			Expect(resp.Body.String()).To(Equal("hello"))
+			Expect(extractSSEData(resp.Body.String())).To(Equal("hello"))
 		})
 
 		It("returns 409 when closing already closed stdin", func() {
@@ -534,7 +559,7 @@ var _ = Describe("Command Handlers", func() {
 
 			// Output written before the kill should be preserved
 			resp := commandAPI.Get(fmt.Sprintf("/commands/%s/stdout", result.CommandID))
-			Expect(resp.Body.String()).To(Equal("before-timeout"))
+			Expect(extractSSEData(resp.Body.String())).To(Equal("before-timeout"))
 		})
 	})
 
@@ -554,7 +579,7 @@ var _ = Describe("Command Handlers", func() {
 			// Output should still be available
 			resp := commandAPI.Get(fmt.Sprintf("/commands/%s/stdout", result.CommandID))
 			Expect(resp.Code).To(Equal(http.StatusOK))
-			Expect(resp.Body.String()).To(Equal("fast"))
+			Expect(extractSSEData(resp.Body.String())).To(Equal("fast"))
 		})
 	})
 
@@ -576,7 +601,7 @@ var _ = Describe("Command Handlers", func() {
 
 			// The goroutine should complete once the process exits and the stream closes
 			Eventually(done, "2s").Should(BeClosed())
-			Expect(w.Body.String()).To(Equal("hello"))
+			Expect(extractSSEData(w.Body.String())).To(Equal("hello"))
 		})
 
 		It("stream delivers final output written just before exit", func() {
@@ -595,7 +620,7 @@ var _ = Describe("Command Handlers", func() {
 			}()
 
 			Eventually(done, "5s").Should(BeClosed())
-			Expect(w.Body.String()).To(Equal("final"))
+			Expect(extractSSEData(w.Body.String())).To(Equal("final"))
 		})
 
 		It("concurrent stdout and stderr streams both close on exit", func() {
@@ -624,8 +649,8 @@ var _ = Describe("Command Handlers", func() {
 
 			Eventually(stdoutDone, "2s").Should(BeClosed())
 			Eventually(stderrDone, "2s").Should(BeClosed())
-			Expect(stdoutW.Body.String()).To(Equal("out"))
-			Expect(stderrW.Body.String()).To(Equal("err"))
+			Expect(extractSSEData(stdoutW.Body.String())).To(Equal("out"))
+			Expect(extractSSEData(stderrW.Body.String())).To(Equal("err"))
 		})
 	})
 
@@ -703,7 +728,7 @@ var _ = Describe("Command Handlers", func() {
 		})
 	})
 
-	Describe("offset beyond file size", func() {
+	Describe("Last-Event-ID beyond file size", func() {
 		It("returns empty body when offset exceeds output size for exited command", func() {
 			code, result := postCommand(`{"args": ["echo", "-n", "short"]}`)
 			Expect(code).To(Equal(http.StatusAccepted))
@@ -715,9 +740,12 @@ var _ = Describe("Command Handlers", func() {
 				return status.ExitCode
 			}).ShouldNot(BeNil())
 
-			resp := commandAPI.Get(fmt.Sprintf("/commands/%s/stdout?offset=9999", result.CommandID))
-			Expect(resp.Code).To(Equal(http.StatusOK))
-			Expect(resp.Body.String()).To(BeEmpty())
+			req := httptest.NewRequest("GET", fmt.Sprintf("/commands/%s/stdout", result.CommandID), nil)
+			req.Header.Set("Last-Event-ID", "9999")
+			w := httptest.NewRecorder()
+			commandHandler.ServeHTTP(w, req)
+			Expect(w.Code).To(Equal(http.StatusOK))
+			Expect(extractSSEData(w.Body.String())).To(BeEmpty())
 		})
 	})
 
@@ -742,7 +770,7 @@ var _ = Describe("Command Handlers", func() {
 
 			Eventually(func() string {
 				resp := commandAPI.Get(fmt.Sprintf("/commands/%s/stdout", result.CommandID))
-				return resp.Body.String()
+				return extractSSEData(resp.Body.String())
 			}).Should(Equal("helloworld"))
 		})
 	})
@@ -785,7 +813,7 @@ var _ = Describe("Command Handlers", func() {
 
 			Eventually(func() string {
 				resp := commandAPI.Get(fmt.Sprintf("/commands/%s/stdout", result.CommandID))
-				return resp.Body.String()
+				return extractSSEData(resp.Body.String())
 			}).Should(Equal("hello world\nfoo  bar\na*b\n"))
 		})
 
@@ -798,7 +826,7 @@ var _ = Describe("Command Handlers", func() {
 
 			Eventually(func() string {
 				resp := commandAPI.Get(fmt.Sprintf("/commands/%s/stdout", result.CommandID))
-				return resp.Body.String()
+				return extractSSEData(resp.Body.String())
 			}).Should(Equal("via-path"))
 		})
 
@@ -830,7 +858,7 @@ var _ = Describe("Command Handlers", func() {
 
 			Eventually(func() string {
 				resp := commandAPI.Get(fmt.Sprintf("/commands/%s/stdout", result.CommandID))
-				return strings.TrimSpace(resp.Body.String())
+				return strings.TrimSpace(extractSSEData(resp.Body.String()))
 			}).Should(Equal("/tmp"))
 		})
 	})
@@ -842,7 +870,7 @@ var _ = Describe("Command Handlers", func() {
 
 			Eventually(func() string {
 				resp := commandAPI.Get(fmt.Sprintf("/commands/%s/stdout", result.CommandID))
-				return resp.Body.String()
+				return extractSSEData(resp.Body.String())
 			}).Should(Equal("hello"))
 		})
 
@@ -853,7 +881,7 @@ var _ = Describe("Command Handlers", func() {
 
 			Eventually(func() string {
 				resp := commandAPI.Get(fmt.Sprintf("/commands/%s/stdout", result.CommandID))
-				return resp.Body.String()
+				return extractSSEData(resp.Body.String())
 			}).Should(Equal("/root"))
 		})
 	})
@@ -877,7 +905,7 @@ var _ = Describe("Command Handlers", func() {
 			for _, c := range cmds {
 				Eventually(func() string {
 					resp := commandAPI.Get(fmt.Sprintf("/commands/%s/stdout", c.id))
-					return resp.Body.String()
+					return extractSSEData(resp.Body.String())
 				}).Should(Equal(c.want))
 			}
 		})
@@ -900,18 +928,21 @@ var _ = Describe("Command Handlers", func() {
 		})
 	})
 
-	Describe("stderr offset", func() {
-		It("supports resume via offset on stderr", func() {
+	Describe("stderr Last-Event-ID", func() {
+		It("supports resume via Last-Event-ID on stderr", func() {
 			code, result := postCommand(`{"args": ["/bin/sh", "-c", "echo -n 'hello world' >&2"]}`)
 			Expect(code).To(Equal(http.StatusAccepted))
 
 			Eventually(func() string {
 				resp := commandAPI.Get(fmt.Sprintf("/commands/%s/stderr", result.CommandID))
-				return resp.Body.String()
+				return extractSSEData(resp.Body.String())
 			}).Should(Equal("hello world"))
 
-			resp := commandAPI.Get(fmt.Sprintf("/commands/%s/stderr?offset=6", result.CommandID))
-			Expect(resp.Body.String()).To(Equal("world"))
+			req := httptest.NewRequest("GET", fmt.Sprintf("/commands/%s/stderr", result.CommandID), nil)
+			req.Header.Set("Last-Event-ID", "6")
+			w := httptest.NewRecorder()
+			commandHandler.ServeHTTP(w, req)
+			Expect(extractSSEData(w.Body.String())).To(Equal("world"))
 		})
 	})
 
@@ -950,7 +981,7 @@ var _ = Describe("Command Handlers", func() {
 			}, "5s").ShouldNot(BeNil())
 
 			resp := commandAPI.Get(fmt.Sprintf("/commands/%s/stdout", result.CommandID))
-			Expect(resp.Body.Len()).To(Equal(1024 * 1024))
+			Expect(extractSSEData(resp.Body.String())).To(HaveLen(1024 * 1024))
 		})
 	})
 
@@ -1002,7 +1033,7 @@ var _ = Describe("Command Handlers", func() {
 
 			Eventually(func() string {
 				resp := envFailAPI.Get(fmt.Sprintf("/commands/%s/stdout", result.CommandID))
-				return resp.Body.String()
+				return extractSSEData(resp.Body.String())
 			}).Should(Equal("ok"))
 		})
 	})

--- a/internal/sandbox-sidecar/command/command_test.go
+++ b/internal/sandbox-sidecar/command/command_test.go
@@ -285,6 +285,40 @@ var _ = Describe("Command Handlers", func() {
 			resp := commandAPI.Get("/commands/00000000-0000-0000-0000-000000000000/stdout")
 			Expect(resp.Code).To(Equal(http.StatusNotFound))
 		})
+
+		It("emits id: field with byte offset in each event", func() {
+			code, result := postCommand(`{"args": ["echo", "-n", "hello"]}`)
+			Expect(code).To(Equal(http.StatusAccepted))
+
+			var body string
+			Eventually(func() string {
+				resp := commandAPI.Get(fmt.Sprintf("/commands/%s/stdout", result.CommandID))
+				body = resp.Body.String()
+				return extractSSEData(body)
+			}).Should(Equal("hello"))
+
+			Expect(body).To(MatchRegexp(`(?m)^id: \d+$`))
+		})
+
+		It("preserves multiline output through SSE", func() {
+			code, result := postCommand(`{"args": ["printf", "line1\\nline2"]}`)
+			Expect(code).To(Equal(http.StatusAccepted))
+
+			Eventually(func() string {
+				resp := commandAPI.Get(fmt.Sprintf("/commands/%s/stdout", result.CommandID))
+				return extractSSEData(resp.Body.String())
+			}).Should(Equal("line1\nline2"))
+		})
+
+		It("preserves trailing newline in output", func() {
+			code, result := postCommand(`{"args": ["echo", "hello"]}`)
+			Expect(code).To(Equal(http.StatusAccepted))
+
+			Eventually(func() string {
+				resp := commandAPI.Get(fmt.Sprintf("/commands/%s/stdout", result.CommandID))
+				return extractSSEData(resp.Body.String())
+			}).Should(Equal("hello\n"))
+		})
 	})
 
 	Describe("GET /commands/{cmdId}/stderr", func() {

--- a/internal/sseutil/writer.go
+++ b/internal/sseutil/writer.go
@@ -15,17 +15,13 @@
 package sseutil
 
 import (
+	"bufio"
 	"io"
 	"strconv"
 	"unicode/utf8"
 )
 
-var (
-	dataPrefix = []byte("data: ")
-	idPrefix   = []byte("id: ")
-	newline    = []byte{'\n'}
-	keepalive  = []byte(": keepalive\n\n")
-)
+var keepalive = []byte(": keepalive\n\n")
 
 // Writer wraps an io.Writer and emits Server-Sent Events.
 //
@@ -36,14 +32,18 @@ var (
 // The writer performs incremental UTF-8 validation, replacing invalid byte
 // sequences with U+FFFD (�). Partial multi-byte sequences are buffered
 // across WriteData calls.
+//
+// All parts of an SSE event (data: lines, id: line, blank terminator)
+// are accumulated in a bufio.Writer and flushed as a single Write call
+// to minimize overhead through the deadline/flush writer chain.
 type Writer struct {
-	w   io.Writer
-	buf []byte // partial UTF-8 multi-byte sequence from previous WriteData call
+	w       *bufio.Writer
+	partial []byte // incomplete UTF-8 multi-byte sequence from previous WriteData call
 }
 
 // NewWriter creates a new SSE writer wrapping w.
 func NewWriter(w io.Writer) *Writer {
-	return &Writer{w: w}
+	return &Writer{w: bufio.NewWriter(w)}
 }
 
 // WriteData writes an SSE data event with the given raw bytes and byte offset as the event id.
@@ -58,14 +58,14 @@ func (w *Writer) WriteData(data []byte, offset int64) error {
 	}
 
 	// Prepend any buffered partial multi-byte sequence from previous call
-	if len(w.buf) > 0 {
-		data = append(w.buf, data...)
-		w.buf = w.buf[:0]
+	if len(w.partial) > 0 {
+		data = append(w.partial, data...)
+		w.partial = w.partial[:0]
 	}
 
 	// Check for incomplete UTF-8 sequence at end of data
 	if tail := incompleteUTF8Tail(data); tail > 0 {
-		w.buf = append(w.buf[:0], data[len(data)-tail:]...)
+		w.partial = append(w.partial[:0], data[len(data)-tail:]...)
 		data = data[:len(data)-tail]
 		if len(data) == 0 {
 			return nil
@@ -75,84 +75,66 @@ func (w *Writer) WriteData(data []byte, offset int64) error {
 	// Validate UTF-8, replacing invalid sequences with U+FFFD
 	validated := validateUTF8(data)
 
-	// Write data: lines by iterating through newlines inline (no slice allocation)
-	if err := w.writeDataLines(validated); err != nil {
-		return err
-	}
-
-	// Write the id and terminate the event
-	return w.writeID(offset)
+	// Write data: lines and id into the bufio buffer, then flush once
+	w.writeDataLines(validated)
+	w.writeID(offset)
+	return w.w.Flush()
 }
 
 // Flush writes any buffered partial UTF-8 sequence as U+FFFD replacement characters.
 // Call this when the stream ends to flush any incomplete multi-byte sequences.
 func (w *Writer) Flush(offset int64) error {
-	if len(w.buf) == 0 {
+	if len(w.partial) == 0 {
 		return nil
 	}
 	// Replace each byte of the incomplete sequence with U+FFFD
-	replacement := make([]byte, 0, len(w.buf)*3)
-	for range w.buf {
+	replacement := make([]byte, 0, len(w.partial)*3)
+	for range w.partial {
 		replacement = append(replacement, "\uFFFD"...)
 	}
-	w.buf = w.buf[:0]
+	w.partial = w.partial[:0]
 
-	if err := w.writeDataLine(string(replacement)); err != nil {
-		return err
-	}
-	return w.writeID(offset)
+	w.writeDataLine(string(replacement))
+	w.writeID(offset)
+	return w.w.Flush()
 }
 
 // WriteKeepalive writes an SSE comment line that keeps the connection alive
 // through intermediate infrastructure without being visible to SSE clients.
 func (w *Writer) WriteKeepalive() error {
-	_, err := w.w.Write(keepalive)
-	return err
+	w.w.Write(keepalive) //nolint:errcheck // error is sticky; returned by Flush
+	return w.w.Flush()
 }
 
-// writeDataLine writes a single "data: <line>\n".
-func (w *Writer) writeDataLine(line string) error {
-	if _, err := w.w.Write(dataPrefix); err != nil {
-		return err
-	}
-	if _, err := io.WriteString(w.w, line); err != nil {
-		return err
-	}
-	_, err := w.w.Write(newline)
-	return err
+// writeDataLine writes a single "data: <line>\n" into the buffer.
+func (w *Writer) writeDataLine(line string) {
+	w.w.WriteString("data: ") //nolint:errcheck // error is sticky; returned by Flush
+	w.w.WriteString(line)     //nolint:errcheck // error is sticky; returned by Flush
+	w.w.WriteByte('\n')       //nolint:errcheck // error is sticky; returned by Flush
 }
 
-// writeID writes "id: <offset>\n\n" to terminate an event.
-func (w *Writer) writeID(offset int64) error {
-	if _, err := w.w.Write(idPrefix); err != nil {
-		return err
-	}
-	if _, err := io.WriteString(w.w, strconv.FormatInt(offset, 10)); err != nil {
-		return err
-	}
-	if _, err := w.w.Write(newline); err != nil {
-		return err
-	}
-	_, err := w.w.Write(newline)
-	return err
+// writeID writes "id: <offset>\n\n" into the buffer.
+func (w *Writer) writeID(offset int64) {
+	w.w.WriteString("id: ")                        //nolint:errcheck // error is sticky; returned by Flush
+	w.w.WriteString(strconv.FormatInt(offset, 10)) //nolint:errcheck // error is sticky; returned by Flush
+	w.w.WriteString("\n\n")                        //nolint:errcheck // error is sticky; returned by Flush
 }
 
 // writeDataLines splits s on \n, \r\n, and bare \r into "data:" lines.
-// If s ends with a newline, an extra empty "data:" line is emitted so the
+// If s ends with a newline, an extra empty "data:" line is written so the
 // SSE parser's trailing-LF-stripping preserves it.
-func (w *Writer) writeDataLines(s string) error {
+func (w *Writer) writeDataLines(s string) {
 	for {
 		line, rest, hasNewline := nextChunk(s)
-		if err := w.writeDataLine(line); err != nil {
-			return err
-		}
+		w.writeDataLine(line)
 		if !hasNewline {
-			return nil
+			return
 		}
 		s = rest
 		if s == "" {
 			// Input ended with a newline — emit extra empty data: line
-			return w.writeDataLine("")
+			w.writeDataLine("")
+			return
 		}
 	}
 }

--- a/internal/sseutil/writer.go
+++ b/internal/sseutil/writer.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"io"
 	"strconv"
-	"strings"
 	"unicode/utf8"
 )
 
@@ -26,18 +25,13 @@ var keepalive = []byte(": keepalive\n\n")
 
 // Writer wraps an io.Writer and emits Server-Sent Events.
 //
-// Data events carry raw stdout/stderr text with an id: field for resume
-// via Last-Event-ID. Keepalive comments (": keepalive") keep connections
-// alive through intermediate infrastructure with idle timeouts.
-//
 // The writer performs incremental UTF-8 validation, replacing invalid byte
-// sequences with U+FFFD (�). Partial multi-byte sequences are buffered
+// sequences with U+FFFD. Partial multi-byte sequences are buffered
 // across WriteData calls.
 //
-// The writer owns byte-offset accounting for resumable streams. It only emits
-// ids for bytes whose effect is already visible to the client, buffering
-// ambiguous tails (for example an incomplete UTF-8 sequence or a trailing \r
-// that might become part of a later \r\n).
+// It only emits ids for bytes whose effect is already visible to the client,
+// buffering ambiguous tails (for example an incomplete UTF-8 sequence
+// or a trailing \r that might become part of a later \r\n).
 type Writer struct {
 	w       io.Writer
 	offset  int64
@@ -57,9 +51,6 @@ func NewWriterAtOffset(w io.Writer, offset int64) *Writer {
 // WriteData writes an SSE data event for the given raw bytes.
 // The data is validated as UTF-8 with invalid sequences replaced by U+FFFD.
 // Newlines (\n, \r\n, \r) split the payload into multiple data: lines per the SSE spec.
-// If the payload ends with a newline, an extra empty data: line is emitted so the
-// SSE parser's trailing-LF-stripping preserves it.
-// Zero-byte writes are ignored (no event emitted).
 func (w *Writer) WriteData(data []byte) error {
 	if len(data) == 0 {
 		return nil
@@ -67,41 +58,56 @@ func (w *Writer) WriteData(data []byte) error {
 
 	w.offset += int64(len(data))
 
-	combined := data
-	if len(w.pending) > 0 {
+	var combined []byte
+	if len(w.pending) == 0 {
+		combined = data
+	} else {
 		combined = make([]byte, 0, len(w.pending)+len(data))
 		combined = append(combined, w.pending...)
 		combined = append(combined, data...)
 	}
 
 	safeLen := safePrefixLen(combined)
-	w.pending = append(w.pending[:0], combined[safeLen:]...)
+	w.pending = append(w.pending[:0], combined[safeLen:]...) // pending unsafe suffix
 	if safeLen == 0 {
 		return nil
 	}
 
-	// Validate UTF-8, replacing invalid sequences with U+FFFD
-	validated := validateUTF8(combined[:safeLen])
+	sanitized := sanitizeUTF8(combined[:safeLen])
 
 	var event bytes.Buffer
-	writeDataLines(&event, validated)
+	writeDataLines(&event, sanitized)
 	writeID(&event, w.offset-int64(len(w.pending)))
 	_, err := w.w.Write(event.Bytes())
 	return err
 }
 
-// Flush writes any buffered tail bytes now that no future data can disambiguate them.
-func (w *Writer) Flush() error {
+// Finish finalizes any buffered tail bytes now that no future data can
+// disambiguate them. It does not close the underlying writer.
+//
+// Only call Finish when the input stream is genuinely complete (e.g. process
+// exited and all output drained). Calling it mid-stream replaces incomplete
+// UTF-8 tails with U+FFFD and commits the final byte offset as an SSE id.
+// A client resuming from that id would skip the real bytes, corrupting the
+// stream. On abnormal termination (client disconnect, write error), simply
+// discard the writer — the uncommitted pending bytes will be re-read on
+// the next resume.
+func (w *Writer) Finish() error {
 	if len(w.pending) == 0 {
 		return nil
 	}
 
 	tail := incompleteUTF8Tail(w.pending)
-	flushed := validateUTF8(w.pending[:len(w.pending)-tail]) + strings.Repeat("\uFFFD", tail)
+	sanitized := sanitizeUTF8(w.pending[:len(w.pending)-tail])
+	if tail > 0 {
+		// An unfinished UTF-8 prefix at end-of-stream is one maximal subpart and
+		// therefore becomes a single replacement character.
+		sanitized += "\uFFFD"
+	}
 	w.pending = w.pending[:0]
 
 	var event bytes.Buffer
-	writeDataLines(&event, flushed)
+	writeDataLines(&event, sanitized)
 	writeID(&event, w.offset)
 	_, err := w.w.Write(event.Bytes())
 	return err
@@ -129,8 +135,15 @@ func writeID(buf *bytes.Buffer, offset int64) {
 }
 
 // writeDataLines splits s on \n, \r\n, and bare \r into "data:" lines.
-// If s ends with a newline, an extra empty "data:" line is written so the
-// SSE parser's trailing-LF-stripping preserves it.
+//
+//	"hello"    -> data: hello
+//	"a\nb"     -> data: a / data: b
+//	"hello\n"  -> data: hello / data:
+//
+// The trailing-newline case matters: the SSE spec strips one trailing LF when
+// concatenating data fields, so the extra empty "data:" line preserves the
+// original \n. Without it the client receives "hello" instead of "hello\n",
+// which breaks byte-offset resume (resuming with Last-Event-ID header).
 func writeDataLines(buf *bytes.Buffer, s string) {
 	for {
 		line, rest, hasNewline := nextChunk(s)
@@ -139,16 +152,15 @@ func writeDataLines(buf *bytes.Buffer, s string) {
 			return
 		}
 		s = rest
-		if s == "" {
-			// Input ended with a newline — emit extra empty data: line
-			writeDataLine(buf, "")
-			return
-		}
 	}
 }
 
-// nextChunk returns the text before the first newline (\n, \r\n, or \r),
-// the remaining text after it, and whether a newline was found.
+// nextChunk splits s at the first newline (\n, \r\n, or \r).
+// Returns the text before it, the text after it, and whether one was found.
+//
+//	"a\nb"  -> ("a", "b", true)
+//	"a\r\n" -> ("a", "",  true)
+//	"hello" -> ("hello", "", false)
 func nextChunk(s string) (chunk, remaining string, hasNewline bool) {
 	for i := 0; i < len(s); i++ {
 		switch s[i] {
@@ -168,6 +180,8 @@ func nextChunk(s string) (chunk, remaining string, hasNewline bool) {
 // emitted immediately without advancing the resume offset past ambiguous bytes.
 func safePrefixLen(data []byte) int {
 	n := len(data) - incompleteUTF8Tail(data)
+	// SSE line endings are \r\n, \r or \n. If we got \r,
+	// we still don't know whether the next byte will be \n (ambiguous).
 	if n > 0 && data[n-1] == '\r' {
 		n--
 	}
@@ -190,21 +204,23 @@ func incompleteUTF8Tail(data []byte) int {
 	return 0
 }
 
-// validateUTF8 returns s with invalid UTF-8 sequences replaced by U+FFFD.
-func validateUTF8(data []byte) string {
+// sanitizeUTF8 returns s with invalid UTF-8 sequences replaced by U+FFFD.
+func sanitizeUTF8(data []byte) string {
 	if utf8.Valid(data) {
 		return string(data)
 	}
 
 	result := make([]byte, 0, len(data))
 	for len(data) > 0 {
-		r, size := utf8.DecodeRune(data)
-		if r == utf8.RuneError && size == 1 {
+		// DecodeRune unpacks the first UTF-8 encoding in p and returns the rune
+		firstRune, size := utf8.DecodeRune(data)
+		invalidEncoding := firstRune == utf8.RuneError && size == 1
+		if invalidEncoding {
 			result = append(result, "\uFFFD"...)
 		} else {
 			result = append(result, data[:size]...)
 		}
-		data = data[size:]
+		data = data[size:] // skip the handled rune for next iteration
 	}
 	return string(result)
 }

--- a/internal/sseutil/writer.go
+++ b/internal/sseutil/writer.go
@@ -1,0 +1,230 @@
+// Copyright The Isola Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sseutil
+
+import (
+	"io"
+	"strconv"
+	"unicode/utf8"
+)
+
+var (
+	dataPrefix = []byte("data: ")
+	idPrefix   = []byte("id: ")
+	newline    = []byte{'\n'}
+	keepalive  = []byte(": keepalive\n\n")
+)
+
+// Writer wraps an io.Writer and emits Server-Sent Events.
+//
+// Data events carry raw stdout/stderr text with an id: field for resume
+// via Last-Event-ID. Keepalive comments (": keepalive") keep connections
+// alive through intermediate infrastructure with idle timeouts.
+//
+// The writer performs incremental UTF-8 validation, replacing invalid byte
+// sequences with U+FFFD (�). Partial multi-byte sequences are buffered
+// across WriteData calls.
+type Writer struct {
+	w   io.Writer
+	buf []byte // partial UTF-8 multi-byte sequence from previous WriteData call
+}
+
+// NewWriter creates a new SSE writer wrapping w.
+func NewWriter(w io.Writer) *Writer {
+	return &Writer{w: w}
+}
+
+// WriteData writes an SSE data event with the given raw bytes and byte offset as the event id.
+// The data is validated as UTF-8 with invalid sequences replaced by U+FFFD.
+// Newlines (\n, \r\n, \r) split the payload into multiple data: lines per the SSE spec.
+// If the payload ends with a newline, an extra empty data: line is emitted so the
+// SSE parser's trailing-LF-stripping preserves it.
+// Zero-byte writes are ignored (no event emitted).
+func (w *Writer) WriteData(data []byte, offset int64) error {
+	if len(data) == 0 {
+		return nil
+	}
+
+	// Prepend any buffered partial multi-byte sequence from previous call
+	if len(w.buf) > 0 {
+		data = append(w.buf, data...)
+		w.buf = w.buf[:0]
+	}
+
+	// Check for incomplete UTF-8 sequence at end of data
+	if tail := incompleteUTF8Tail(data); tail > 0 {
+		w.buf = append(w.buf[:0], data[len(data)-tail:]...)
+		data = data[:len(data)-tail]
+		if len(data) == 0 {
+			return nil
+		}
+	}
+
+	// Validate UTF-8, replacing invalid sequences with U+FFFD
+	validated := validateUTF8(data)
+
+	// Write data: lines by iterating through newlines inline (no slice allocation)
+	if err := w.writeDataLines(validated); err != nil {
+		return err
+	}
+
+	// Write the id and terminate the event
+	return w.writeID(offset)
+}
+
+// Flush writes any buffered partial UTF-8 sequence as U+FFFD replacement characters.
+// Call this when the stream ends to flush any incomplete multi-byte sequences.
+func (w *Writer) Flush(offset int64) error {
+	if len(w.buf) == 0 {
+		return nil
+	}
+	// Replace each byte of the incomplete sequence with U+FFFD
+	replacement := make([]byte, 0, len(w.buf)*3)
+	for range w.buf {
+		replacement = append(replacement, "\uFFFD"...)
+	}
+	w.buf = w.buf[:0]
+
+	if err := w.writeDataLine(string(replacement)); err != nil {
+		return err
+	}
+	return w.writeID(offset)
+}
+
+// WriteKeepalive writes an SSE comment line that keeps the connection alive
+// through intermediate infrastructure without being visible to SSE clients.
+func (w *Writer) WriteKeepalive() error {
+	_, err := w.w.Write(keepalive)
+	return err
+}
+
+// writeDataLine writes a single "data: <line>\n".
+func (w *Writer) writeDataLine(line string) error {
+	if _, err := w.w.Write(dataPrefix); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w.w, line); err != nil {
+		return err
+	}
+	_, err := w.w.Write(newline)
+	return err
+}
+
+// writeID writes "id: <offset>\n\n" to terminate an event.
+func (w *Writer) writeID(offset int64) error {
+	if _, err := w.w.Write(idPrefix); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w.w, strconv.FormatInt(offset, 10)); err != nil {
+		return err
+	}
+	if _, err := w.w.Write(newline); err != nil {
+		return err
+	}
+	_, err := w.w.Write(newline)
+	return err
+}
+
+// writeDataLines splits s on \n, \r\n, and bare \r into "data:" lines.
+// If s ends with a newline, an extra empty "data:" line is emitted so the
+// SSE parser's trailing-LF-stripping preserves it.
+func (w *Writer) writeDataLines(s string) error {
+	for {
+		line, rest, hasNewline := nextChunk(s)
+		if err := w.writeDataLine(line); err != nil {
+			return err
+		}
+		if !hasNewline {
+			return nil
+		}
+		s = rest
+		if s == "" {
+			// Input ended with a newline — emit extra empty data: line
+			return w.writeDataLine("")
+		}
+	}
+}
+
+// nextChunk returns the text before the first newline (\n, \r\n, or \r),
+// the remaining text after it, and whether a newline was found.
+func nextChunk(s string) (chunk, remaining string, hasNewline bool) {
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '\n':
+			return s[:i], s[i+1:], true
+		case '\r':
+			if i+1 < len(s) && s[i+1] == '\n' {
+				return s[:i], s[i+2:], true
+			}
+			return s[:i], s[i+1:], true
+		}
+	}
+	return s, "", false
+}
+
+// incompleteUTF8Tail returns the number of bytes at the end of data that form
+// an incomplete multi-byte UTF-8 sequence. Returns 0 if the data ends with
+// complete sequences.
+func incompleteUTF8Tail(data []byte) int {
+	if len(data) == 0 {
+		return 0
+	}
+
+	// Check the last 1-3 bytes for a start byte without enough continuation bytes
+	for i := 1; i <= 3 && i <= len(data); i++ {
+		b := data[len(data)-i]
+		if b < 0x80 {
+			return 0
+		}
+		if b&0xC0 == 0xC0 {
+			var expected int
+			switch {
+			case b&0xE0 == 0xC0:
+				expected = 2
+			case b&0xF0 == 0xE0:
+				expected = 3
+			case b&0xF8 == 0xF0:
+				expected = 4
+			default:
+				return 0
+			}
+			if i < expected {
+				return i
+			}
+			return 0
+		}
+	}
+
+	return 0
+}
+
+// validateUTF8 returns s with invalid UTF-8 sequences replaced by U+FFFD.
+func validateUTF8(data []byte) string {
+	if utf8.Valid(data) {
+		return string(data)
+	}
+
+	result := make([]byte, 0, len(data))
+	for len(data) > 0 {
+		r, size := utf8.DecodeRune(data)
+		if r == utf8.RuneError && size == 1 {
+			result = append(result, "\uFFFD"...)
+		} else {
+			result = append(result, data[:size]...)
+		}
+		data = data[size:]
+	}
+	return string(result)
+}

--- a/internal/sseutil/writer.go
+++ b/internal/sseutil/writer.go
@@ -15,7 +15,7 @@
 package sseutil
 
 import (
-	"bufio"
+	"bytes"
 	"io"
 	"strconv"
 	"strings"
@@ -39,7 +39,7 @@ var keepalive = []byte(": keepalive\n\n")
 // ambiguous tails (for example an incomplete UTF-8 sequence or a trailing \r
 // that might become part of a later \r\n).
 type Writer struct {
-	w       *bufio.Writer
+	w       io.Writer
 	offset  int64
 	pending []byte // raw bytes withheld until they can be emitted with a stable resume offset
 }
@@ -51,7 +51,7 @@ func NewWriter(w io.Writer) *Writer {
 
 // NewWriterAtOffset creates a new SSE writer whose first event id starts at offset.
 func NewWriterAtOffset(w io.Writer, offset int64) *Writer {
-	return &Writer{w: bufio.NewWriter(w), offset: offset}
+	return &Writer{w: w, offset: offset}
 }
 
 // WriteData writes an SSE data event for the given raw bytes.
@@ -83,9 +83,11 @@ func (w *Writer) WriteData(data []byte) error {
 	// Validate UTF-8, replacing invalid sequences with U+FFFD
 	validated := validateUTF8(combined[:safeLen])
 
-	w.writeDataLines(validated)
-	w.writeID(w.offset - int64(len(w.pending)))
-	return w.w.Flush()
+	var event bytes.Buffer
+	writeDataLines(&event, validated)
+	writeID(&event, w.offset-int64(len(w.pending)))
+	_, err := w.w.Write(event.Bytes())
+	return err
 }
 
 // Flush writes any buffered tail bytes now that no future data can disambiguate them.
@@ -98,46 +100,48 @@ func (w *Writer) Flush() error {
 	flushed := validateUTF8(w.pending[:len(w.pending)-tail]) + strings.Repeat("\uFFFD", tail)
 	w.pending = w.pending[:0]
 
-	w.writeDataLines(flushed)
-	w.writeID(w.offset)
-	return w.w.Flush()
+	var event bytes.Buffer
+	writeDataLines(&event, flushed)
+	writeID(&event, w.offset)
+	_, err := w.w.Write(event.Bytes())
+	return err
 }
 
 // WriteKeepalive writes an SSE comment line that keeps the connection alive
 // through intermediate infrastructure without being visible to SSE clients.
 func (w *Writer) WriteKeepalive() error {
-	w.write(keepalive)
-	return w.w.Flush()
+	_, err := w.w.Write(keepalive)
+	return err
 }
 
 // writeDataLine writes a single "data: <line>\n" into the buffer.
-func (w *Writer) writeDataLine(line string) {
-	w.writeString("data: ")
-	w.writeString(line)
-	w.writeByte('\n')
+func writeDataLine(buf *bytes.Buffer, line string) {
+	buf.WriteString("data: ")
+	buf.WriteString(line)
+	buf.WriteByte('\n')
 }
 
 // writeID writes "id: <offset>\n\n" into the buffer.
-func (w *Writer) writeID(offset int64) {
-	w.writeString("id: ")
-	w.writeString(strconv.FormatInt(offset, 10))
-	w.writeString("\n\n")
+func writeID(buf *bytes.Buffer, offset int64) {
+	buf.WriteString("id: ")
+	buf.WriteString(strconv.FormatInt(offset, 10))
+	buf.WriteString("\n\n")
 }
 
 // writeDataLines splits s on \n, \r\n, and bare \r into "data:" lines.
 // If s ends with a newline, an extra empty "data:" line is written so the
 // SSE parser's trailing-LF-stripping preserves it.
-func (w *Writer) writeDataLines(s string) {
+func writeDataLines(buf *bytes.Buffer, s string) {
 	for {
 		line, rest, hasNewline := nextChunk(s)
-		w.writeDataLine(line)
+		writeDataLine(buf, line)
 		if !hasNewline {
 			return
 		}
 		s = rest
 		if s == "" {
 			// Input ended with a newline — emit extra empty data: line
-			w.writeDataLine("")
+			writeDataLine(buf, "")
 			return
 		}
 	}
@@ -158,20 +162,6 @@ func nextChunk(s string) (chunk, remaining string, hasNewline bool) {
 		}
 	}
 	return s, "", false
-}
-
-// bufio.Writer stores the first write error and returns it from Flush, so the
-// incremental writes below can safely ignore their direct return values.
-func (w *Writer) write(p []byte) {
-	_, _ = w.w.Write(p)
-}
-
-func (w *Writer) writeString(s string) {
-	_, _ = w.w.WriteString(s)
-}
-
-func (w *Writer) writeByte(b byte) {
-	_ = w.w.WriteByte(b)
 }
 
 // safePrefixLen returns the number of bytes at the start of data that can be

--- a/internal/sseutil/writer.go
+++ b/internal/sseutil/writer.go
@@ -106,22 +106,22 @@ func (w *Writer) Flush() error {
 // WriteKeepalive writes an SSE comment line that keeps the connection alive
 // through intermediate infrastructure without being visible to SSE clients.
 func (w *Writer) WriteKeepalive() error {
-	w.w.Write(keepalive) //nolint:errcheck // error is sticky; returned by Flush
+	w.write(keepalive)
 	return w.w.Flush()
 }
 
 // writeDataLine writes a single "data: <line>\n" into the buffer.
 func (w *Writer) writeDataLine(line string) {
-	w.w.WriteString("data: ") //nolint:errcheck // error is sticky; returned by Flush
-	w.w.WriteString(line)     //nolint:errcheck // error is sticky; returned by Flush
-	w.w.WriteByte('\n')       //nolint:errcheck // error is sticky; returned by Flush
+	w.writeString("data: ")
+	w.writeString(line)
+	w.writeByte('\n')
 }
 
 // writeID writes "id: <offset>\n\n" into the buffer.
 func (w *Writer) writeID(offset int64) {
-	w.w.WriteString("id: ")                        //nolint:errcheck // error is sticky; returned by Flush
-	w.w.WriteString(strconv.FormatInt(offset, 10)) //nolint:errcheck // error is sticky; returned by Flush
-	w.w.WriteString("\n\n")                        //nolint:errcheck // error is sticky; returned by Flush
+	w.writeString("id: ")
+	w.writeString(strconv.FormatInt(offset, 10))
+	w.writeString("\n\n")
 }
 
 // writeDataLines splits s on \n, \r\n, and bare \r into "data:" lines.
@@ -158,6 +158,20 @@ func nextChunk(s string) (chunk, remaining string, hasNewline bool) {
 		}
 	}
 	return s, "", false
+}
+
+// bufio.Writer stores the first write error and returns it from Flush, so the
+// incremental writes below can safely ignore their direct return values.
+func (w *Writer) write(p []byte) {
+	_, _ = w.w.Write(p)
+}
+
+func (w *Writer) writeString(s string) {
+	_, _ = w.w.WriteString(s)
+}
+
+func (w *Writer) writeByte(b byte) {
+	_ = w.w.WriteByte(b)
 }
 
 // safePrefixLen returns the number of bytes at the start of data that can be

--- a/internal/sseutil/writer.go
+++ b/internal/sseutil/writer.go
@@ -176,37 +176,17 @@ func nextChunk(s string) (chunk, remaining string, hasNewline bool) {
 
 // incompleteUTF8Tail returns the number of bytes at the end of data that form
 // an incomplete multi-byte UTF-8 sequence. Returns 0 if the data ends with
-// complete sequences.
+// complete sequences or only invalid bytes (which validateUTF8 handles).
 func incompleteUTF8Tail(data []byte) int {
-	if len(data) == 0 {
-		return 0
-	}
-
-	// Check the last 1-3 bytes for a start byte without enough continuation bytes
-	for i := 1; i <= 3 && i <= len(data); i++ {
-		b := data[len(data)-i]
-		if b < 0x80 {
+	for i := len(data) - 1; i >= 0 && i >= len(data)-3; i-- {
+		if !utf8.RuneStart(data[i]) {
+			continue
+		}
+		if utf8.FullRune(data[i:]) {
 			return 0
 		}
-		if b&0xC0 == 0xC0 {
-			var expected int
-			switch {
-			case b&0xE0 == 0xC0:
-				expected = 2
-			case b&0xF0 == 0xE0:
-				expected = 3
-			case b&0xF8 == 0xF0:
-				expected = 4
-			default:
-				return 0
-			}
-			if i < expected {
-				return i
-			}
-			return 0
-		}
+		return len(data) - i
 	}
-
 	return 0
 }
 

--- a/internal/sseutil/writer.go
+++ b/internal/sseutil/writer.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"io"
 	"strconv"
+	"strings"
 	"unicode/utf8"
 )
 
@@ -33,69 +34,72 @@ var keepalive = []byte(": keepalive\n\n")
 // sequences with U+FFFD (�). Partial multi-byte sequences are buffered
 // across WriteData calls.
 //
-// All parts of an SSE event (data: lines, id: line, blank terminator)
-// are accumulated in a bufio.Writer and flushed as a single Write call
-// to minimize overhead through the deadline/flush writer chain.
+// The writer owns byte-offset accounting for resumable streams. It only emits
+// ids for bytes whose effect is already visible to the client, buffering
+// ambiguous tails (for example an incomplete UTF-8 sequence or a trailing \r
+// that might become part of a later \r\n).
 type Writer struct {
 	w       *bufio.Writer
-	partial []byte // incomplete UTF-8 multi-byte sequence from previous WriteData call
+	offset  int64
+	pending []byte // raw bytes withheld until they can be emitted with a stable resume offset
 }
 
 // NewWriter creates a new SSE writer wrapping w.
 func NewWriter(w io.Writer) *Writer {
-	return &Writer{w: bufio.NewWriter(w)}
+	return NewWriterAtOffset(w, 0)
 }
 
-// WriteData writes an SSE data event with the given raw bytes and byte offset as the event id.
+// NewWriterAtOffset creates a new SSE writer whose first event id starts at offset.
+func NewWriterAtOffset(w io.Writer, offset int64) *Writer {
+	return &Writer{w: bufio.NewWriter(w), offset: offset}
+}
+
+// WriteData writes an SSE data event for the given raw bytes.
 // The data is validated as UTF-8 with invalid sequences replaced by U+FFFD.
 // Newlines (\n, \r\n, \r) split the payload into multiple data: lines per the SSE spec.
 // If the payload ends with a newline, an extra empty data: line is emitted so the
 // SSE parser's trailing-LF-stripping preserves it.
 // Zero-byte writes are ignored (no event emitted).
-func (w *Writer) WriteData(data []byte, offset int64) error {
+func (w *Writer) WriteData(data []byte) error {
 	if len(data) == 0 {
 		return nil
 	}
 
-	// Prepend any buffered partial multi-byte sequence from previous call
-	if len(w.partial) > 0 {
-		data = append(w.partial, data...)
-		w.partial = w.partial[:0]
+	w.offset += int64(len(data))
+
+	combined := data
+	if len(w.pending) > 0 {
+		combined = make([]byte, 0, len(w.pending)+len(data))
+		combined = append(combined, w.pending...)
+		combined = append(combined, data...)
 	}
 
-	// Check for incomplete UTF-8 sequence at end of data
-	if tail := incompleteUTF8Tail(data); tail > 0 {
-		w.partial = append(w.partial[:0], data[len(data)-tail:]...)
-		data = data[:len(data)-tail]
-		if len(data) == 0 {
-			return nil
-		}
+	safeLen := safePrefixLen(combined)
+	w.pending = append(w.pending[:0], combined[safeLen:]...)
+	if safeLen == 0 {
+		return nil
 	}
 
 	// Validate UTF-8, replacing invalid sequences with U+FFFD
-	validated := validateUTF8(data)
+	validated := validateUTF8(combined[:safeLen])
 
-	// Write data: lines and id into the bufio buffer, then flush once
 	w.writeDataLines(validated)
-	w.writeID(offset)
+	w.writeID(w.offset - int64(len(w.pending)))
 	return w.w.Flush()
 }
 
-// Flush writes any buffered partial UTF-8 sequence as U+FFFD replacement characters.
-// Call this when the stream ends to flush any incomplete multi-byte sequences.
-func (w *Writer) Flush(offset int64) error {
-	if len(w.partial) == 0 {
+// Flush writes any buffered tail bytes now that no future data can disambiguate them.
+func (w *Writer) Flush() error {
+	if len(w.pending) == 0 {
 		return nil
 	}
-	// Replace each byte of the incomplete sequence with U+FFFD
-	replacement := make([]byte, 0, len(w.partial)*3)
-	for range w.partial {
-		replacement = append(replacement, "\uFFFD"...)
-	}
-	w.partial = w.partial[:0]
 
-	w.writeDataLine(string(replacement))
-	w.writeID(offset)
+	tail := incompleteUTF8Tail(w.pending)
+	flushed := validateUTF8(w.pending[:len(w.pending)-tail]) + strings.Repeat("\uFFFD", tail)
+	w.pending = w.pending[:0]
+
+	w.writeDataLines(flushed)
+	w.writeID(w.offset)
 	return w.w.Flush()
 }
 
@@ -154,6 +158,16 @@ func nextChunk(s string) (chunk, remaining string, hasNewline bool) {
 		}
 	}
 	return s, "", false
+}
+
+// safePrefixLen returns the number of bytes at the start of data that can be
+// emitted immediately without advancing the resume offset past ambiguous bytes.
+func safePrefixLen(data []byte) int {
+	n := len(data) - incompleteUTF8Tail(data)
+	if n > 0 && data[n-1] == '\r' {
+		n--
+	}
+	return n
 }
 
 // incompleteUTF8Tail returns the number of bytes at the end of data that form

--- a/internal/sseutil/writer_test.go
+++ b/internal/sseutil/writer_test.go
@@ -337,7 +337,7 @@ func TestWriteData_TrailingCR(t *testing.T) {
 		t.Errorf("got %q, want %q", got, want)
 	}
 
-	if err := w.Flush(); err != nil {
+	if err := w.Finish(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -361,7 +361,7 @@ func TestWriteData_TrailingCRLF(t *testing.T) {
 	}
 }
 
-func TestFlush_IncompleteSequence(t *testing.T) {
+func TestFinish_IncompleteSequence(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 
@@ -373,7 +373,7 @@ func TestFlush_IncompleteSequence(t *testing.T) {
 		t.Errorf("expected empty output for partial multibyte, got %q", got)
 	}
 
-	if err := w.Flush(); err != nil {
+	if err := w.Finish(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -383,11 +383,34 @@ func TestFlush_IncompleteSequence(t *testing.T) {
 	}
 }
 
-func TestFlush_NothingBuffered(t *testing.T) {
+func TestFinish_IncompleteSequence_UsesSingleReplacementForMaximalSubpart(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 
-	if err := w.Flush(); err != nil {
+	// E4 B8 is a valid prefix of a 3-byte UTF-8 sequence, so at end-of-stream
+	// it is one unfinished sequence and should become one replacement character.
+	if err := w.WriteData([]byte{0xE4, 0xB8}); err != nil {
+		t.Fatal(err)
+	}
+	if got := buf.String(); got != "" {
+		t.Errorf("expected empty output for incomplete prefix, got %q", got)
+	}
+
+	if err := w.Finish(); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "data: \uFFFD\nid: 2\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFinish_NothingBuffered(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.Finish(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -773,6 +796,52 @@ func TestWriteData_KeepaliveDoesNotInterfereWithEvents(t *testing.T) {
 	want := "data: first\nid: 5\n\n: keepalive\n\ndata: second\nid: 11\n\n"
 	if got := buf.String(); got != want {
 		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteData_TrailingNewlineRoundTrip(t *testing.T) {
+	// Regression: trailing newline preservation is load-bearing for byte-offset
+	// resume. Without the extra empty "data:" line, the SSE parser strips the
+	// trailing \n, making the reconstructed data shorter than the byte offset
+	// reported in the id field. A resumed writer would then skip a byte the
+	// client never received, corrupting the stream.
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	// Simulate two stdout writes, each ending with \n (the common case).
+	if err := w.WriteData([]byte("line1\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.WriteData([]byte("line2\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	data := extractSSEData(buf.String())
+	ids := extractSSEIDs(buf.String())
+
+	// The round-tripped data must exactly match the original bytes.
+	if data != "line1\nline2\n" {
+		t.Fatalf("round-trip data = %q, want %q", data, "line1\nline2\n")
+	}
+
+	// The last id must equal the total byte count so a resumed writer
+	// picks up at the right position.
+	lastID := ids[len(ids)-1]
+	if lastID != "12" {
+		t.Fatalf("last id = %s, want 12", lastID)
+	}
+
+	// Simulate resume: a new writer at the last id writes more data.
+	var buf2 bytes.Buffer
+	w2 := NewWriterAtOffset(&buf2, 12)
+	if err := w2.WriteData([]byte("line3\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	// The combined reconstructed data must be the full original stream.
+	combined := data + extractSSEData(buf2.String())
+	if combined != "line1\nline2\nline3\n" {
+		t.Errorf("combined round-trip = %q, want %q", combined, "line1\nline2\nline3\n")
 	}
 }
 

--- a/internal/sseutil/writer_test.go
+++ b/internal/sseutil/writer_test.go
@@ -16,14 +16,47 @@ package sseutil
 
 import (
 	"bytes"
+	"slices"
+	"strings"
 	"testing"
 )
+
+func extractSSEData(body string) string {
+	var result strings.Builder
+	var dataParts []string
+
+	for line := range strings.SplitSeq(body, "\n") {
+		switch {
+		case strings.HasPrefix(line, "data: "):
+			dataParts = append(dataParts, line[6:])
+		case line == "data:":
+			dataParts = append(dataParts, "")
+		case line == "":
+			if len(dataParts) > 0 {
+				result.WriteString(strings.Join(dataParts, "\n"))
+				dataParts = dataParts[:0]
+			}
+		}
+	}
+
+	return result.String()
+}
+
+func extractSSEIDs(body string) []string {
+	var ids []string
+	for line := range strings.SplitSeq(body, "\n") {
+		if id, ok := strings.CutPrefix(line, "id: "); ok {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
 
 func TestWriteData_Simple(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 
-	if err := w.WriteData([]byte("hello world"), 11); err != nil {
+	if err := w.WriteData([]byte("hello world")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -37,7 +70,7 @@ func TestWriteData_Multiline(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 
-	if err := w.WriteData([]byte("line1\nline2"), 11); err != nil {
+	if err := w.WriteData([]byte("line1\nline2")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -52,7 +85,7 @@ func TestWriteData_TrailingNewline(t *testing.T) {
 	w := NewWriter(&buf)
 
 	// "hello\n" should produce data: hello\ndata: \n so the parser yields "hello\n"
-	if err := w.WriteData([]byte("hello\n"), 6); err != nil {
+	if err := w.WriteData([]byte("hello\n")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -66,7 +99,7 @@ func TestWriteData_CRLF(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 
-	if err := w.WriteData([]byte("a\r\nb"), 4); err != nil {
+	if err := w.WriteData([]byte("a\r\nb")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -80,7 +113,7 @@ func TestWriteData_BareCarriageReturn(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 
-	if err := w.WriteData([]byte("a\rb"), 3); err != nil {
+	if err := w.WriteData([]byte("a\rb")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -94,7 +127,7 @@ func TestWriteData_LeadingSpace(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 
-	if err := w.WriteData([]byte("  indented"), 10); err != nil {
+	if err := w.WriteData([]byte("  indented")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -109,7 +142,7 @@ func TestWriteData_EmptyLines(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 
-	if err := w.WriteData([]byte("a\n\nb"), 4); err != nil {
+	if err := w.WriteData([]byte("a\n\nb")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -123,7 +156,7 @@ func TestWriteData_ZeroByte(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 
-	if err := w.WriteData([]byte{}, 0); err != nil {
+	if err := w.WriteData([]byte{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -136,7 +169,7 @@ func TestWriteData_NilSlice(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 
-	if err := w.WriteData(nil, 0); err != nil {
+	if err := w.WriteData(nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -150,7 +183,7 @@ func TestWriteData_InvalidUTF8(t *testing.T) {
 	w := NewWriter(&buf)
 
 	// 0xFF is not a valid UTF-8 byte
-	if err := w.WriteData([]byte("hello\xffworld"), 11); err != nil {
+	if err := w.WriteData([]byte("hello\xffworld")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -165,22 +198,59 @@ func TestWriteData_SplitMultibyte(t *testing.T) {
 	w := NewWriter(&buf)
 
 	// é = 0xC3 0xA9 — split across two WriteData calls.
-	// The writer emits the valid prefix "caf" and buffers the incomplete 0xC3.
-	if err := w.WriteData([]byte("caf\xc3"), 4); err != nil {
+	// The writer emits the valid prefix "caf" but holds the resume id at byte 3
+	// until the buffered 0xC3 can be completed on a later write.
+	if err := w.WriteData([]byte("caf\xc3")); err != nil {
 		t.Fatal(err)
 	}
-	want1 := "data: caf\nid: 4\n\n"
+	want1 := "data: caf\nid: 3\n\n"
 	if got := buf.String(); got != want1 {
 		t.Errorf("after first write: got %q, want %q", got, want1)
 	}
 
-	if err := w.WriteData([]byte("\xa9!"), 6); err != nil {
+	if err := w.WriteData([]byte("\xa9!")); err != nil {
 		t.Fatal(err)
 	}
 
-	want := "data: caf\nid: 4\n\ndata: é!\nid: 6\n\n"
+	want := "data: caf\nid: 3\n\ndata: é!\nid: 6\n\n"
 	if got := buf.String(); got != want {
 		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteData_SplitMultibyteAtReadBoundary(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	// Simulate a 32 KiB file read that ends with the first byte of a 2-byte rune.
+	chunk := append(bytes.Repeat([]byte{'a'}, 32767), 0xC3)
+	if err := w.WriteData(chunk); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := extractSSEData(buf.String()); got != strings.Repeat("a", 32767) {
+		t.Errorf("got data len %d, want %d", len(got), 32767)
+	}
+	if got := extractSSEIDs(buf.String()); !slices.Equal(got, []string{"32767"}) {
+		t.Errorf("got ids %v, want [32767]", got)
+	}
+}
+
+func TestNewWriterAtOffset_ResumeFromSplitMultibyteBoundary(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriterAtOffset(&buf, 32767)
+
+	// Resume from the last committed byte and deliver the buffered rune plus the
+	// following ASCII byte as one event.
+	if err := w.WriteData([]byte{0xC3, 0xA9, '!'}); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := extractSSEData(buf.String()); got != "é!" {
+		t.Errorf("got data %q, want %q", got, "é!")
+	}
+	if got := extractSSEIDs(buf.String()); !slices.Equal(got, []string{"32770"}) {
+		t.Errorf("got ids %v, want [32770]", got)
 	}
 }
 
@@ -189,7 +259,7 @@ func TestWriteData_SplitMultibyte_OnlyPartial(t *testing.T) {
 	w := NewWriter(&buf)
 
 	// Write only the first byte of a 2-byte sequence — nothing should be emitted
-	if err := w.WriteData([]byte("\xc3"), 1); err != nil {
+	if err := w.WriteData([]byte("\xc3")); err != nil {
 		t.Fatal(err)
 	}
 	if got := buf.String(); got != "" {
@@ -197,7 +267,7 @@ func TestWriteData_SplitMultibyte_OnlyPartial(t *testing.T) {
 	}
 
 	// Complete the sequence
-	if err := w.WriteData([]byte("\xa9"), 2); err != nil {
+	if err := w.WriteData([]byte("\xa9")); err != nil {
 		t.Fatal(err)
 	}
 	want := "data: é\nid: 2\n\n"
@@ -224,10 +294,10 @@ func TestWriteData_OffsetTracking(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 
-	if err := w.WriteData([]byte("ab"), 2); err != nil {
+	if err := w.WriteData([]byte("ab")); err != nil {
 		t.Fatal(err)
 	}
-	if err := w.WriteData([]byte("cd"), 4); err != nil {
+	if err := w.WriteData([]byte("cd")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -237,17 +307,43 @@ func TestWriteData_OffsetTracking(t *testing.T) {
 	}
 }
 
+func TestNewWriterAtOffset(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriterAtOffset(&buf, 10)
+
+	if err := w.WriteData([]byte("ab")); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.WriteData([]byte("cd")); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "data: ab\nid: 12\n\ndata: cd\nid: 14\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestWriteData_TrailingCR(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 
-	if err := w.WriteData([]byte("hello\r"), 6); err != nil {
+	if err := w.WriteData([]byte("hello\r")); err != nil {
 		t.Fatal(err)
 	}
 
-	want := "data: hello\ndata: \nid: 6\n\n"
+	want := "data: hello\nid: 5\n\n"
 	if got := buf.String(); got != want {
 		t.Errorf("got %q, want %q", got, want)
+	}
+
+	if err := w.Flush(); err != nil {
+		t.Fatal(err)
+	}
+
+	want = "data: hello\nid: 5\n\ndata: \ndata: \nid: 6\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("after flush: got %q, want %q", got, want)
 	}
 }
 
@@ -255,7 +351,7 @@ func TestWriteData_TrailingCRLF(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 
-	if err := w.WriteData([]byte("hello\r\n"), 7); err != nil {
+	if err := w.WriteData([]byte("hello\r\n")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -270,14 +366,14 @@ func TestFlush_IncompleteSequence(t *testing.T) {
 	w := NewWriter(&buf)
 
 	// Buffer a partial multi-byte sequence
-	if err := w.WriteData([]byte("\xc3"), 1); err != nil {
+	if err := w.WriteData([]byte("\xc3")); err != nil {
 		t.Fatal(err)
 	}
 	if got := buf.String(); got != "" {
 		t.Errorf("expected empty output for partial multibyte, got %q", got)
 	}
 
-	if err := w.Flush(1); err != nil {
+	if err := w.Flush(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -291,7 +387,7 @@ func TestFlush_NothingBuffered(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 
-	if err := w.Flush(0); err != nil {
+	if err := w.Flush(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -304,10 +400,9 @@ func TestWriteData_NullByte(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 
-	// Null bytes are valid UTF-8 (U+0000) but the SSE spec says to replace them.
-	// However, per our plan, we only replace invalid UTF-8 sequences.
-	// Null bytes pass through as-is since they're valid UTF-8.
-	if err := w.WriteData([]byte("a\x00b"), 3); err != nil {
+	// U+0000 is allowed in SSE field values. The parser only rejects NUL inside
+	// id fields; data fields keep it as payload.
+	if err := w.WriteData([]byte("a\x00b")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -321,7 +416,7 @@ func TestWriteData_MultipleConsecutiveNewlines(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 
-	if err := w.WriteData([]byte("\n\n"), 2); err != nil {
+	if err := w.WriteData([]byte("\n\n")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -339,11 +434,11 @@ func TestWriteData_MixedNewlineStyles(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 
-	if err := w.WriteData([]byte("line1\nline2\r\nline3\rline4"), 23); err != nil {
+	if err := w.WriteData([]byte("line1\nline2\r\nline3\rline4")); err != nil {
 		t.Fatal(err)
 	}
 
-	want := "data: line1\ndata: line2\ndata: line3\ndata: line4\nid: 23\n\n"
+	want := "data: line1\ndata: line2\ndata: line3\ndata: line4\nid: 24\n\n"
 	if got := buf.String(); got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -355,7 +450,7 @@ func TestWriteData_DataContainingColons(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 
-	if err := w.WriteData([]byte("key: value"), 10); err != nil {
+	if err := w.WriteData([]byte("key: value")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -373,7 +468,7 @@ func TestWriteData_ParserSpaceStripping(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 
-	if err := w.WriteData([]byte(" x"), 2); err != nil {
+	if err := w.WriteData([]byte(" x")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -391,7 +486,7 @@ func TestWriteData_BOM(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 
-	if err := w.WriteData([]byte("\xEF\xBB\xBFhello"), 8); err != nil {
+	if err := w.WriteData([]byte("\xEF\xBB\xBFhello")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -405,7 +500,7 @@ func TestWriteData_StartsWithNewline(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 
-	if err := w.WriteData([]byte("\nhello"), 6); err != nil {
+	if err := w.WriteData([]byte("\nhello")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -419,7 +514,7 @@ func TestWriteData_OnlyNewline(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 
-	if err := w.WriteData([]byte("\n"), 1); err != nil {
+	if err := w.WriteData([]byte("\n")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -437,11 +532,11 @@ func TestWriteData_Emoji4Byte(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 
-	if err := w.WriteData([]byte("🎉🚀✨"), 13); err != nil {
+	if err := w.WriteData([]byte("🎉🚀✨")); err != nil {
 		t.Fatal(err)
 	}
 
-	want := "data: 🎉🚀✨\nid: 13\n\n"
+	want := "data: 🎉🚀✨\nid: 11\n\n"
 	if got := buf.String(); got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -452,7 +547,7 @@ func TestWriteData_CJK3Byte(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 
-	if err := w.WriteData([]byte("世界你好"), 12); err != nil {
+	if err := w.WriteData([]byte("世界你好")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -466,11 +561,11 @@ func TestWriteData_MixedASCIIAndMultibyte(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 
-	if err := w.WriteData([]byte("hello 世界!\n🎉 done"), 24); err != nil {
+	if err := w.WriteData([]byte("hello 世界!\n🎉 done")); err != nil {
 		t.Fatal(err)
 	}
 
-	want := "data: hello 世界!\ndata: 🎉 done\nid: 24\n\n"
+	want := "data: hello 世界!\ndata: 🎉 done\nid: 23\n\n"
 	if got := buf.String(); got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -495,11 +590,9 @@ func TestWriteData_Split4ByteEmoji(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
 			w := NewWriter(&buf)
-			offset := int64(0)
 
 			for _, part := range tc.splits {
-				offset += int64(len(part))
-				if err := w.WriteData(part, offset); err != nil {
+				if err := w.WriteData(part); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -530,11 +623,9 @@ func TestWriteData_Split3ByteCJK(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
 			w := NewWriter(&buf)
-			offset := int64(0)
 
 			for _, part := range tc.splits {
-				offset += int64(len(part))
-				if err := w.WriteData(part, offset); err != nil {
+				if err := w.WriteData(part); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -585,7 +676,7 @@ func TestWriteData_InvalidUTF8_Positions(t *testing.T) {
 			var buf bytes.Buffer
 			w := NewWriter(&buf)
 
-			if err := w.WriteData(tc.input, int64(len(tc.input))); err != nil {
+			if err := w.WriteData(tc.input); err != nil {
 				t.Fatal(err)
 			}
 
@@ -601,7 +692,7 @@ func TestWriteData_OverlongUTF8(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 
-	if err := w.WriteData([]byte("\xc0\xaf"), 2); err != nil {
+	if err := w.WriteData([]byte("\xc0\xaf")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -617,7 +708,7 @@ func TestWriteData_SurrogateHalf(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 
-	if err := w.WriteData([]byte("\xed\xa0\x80"), 3); err != nil {
+	if err := w.WriteData([]byte("\xed\xa0\x80")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -632,7 +723,7 @@ func TestWriteData_ValidMultibyteOnNewlineBoundary(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 
-	if err := w.WriteData([]byte("é\né"), 5); err != nil {
+	if err := w.WriteData([]byte("é\né")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -649,7 +740,7 @@ func TestWriteData_LargePayload(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 
-	if err := w.WriteData(large, int64(len(large))); err != nil {
+	if err := w.WriteData(large); err != nil {
 		t.Fatal(err)
 	}
 
@@ -669,13 +760,13 @@ func TestWriteData_KeepaliveDoesNotInterfereWithEvents(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 
-	if err := w.WriteData([]byte("first"), 5); err != nil {
+	if err := w.WriteData([]byte("first")); err != nil {
 		t.Fatal(err)
 	}
 	if err := w.WriteKeepalive(); err != nil {
 		t.Fatal(err)
 	}
-	if err := w.WriteData([]byte("second"), 11); err != nil {
+	if err := w.WriteData([]byte("second")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -686,21 +777,22 @@ func TestWriteData_KeepaliveDoesNotInterfereWithEvents(t *testing.T) {
 }
 
 func TestWriteData_CRLFAtBoundaryOfWrites(t *testing.T) {
-	// \r at end of one write, \n at start of next — they should NOT be
-	// treated as a single \r\n across calls (they're separate WriteData calls
-	// = separate events).
+	// The parser sees one continuous byte stream, not two logical records, so a
+	// trailing \r followed by a later \n still forms one CRLF line ending.
 	var buf bytes.Buffer
 	w := NewWriter(&buf)
 
-	if err := w.WriteData([]byte("hello\r"), 6); err != nil {
+	if err := w.WriteData([]byte("hello\r")); err != nil {
 		t.Fatal(err)
 	}
-	if err := w.WriteData([]byte("\nworld"), 12); err != nil {
+	if err := w.WriteData([]byte("\nworld")); err != nil {
 		t.Fatal(err)
 	}
 
-	want := "data: hello\ndata: \nid: 6\n\ndata: \ndata: world\nid: 12\n\n"
-	if got := buf.String(); got != want {
-		t.Errorf("got %q, want %q", got, want)
+	if got := extractSSEData(buf.String()); got != "hello\nworld" {
+		t.Errorf("got data %q, want %q", got, "hello\nworld")
+	}
+	if got := extractSSEIDs(buf.String()); !slices.Equal(got, []string{"5", "12"}) {
+		t.Errorf("got ids %v, want [5 12]", got)
 	}
 }

--- a/internal/sseutil/writer_test.go
+++ b/internal/sseutil/writer_test.go
@@ -1,0 +1,706 @@
+// Copyright The Isola Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sseutil
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestWriteData_Simple(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.WriteData([]byte("hello world"), 11); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "data: hello world\nid: 11\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteData_Multiline(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.WriteData([]byte("line1\nline2"), 11); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "data: line1\ndata: line2\nid: 11\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteData_TrailingNewline(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	// "hello\n" should produce data: hello\ndata: \n so the parser yields "hello\n"
+	if err := w.WriteData([]byte("hello\n"), 6); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "data: hello\ndata: \nid: 6\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteData_CRLF(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.WriteData([]byte("a\r\nb"), 4); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "data: a\ndata: b\nid: 4\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteData_BareCarriageReturn(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.WriteData([]byte("a\rb"), 3); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "data: a\ndata: b\nid: 3\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteData_LeadingSpace(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.WriteData([]byte("  indented"), 10); err != nil {
+		t.Fatal(err)
+	}
+
+	// Space after colon + data's leading spaces must be preserved
+	want := "data:   indented\nid: 10\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteData_EmptyLines(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.WriteData([]byte("a\n\nb"), 4); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "data: a\ndata: \ndata: b\nid: 4\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteData_ZeroByte(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.WriteData([]byte{}, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := buf.String(); got != "" {
+		t.Errorf("expected empty output for zero-byte write, got %q", got)
+	}
+}
+
+func TestWriteData_NilSlice(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.WriteData(nil, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := buf.String(); got != "" {
+		t.Errorf("expected empty output for nil write, got %q", got)
+	}
+}
+
+func TestWriteData_InvalidUTF8(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	// 0xFF is not a valid UTF-8 byte
+	if err := w.WriteData([]byte("hello\xffworld"), 11); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "data: hello\uFFFDworld\nid: 11\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteData_SplitMultibyte(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	// é = 0xC3 0xA9 — split across two WriteData calls.
+	// The writer emits the valid prefix "caf" and buffers the incomplete 0xC3.
+	if err := w.WriteData([]byte("caf\xc3"), 4); err != nil {
+		t.Fatal(err)
+	}
+	want1 := "data: caf\nid: 4\n\n"
+	if got := buf.String(); got != want1 {
+		t.Errorf("after first write: got %q, want %q", got, want1)
+	}
+
+	if err := w.WriteData([]byte("\xa9!"), 6); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "data: caf\nid: 4\n\ndata: é!\nid: 6\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteData_SplitMultibyte_OnlyPartial(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	// Write only the first byte of a 2-byte sequence — nothing should be emitted
+	if err := w.WriteData([]byte("\xc3"), 1); err != nil {
+		t.Fatal(err)
+	}
+	if got := buf.String(); got != "" {
+		t.Errorf("expected empty output for partial-only multibyte, got %q", got)
+	}
+
+	// Complete the sequence
+	if err := w.WriteData([]byte("\xa9"), 2); err != nil {
+		t.Fatal(err)
+	}
+	want := "data: é\nid: 2\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteKeepalive(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.WriteKeepalive(); err != nil {
+		t.Fatal(err)
+	}
+
+	want := ": keepalive\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteData_OffsetTracking(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.WriteData([]byte("ab"), 2); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.WriteData([]byte("cd"), 4); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "data: ab\nid: 2\n\ndata: cd\nid: 4\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteData_TrailingCR(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.WriteData([]byte("hello\r"), 6); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "data: hello\ndata: \nid: 6\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteData_TrailingCRLF(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.WriteData([]byte("hello\r\n"), 7); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "data: hello\ndata: \nid: 7\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFlush_IncompleteSequence(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	// Buffer a partial multi-byte sequence
+	if err := w.WriteData([]byte("\xc3"), 1); err != nil {
+		t.Fatal(err)
+	}
+	if got := buf.String(); got != "" {
+		t.Errorf("expected empty output for partial multibyte, got %q", got)
+	}
+
+	if err := w.Flush(1); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "data: \uFFFD\nid: 1\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFlush_NothingBuffered(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.Flush(0); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := buf.String(); got != "" {
+		t.Errorf("expected empty output for flush with nothing buffered, got %q", got)
+	}
+}
+
+func TestWriteData_NullByte(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	// Null bytes are valid UTF-8 (U+0000) but the SSE spec says to replace them.
+	// However, per our plan, we only replace invalid UTF-8 sequences.
+	// Null bytes pass through as-is since they're valid UTF-8.
+	if err := w.WriteData([]byte("a\x00b"), 3); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "data: a\x00b\nid: 3\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteData_MultipleConsecutiveNewlines(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.WriteData([]byte("\n\n"), 2); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "data: \ndata: \ndata: \nid: 2\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// --- Spec compliance tests (https://html.spec.whatwg.org/multipage/server-sent-events.html) ---
+
+func TestWriteData_MixedNewlineStyles(t *testing.T) {
+	// go-sse parser_test: "sarmale cu\nghimbir\r\nsunt\rsuper\n\ngenial sincer\r\n"
+	// All three newline styles (\n, \r\n, \r) must split into separate data: lines.
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.WriteData([]byte("line1\nline2\r\nline3\rline4"), 23); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "data: line1\ndata: line2\ndata: line3\ndata: line4\nid: 23\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteData_DataContainingColons(t *testing.T) {
+	// Per spec, the parser splits at the FIRST colon only.
+	// "data: key: value" → field name "data", value "key: value".
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.WriteData([]byte("key: value"), 10); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "data: key: value\nid: 10\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteData_ParserSpaceStripping(t *testing.T) {
+	// Spec: "If value starts with a U+0020 SPACE character, remove it from value."
+	// Our "data: " prefix provides the padding space that gets stripped.
+	// Data with a leading space should produce "data:  X" so the parser
+	// strips one space and preserves the original leading space.
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.WriteData([]byte(" x"), 2); err != nil {
+		t.Fatal(err)
+	}
+
+	// "data:  x" → parser strips first space → " x" ✓
+	want := "data:  x\nid: 2\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteData_BOM(t *testing.T) {
+	// U+FEFF BOM is valid UTF-8 (3 bytes: EF BB BF). It should pass through
+	// as regular data. The spec's BOM handling only applies to the stream start,
+	// not within data fields.
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.WriteData([]byte("\xEF\xBB\xBFhello"), 8); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "data: \uFEFFhello\nid: 8\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteData_StartsWithNewline(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.WriteData([]byte("\nhello"), 6); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "data: \ndata: hello\nid: 6\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteData_OnlyNewline(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.WriteData([]byte("\n"), 1); err != nil {
+		t.Fatal(err)
+	}
+
+	// "\n" → two data: lines (empty + empty for trailing newline preservation)
+	want := "data: \ndata: \nid: 1\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// --- UTF-8 edge cases ---
+
+func TestWriteData_Emoji4Byte(t *testing.T) {
+	// 🎉 = F0 9F 8E 89 (4-byte UTF-8)
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.WriteData([]byte("🎉🚀✨"), 13); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "data: 🎉🚀✨\nid: 13\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteData_CJK3Byte(t *testing.T) {
+	// CJK characters are 3-byte UTF-8 (U+4E16 = E4 B8 96, etc.)
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.WriteData([]byte("世界你好"), 12); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "data: 世界你好\nid: 12\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteData_MixedASCIIAndMultibyte(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.WriteData([]byte("hello 世界!\n🎉 done"), 24); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "data: hello 世界!\ndata: 🎉 done\nid: 24\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteData_Split4ByteEmoji(t *testing.T) {
+	// 🎉 = F0 9F 8E 89 — split across calls at every boundary
+	emoji := []byte{0xF0, 0x9F, 0x8E, 0x89}
+
+	tests := []struct {
+		name   string
+		splits [][]byte
+	}{
+		{"1+3", [][]byte{emoji[:1], emoji[1:]}},
+		{"2+2", [][]byte{emoji[:2], emoji[2:]}},
+		{"3+1", [][]byte{emoji[:3], emoji[3:]}},
+		{"1+1+1+1", [][]byte{emoji[:1], emoji[1:2], emoji[2:3], emoji[3:]}},
+		{"1+2+1", [][]byte{emoji[:1], emoji[1:3], emoji[3:]}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			offset := int64(0)
+
+			for _, part := range tc.splits {
+				offset += int64(len(part))
+				if err := w.WriteData(part, offset); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			got := buf.String()
+			// The final event must contain the complete emoji
+			if !bytes.Contains([]byte(got), []byte("🎉")) {
+				t.Errorf("emoji not found in output: %q", got)
+			}
+		})
+	}
+}
+
+func TestWriteData_Split3ByteCJK(t *testing.T) {
+	// 世 = E4 B8 96 — split across calls
+	char := []byte{0xE4, 0xB8, 0x96}
+
+	tests := []struct {
+		name   string
+		splits [][]byte
+	}{
+		{"1+2", [][]byte{char[:1], char[1:]}},
+		{"2+1", [][]byte{char[:2], char[2:]}},
+		{"1+1+1", [][]byte{char[:1], char[1:2], char[2:]}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+			offset := int64(0)
+
+			for _, part := range tc.splits {
+				offset += int64(len(part))
+				if err := w.WriteData(part, offset); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			got := buf.String()
+			if !bytes.Contains([]byte(got), []byte("世")) {
+				t.Errorf("CJK char not found in output: %q", got)
+			}
+		})
+	}
+}
+
+func TestWriteData_InvalidUTF8_Positions(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []byte
+		want  string
+	}{
+		{
+			"at start",
+			[]byte("\xffhello"),
+			"data: \uFFFDhello\nid: 6\n\n",
+		},
+		{
+			"at end",
+			[]byte("hello\xff"),
+			"data: hello\uFFFD\nid: 6\n\n",
+		},
+		{
+			"multiple consecutive",
+			[]byte("\xff\xfe\xfd"),
+			"data: \uFFFD\uFFFD\uFFFD\nid: 3\n\n",
+		},
+		{
+			"between valid multibyte",
+			[]byte("é\xffé"),
+			"data: é\uFFFDé\nid: 5\n\n",
+		},
+		{
+			"invalid continuation without start byte",
+			[]byte("\x80\x81\x82"),
+			"data: \uFFFD\uFFFD\uFFFD\nid: 3\n\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			w := NewWriter(&buf)
+
+			if err := w.WriteData(tc.input, int64(len(tc.input))); err != nil {
+				t.Fatal(err)
+			}
+
+			if got := buf.String(); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWriteData_OverlongUTF8(t *testing.T) {
+	// Overlong encoding of '/' (U+002F): C0 AF — must be rejected as invalid UTF-8
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.WriteData([]byte("\xc0\xaf"), 2); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "data: \uFFFD\uFFFD\nid: 2\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteData_SurrogateHalf(t *testing.T) {
+	// UTF-16 surrogate halves (U+D800..U+DFFF) are invalid in UTF-8.
+	// ED A0 80 = U+D800 encoded (invalid)
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.WriteData([]byte("\xed\xa0\x80"), 3); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "data: \uFFFD\uFFFD\uFFFD\nid: 3\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteData_ValidMultibyteOnNewlineBoundary(t *testing.T) {
+	// Multi-byte character immediately before and after a newline
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.WriteData([]byte("é\né"), 5); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "data: é\ndata: é\nid: 5\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteData_LargePayload(t *testing.T) {
+	// Inspired by go-sse parser_test: long string (5018 bytes)
+	// Ensure the writer handles large payloads without issues.
+	large := bytes.Repeat([]byte("abcdefghijklmnopqrstuvwxyz"), 193)
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.WriteData(large, int64(len(large))); err != nil {
+		t.Fatal(err)
+	}
+
+	got := buf.String()
+	wantPrefix := "data: "
+	wantSuffix := "\nid: 5018\n\n"
+	if !bytes.HasPrefix([]byte(got), []byte(wantPrefix)) {
+		t.Errorf("missing data: prefix")
+	}
+	if !bytes.HasSuffix([]byte(got), []byte(wantSuffix)) {
+		t.Errorf("missing id/terminator suffix, got suffix: %q", got[len(got)-20:])
+	}
+}
+
+func TestWriteData_KeepaliveDoesNotInterfereWithEvents(t *testing.T) {
+	// Interleave keepalive with data events
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.WriteData([]byte("first"), 5); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.WriteKeepalive(); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.WriteData([]byte("second"), 11); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "data: first\nid: 5\n\n: keepalive\n\ndata: second\nid: 11\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteData_CRLFAtBoundaryOfWrites(t *testing.T) {
+	// \r at end of one write, \n at start of next — they should NOT be
+	// treated as a single \r\n across calls (they're separate WriteData calls
+	// = separate events).
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.WriteData([]byte("hello\r"), 6); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.WriteData([]byte("\nworld"), 12); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "data: hello\ndata: \nid: 6\n\ndata: \ndata: world\nid: 12\n\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/internal/sseutil/writer_test.go
+++ b/internal/sseutil/writer_test.go
@@ -16,6 +16,7 @@ package sseutil
 
 import (
 	"bytes"
+	"errors"
 	"slices"
 	"strings"
 	"testing"
@@ -620,10 +621,11 @@ func TestWriteData_Split4ByteEmoji(t *testing.T) {
 				}
 			}
 
-			got := buf.String()
-			// The final event must contain the complete emoji
-			if !bytes.Contains([]byte(got), []byte("🎉")) {
-				t.Errorf("emoji not found in output: %q", got)
+			if got := extractSSEData(buf.String()); got != "🎉" {
+				t.Errorf("round-trip data = %q, want %q", got, "🎉")
+			}
+			if got := extractSSEIDs(buf.String()); got[len(got)-1] != "4" {
+				t.Errorf("last id = %s, want 4", got[len(got)-1])
 			}
 		})
 	}
@@ -653,9 +655,11 @@ func TestWriteData_Split3ByteCJK(t *testing.T) {
 				}
 			}
 
-			got := buf.String()
-			if !bytes.Contains([]byte(got), []byte("世")) {
-				t.Errorf("CJK char not found in output: %q", got)
+			if got := extractSSEData(buf.String()); got != "世" {
+				t.Errorf("round-trip data = %q, want %q", got, "世")
+			}
+			if got := extractSSEIDs(buf.String()); got[len(got)-1] != "3" {
+				t.Errorf("last id = %s, want 3", got[len(got)-1])
 			}
 		})
 	}
@@ -863,5 +867,40 @@ func TestWriteData_CRLFAtBoundaryOfWrites(t *testing.T) {
 	}
 	if got := extractSSEIDs(buf.String()); !slices.Equal(got, []string{"5", "12"}) {
 		t.Errorf("got ids %v, want [5 12]", got)
+	}
+}
+
+// errWriter returns a fixed error on every Write call.
+type errWriter struct{ err error }
+
+func (w *errWriter) Write([]byte) (int, error) { return 0, w.err }
+
+func TestWriteData_PropagatesWriteError(t *testing.T) {
+	want := errors.New("disk full")
+	w := NewWriter(&errWriter{want})
+
+	// WriteData with enough data to trigger a write (not just pending)
+	if err := w.WriteData([]byte("hello")); !errors.Is(err, want) {
+		t.Errorf("WriteData error = %v, want %v", err, want)
+	}
+}
+
+func TestFinish_PropagatesWriteError(t *testing.T) {
+	want := errors.New("broken pipe")
+	w := NewWriter(&errWriter{want})
+
+	// Buffer a partial UTF-8 sequence so Finish has something to flush
+	_ = w.WriteData([]byte("\xc3"))
+	if err := w.Finish(); !errors.Is(err, want) {
+		t.Errorf("Finish error = %v, want %v", err, want)
+	}
+}
+
+func TestWriteKeepalive_PropagatesWriteError(t *testing.T) {
+	want := errors.New("connection reset")
+	w := NewWriter(&errWriter{want})
+
+	if err := w.WriteKeepalive(); !errors.Is(err, want) {
+		t.Errorf("WriteKeepalive error = %v, want %v", err, want)
 	}
 }

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -11,6 +11,7 @@ license = { text = "Apache-2.0" }
 requires-python = ">=3.10"
 dependencies = [
     "httpx>=0.25.0",
+    "httpx-sse>=0.4.3",
     "pydantic>=2.0.0",
 ]
 

--- a/sdks/python/src/isola/_client.py
+++ b/sdks/python/src/isola/_client.py
@@ -137,12 +137,14 @@ class _SyncAPI:
         path: str,
         *,
         params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
         timeout: httpx.Timeout | float | None = None,
     ) -> AbstractContextManager[httpx.Response]:
         return self._client.stream(
             "GET",
             f"{self.base_url}{path}",
             params=params,
+            headers=headers,
             timeout=timeout,
         )
 
@@ -249,12 +251,14 @@ class _AsyncAPI:
         path: str,
         *,
         params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
         timeout: httpx.Timeout | float | None = None,
     ) -> AbstractAsyncContextManager[httpx.Response]:
         return self._client.stream(
             "GET",
             f"{self.base_url}{path}",
             params=params,
+            headers=headers,
             timeout=timeout,
         )
 

--- a/sdks/python/src/isola/_streaming.py
+++ b/sdks/python/src/isola/_streaming.py
@@ -15,13 +15,12 @@
 from __future__ import annotations
 
 import asyncio
-import codecs
-import contextlib
 import time
 from collections.abc import AsyncIterator, Generator, Iterator
 from typing import Any, Protocol
 
 import httpx
+from httpx_sse import EventSource
 
 from ._exceptions import APIError, connection_error_from_request, error_from_http, is_transient
 
@@ -57,16 +56,15 @@ class _AsyncStreamAPI(Protocol):
 class StreamReader:
     """Single-use iterable stream with transparent reconnect.
 
-    Parses SSE (Server-Sent Events) from the response. Data events carry
-    stdout/stderr text, with `id:` fields tracking byte offsets for resume
-    via the `Last-Event-ID` header. Comment lines (`: keepalive`) keep the
-    connection alive through intermediate infrastructure.
+    Delegates SSE parsing to httpx-sse. Data events carry stdout/stderr text,
+    with ``id:`` fields tracking byte offsets for resume via the
+    ``Last-Event-ID`` header.
     """
 
     def __init__(self, api: _SyncStreamAPI, path: str) -> None:
         self._api = api
         self._path = path
-        self._offset = 0
+        self._last_event_id = 0
         self._httpx_timeout = httpx.Timeout(
             connect=STREAM_CONNECT_TIMEOUT,
             read=None,
@@ -85,12 +83,11 @@ class StreamReader:
         return "".join(self)
 
     def _generate(self) -> Generator[str, None, None]:
-        decoder = codecs.getincrementaldecoder("utf-8")("replace")
         reconnects = 0
 
         while True:
             try:
-                headers = {"Last-Event-ID": str(self._offset)} if self._offset > 0 else None
+                headers = {"Last-Event-ID": str(self._last_event_id)} if self._last_event_id > 0 else None
                 with self._api.open_stream(
                     self._path,
                     headers=headers,
@@ -99,43 +96,12 @@ class StreamReader:
                     if response.status_code >= 400:
                         raise error_from_http(response.status_code, None, response.read())
 
-                    data_parts: list[str] = []
-                    event_id = ""
-                    buf = ""
-
-                    for chunk in response.iter_bytes():
-                        if not chunk:
-                            continue
-                        buf += decoder.decode(chunk)
-                        while "\n" in buf:
-                            line, buf = buf.split("\n", 1)
-                            line = line.rstrip("\r")
-                            if not line:
-                                # Empty line = event boundary
-                                if event_id:
-                                    with contextlib.suppress(ValueError):
-                                        self._offset = int(event_id)
-                                    event_id = ""
-                                if data_parts:
-                                    text = "\n".join(data_parts)
-                                    data_parts = []
-                                    reconnects = 0
-                                    if text:
-                                        yield text
-                            elif line.startswith(":"):
-                                pass  # comment (keepalive)
-                            else:
-                                name, _, value = line.partition(":")
-                                if value.startswith(" "):
-                                    value = value[1:]
-                                if name == "data":
-                                    data_parts.append(value)
-                                elif name == "id" and "\0" not in value:
-                                    event_id = value
-
-                    final = decoder.decode(b"", final=True)
-                    if final:
-                        buf += final
+                    for sse in EventSource(response).iter_sse():
+                        if sse.id:
+                            self._last_event_id = int(sse.id)
+                        if sse.data:
+                            reconnects = 0
+                            yield sse.data
 
                     return
 
@@ -153,16 +119,15 @@ class StreamReader:
 class AsyncStreamReader:
     """Single-use async iterable stream with transparent reconnect.
 
-    Parses SSE (Server-Sent Events) from the response. Data events carry
-    stdout/stderr text, with `id:` fields tracking byte offsets for resume
-    via the `Last-Event-ID` header. Comment lines (`: keepalive`) keep the
-    connection alive through intermediate infrastructure.
+    Delegates SSE parsing to httpx-sse. Data events carry stdout/stderr text,
+    with ``id:`` fields tracking byte offsets for resume via the
+    ``Last-Event-ID`` header.
     """
 
     def __init__(self, api: _AsyncStreamAPI, path: str) -> None:
         self._api = api
         self._path = path
-        self._offset = 0
+        self._last_event_id = 0
         self._httpx_timeout = httpx.Timeout(
             connect=STREAM_CONNECT_TIMEOUT,
             read=None,
@@ -176,12 +141,11 @@ class AsyncStreamReader:
             raise RuntimeError("AsyncStreamReader is single-use and has already been consumed")
         self._consumed = True
 
-        decoder = codecs.getincrementaldecoder("utf-8")("replace")
         reconnects = 0
 
         while True:
             try:
-                headers = {"Last-Event-ID": str(self._offset)} if self._offset > 0 else None
+                headers = {"Last-Event-ID": str(self._last_event_id)} if self._last_event_id > 0 else None
                 async with self._api.open_stream(
                     self._path,
                     headers=headers,
@@ -190,43 +154,12 @@ class AsyncStreamReader:
                     if response.status_code >= 400:
                         raise error_from_http(response.status_code, None, await response.aread())
 
-                    data_parts: list[str] = []
-                    event_id = ""
-                    buf = ""
-
-                    async for chunk in response.aiter_bytes():
-                        if not chunk:
-                            continue
-                        buf += decoder.decode(chunk)
-                        while "\n" in buf:
-                            line, buf = buf.split("\n", 1)
-                            line = line.rstrip("\r")
-                            if not line:
-                                # Empty line = event boundary
-                                if event_id:
-                                    with contextlib.suppress(ValueError):
-                                        self._offset = int(event_id)
-                                    event_id = ""
-                                if data_parts:
-                                    text = "\n".join(data_parts)
-                                    data_parts = []
-                                    reconnects = 0
-                                    if text:
-                                        yield text
-                            elif line.startswith(":"):
-                                pass  # comment (keepalive)
-                            else:
-                                name, _, value = line.partition(":")
-                                if value.startswith(" "):
-                                    value = value[1:]
-                                if name == "data":
-                                    data_parts.append(value)
-                                elif name == "id" and "\0" not in value:
-                                    event_id = value
-
-                    final = decoder.decode(b"", final=True)
-                    if final:
-                        buf += final
+                    async for sse in EventSource(response).aiter_sse():
+                        if sse.id:
+                            self._last_event_id = int(sse.id)
+                        if sse.data:
+                            reconnects = 0
+                            yield sse.data
 
                     return
 

--- a/sdks/python/src/isola/_streaming.py
+++ b/sdks/python/src/isola/_streaming.py
@@ -54,12 +54,7 @@ class _AsyncStreamAPI(Protocol):
 
 
 class StreamReader:
-    """Single-use iterable stream with transparent reconnect.
-
-    Delegates SSE parsing to httpx-sse. Data events carry stdout/stderr text,
-    with ``id:`` fields tracking byte offsets for resume via the
-    ``Last-Event-ID`` header.
-    """
+    """Single-use iterable stream with transparent reconnect."""
 
     def __init__(self, api: _SyncStreamAPI, path: str) -> None:
         self._api = api
@@ -67,7 +62,7 @@ class StreamReader:
         self._last_event_id = 0
         self._httpx_timeout = httpx.Timeout(
             connect=STREAM_CONNECT_TIMEOUT,
-            read=None,
+            read=None, # wait forever / until server error for data
             write=STREAM_WRITE_TIMEOUT,
             pool=STREAM_POOL_TIMEOUT,
         )
@@ -117,12 +112,8 @@ class StreamReader:
 
 
 class AsyncStreamReader:
-    """Single-use async iterable stream with transparent reconnect.
+    """Single-use async iterable stream with transparent reconnect."""
 
-    Delegates SSE parsing to httpx-sse. Data events carry stdout/stderr text,
-    with ``id:`` fields tracking byte offsets for resume via the
-    ``Last-Event-ID`` header.
-    """
 
     def __init__(self, api: _AsyncStreamAPI, path: str) -> None:
         self._api = api
@@ -130,7 +121,7 @@ class AsyncStreamReader:
         self._last_event_id = 0
         self._httpx_timeout = httpx.Timeout(
             connect=STREAM_CONNECT_TIMEOUT,
-            read=None,
+            read=None, # wait forever / until server error for data
             write=STREAM_WRITE_TIMEOUT,
             pool=STREAM_POOL_TIMEOUT,
         )

--- a/sdks/python/src/isola/_streaming.py
+++ b/sdks/python/src/isola/_streaming.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import codecs
+import contextlib
 import time
 from collections.abc import AsyncIterator, Generator, Iterator
 from typing import Any, Protocol
@@ -37,6 +38,7 @@ class _SyncStreamAPI(Protocol):
         path: str,
         *,
         params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
         timeout: httpx.Timeout | float | None = None,
     ) -> Any: ...
 
@@ -47,12 +49,19 @@ class _AsyncStreamAPI(Protocol):
         path: str,
         *,
         params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
         timeout: httpx.Timeout | float | None = None,
     ) -> Any: ...
 
 
 class StreamReader:
-    """Single-use iterable stream with transparent reconnect."""
+    """Single-use iterable stream with transparent reconnect.
+
+    Parses SSE (Server-Sent Events) from the response. Data events carry
+    stdout/stderr text, with `id:` fields tracking byte offsets for resume
+    via the `Last-Event-ID` header. Comment lines (`: keepalive`) keep the
+    connection alive through intermediate infrastructure.
+    """
 
     def __init__(self, api: _SyncStreamAPI, path: str) -> None:
         self._api = api
@@ -75,34 +84,58 @@ class StreamReader:
     def read(self) -> str:
         return "".join(self)
 
-    # todo benl: there's a big problem here - if server doesn't have anything to stream for a while (e.g. no stdout)
-    # will close the connections enough times to cause the stream to end without reading the whole stdout
     def _generate(self) -> Generator[str, None, None]:
         decoder = codecs.getincrementaldecoder("utf-8")("replace")
         reconnects = 0
 
         while True:
             try:
+                headers = {"Last-Event-ID": str(self._offset)} if self._offset > 0 else None
                 with self._api.open_stream(
                     self._path,
-                    params={"offset": self._offset},
+                    headers=headers,
                     timeout=self._httpx_timeout,
                 ) as response:
                     if response.status_code >= 400:
                         raise error_from_http(response.status_code, None, response.read())
 
+                    data_parts: list[str] = []
+                    event_id = ""
+                    buf = ""
+
                     for chunk in response.iter_bytes():
                         if not chunk:
                             continue
-                        self._offset += len(chunk)
-                        reconnects = 0
-                        decoded = decoder.decode(chunk)
-                        if decoded:
-                            yield decoded
+                        buf += decoder.decode(chunk)
+                        while "\n" in buf:
+                            line, buf = buf.split("\n", 1)
+                            line = line.rstrip("\r")
+                            if not line:
+                                # Empty line = event boundary
+                                if event_id:
+                                    with contextlib.suppress(ValueError):
+                                        self._offset = int(event_id)
+                                    event_id = ""
+                                if data_parts:
+                                    text = "\n".join(data_parts)
+                                    data_parts = []
+                                    reconnects = 0
+                                    if text:
+                                        yield text
+                            elif line.startswith(":"):
+                                pass  # comment (keepalive)
+                            else:
+                                name, _, value = line.partition(":")
+                                if value.startswith(" "):
+                                    value = value[1:]
+                                if name == "data":
+                                    data_parts.append(value)
+                                elif name == "id" and "\0" not in value:
+                                    event_id = value
 
                     final = decoder.decode(b"", final=True)
                     if final:
-                        yield final
+                        buf += final
 
                     return
 
@@ -118,7 +151,13 @@ class StreamReader:
 
 
 class AsyncStreamReader:
-    """Single-use async iterable stream with transparent reconnect."""
+    """Single-use async iterable stream with transparent reconnect.
+
+    Parses SSE (Server-Sent Events) from the response. Data events carry
+    stdout/stderr text, with `id:` fields tracking byte offsets for resume
+    via the `Last-Event-ID` header. Comment lines (`: keepalive`) keep the
+    connection alive through intermediate infrastructure.
+    """
 
     def __init__(self, api: _AsyncStreamAPI, path: str) -> None:
         self._api = api
@@ -142,26 +181,52 @@ class AsyncStreamReader:
 
         while True:
             try:
+                headers = {"Last-Event-ID": str(self._offset)} if self._offset > 0 else None
                 async with self._api.open_stream(
                     self._path,
-                    params={"offset": self._offset},
+                    headers=headers,
                     timeout=self._httpx_timeout,
                 ) as response:
                     if response.status_code >= 400:
                         raise error_from_http(response.status_code, None, await response.aread())
 
+                    data_parts: list[str] = []
+                    event_id = ""
+                    buf = ""
+
                     async for chunk in response.aiter_bytes():
                         if not chunk:
                             continue
-                        self._offset += len(chunk)
-                        reconnects = 0
-                        decoded = decoder.decode(chunk)
-                        if decoded:
-                            yield decoded
+                        buf += decoder.decode(chunk)
+                        while "\n" in buf:
+                            line, buf = buf.split("\n", 1)
+                            line = line.rstrip("\r")
+                            if not line:
+                                # Empty line = event boundary
+                                if event_id:
+                                    with contextlib.suppress(ValueError):
+                                        self._offset = int(event_id)
+                                    event_id = ""
+                                if data_parts:
+                                    text = "\n".join(data_parts)
+                                    data_parts = []
+                                    reconnects = 0
+                                    if text:
+                                        yield text
+                            elif line.startswith(":"):
+                                pass  # comment (keepalive)
+                            else:
+                                name, _, value = line.partition(":")
+                                if value.startswith(" "):
+                                    value = value[1:]
+                                if name == "data":
+                                    data_parts.append(value)
+                                elif name == "id" and "\0" not in value:
+                                    event_id = value
 
                     final = decoder.decode(b"", final=True)
                     if final:
-                        yield final
+                        buf += final
 
                     return
 

--- a/sdks/python/tests/test_commands.py
+++ b/sdks/python/tests/test_commands.py
@@ -135,7 +135,7 @@ def test_run_returns_command_result(sandbox_response_copy: dict[str, object]) ->
     )
     respx.get(url__regex=r".*/commands/cmd-1/status.*").mock(return_value=httpx.Response(200, json={"exitCode": 0}))
     respx.get("http://localhost:8080/sandboxes/sandbox-123/commands/cmd-1/stdout").mock(
-        return_value=httpx.Response(200, content=b"hello world\n")
+        return_value=httpx.Response(200, content=b"data: hello world\ndata: \nid: 12\n\n")
     )
     respx.get("http://localhost:8080/sandboxes/sandbox-123/commands/cmd-1/stderr").mock(
         return_value=httpx.Response(200, content=b"")
@@ -159,8 +159,8 @@ def test_command_stdout_streams_text(sandbox_response_copy: dict[str, object]) -
     respx.post("http://localhost:8080/sandboxes/sandbox-123/commands").mock(
         return_value=httpx.Response(202, json={"commandId": "cmd-1"})
     )
-    stdout_route = respx.get("http://localhost:8080/sandboxes/sandbox-123/commands/cmd-1/stdout").mock(
-        return_value=httpx.Response(200, content=b"hello world\n")
+    respx.get("http://localhost:8080/sandboxes/sandbox-123/commands/cmd-1/stdout").mock(
+        return_value=httpx.Response(200, content=b"data: hello world\ndata: \nid: 12\n\n")
     )
 
     with Isola(base_url="http://localhost:8080") as client:
@@ -169,7 +169,6 @@ def test_command_stdout_streams_text(sandbox_response_copy: dict[str, object]) -
         output = "".join(cmd.stdout)
 
     assert output == "hello world\n"
-    assert stdout_route.calls[0].request.url.params["offset"] == "0"
 
 
 @respx.mock
@@ -180,8 +179,8 @@ def test_command_stderr_streams_text(sandbox_response_copy: dict[str, object]) -
     respx.post("http://localhost:8080/sandboxes/sandbox-123/commands").mock(
         return_value=httpx.Response(202, json={"commandId": "cmd-2"})
     )
-    stderr_route = respx.get("http://localhost:8080/sandboxes/sandbox-123/commands/cmd-2/stderr").mock(
-        return_value=httpx.Response(200, content=b"error output\n")
+    respx.get("http://localhost:8080/sandboxes/sandbox-123/commands/cmd-2/stderr").mock(
+        return_value=httpx.Response(200, content=b"data: error output\ndata: \nid: 13\n\n")
     )
 
     with Isola(base_url="http://localhost:8080") as client:
@@ -190,7 +189,6 @@ def test_command_stderr_streams_text(sandbox_response_copy: dict[str, object]) -
         output = "".join(cmd.stderr)
 
     assert output == "error output\n"
-    assert stderr_route.calls[0].request.url.params["offset"] == "0"
 
 
 @pytest.mark.asyncio
@@ -203,7 +201,7 @@ async def test_async_command_stdout_streams_text(sandbox_response_copy: dict[str
         return_value=httpx.Response(202, json={"commandId": "cmd-4"})
     )
     respx.get("http://localhost:8080/sandboxes/sandbox-123/commands/cmd-4/stdout").mock(
-        return_value=httpx.Response(200, content=b"async output\n")
+        return_value=httpx.Response(200, content=b"data: async output\ndata: \nid: 13\n\n")
     )
 
     async with AsyncIsola(base_url="http://localhost:8080") as client:
@@ -225,7 +223,7 @@ def test_command_stdout_text_mode_default(sandbox_response_copy: dict[str, objec
         return_value=httpx.Response(202, json={"commandId": "cmd-text"})
     )
     respx.get("http://localhost:8080/sandboxes/sandbox-123/commands/cmd-text/stdout").mock(
-        return_value=httpx.Response(200, content=b"hello text\n")
+        return_value=httpx.Response(200, content=b"data: hello text\ndata: \nid: 11\n\n")
     )
 
     with Isola(base_url="http://localhost:8080") as client:
@@ -339,7 +337,7 @@ async def test_async_run_returns_command_result(sandbox_response_copy: dict[str,
     )
     respx.get(url__regex=r".*/commands/cmd-ar/status.*").mock(return_value=httpx.Response(200, json={"exitCode": 0}))
     respx.get("http://localhost:8080/sandboxes/sandbox-123/commands/cmd-ar/stdout").mock(
-        return_value=httpx.Response(200, content=b"async result\n")
+        return_value=httpx.Response(200, content=b"data: async result\ndata: \nid: 13\n\n")
     )
     respx.get("http://localhost:8080/sandboxes/sandbox-123/commands/cmd-ar/stderr").mock(
         return_value=httpx.Response(200, content=b"")
@@ -391,7 +389,7 @@ def test_run_with_input(sandbox_response_copy: dict[str, object]) -> None:
     )
     respx.get(url__regex=r".*/commands/cmd-input/status.*").mock(return_value=httpx.Response(200, json={"exitCode": 0}))
     respx.get("http://localhost:8080/sandboxes/sandbox-123/commands/cmd-input/stdout").mock(
-        return_value=httpx.Response(200, content=b"hello\n")
+        return_value=httpx.Response(200, content=b"data: hello\ndata: \nid: 6\n\n")
     )
     respx.get("http://localhost:8080/sandboxes/sandbox-123/commands/cmd-input/stderr").mock(
         return_value=httpx.Response(200, content=b"")

--- a/sdks/python/tests/test_commands.py
+++ b/sdks/python/tests/test_commands.py
@@ -135,10 +135,12 @@ def test_run_returns_command_result(sandbox_response_copy: dict[str, object]) ->
     )
     respx.get(url__regex=r".*/commands/cmd-1/status.*").mock(return_value=httpx.Response(200, json={"exitCode": 0}))
     respx.get("http://localhost:8080/sandboxes/sandbox-123/commands/cmd-1/stdout").mock(
-        return_value=httpx.Response(200, content=b"data: hello world\ndata: \nid: 12\n\n")
+        return_value=httpx.Response(
+            200, content=b"data: hello world\ndata: \nid: 12\n\n", headers={"content-type": "text/event-stream"}
+        )
     )
     respx.get("http://localhost:8080/sandboxes/sandbox-123/commands/cmd-1/stderr").mock(
-        return_value=httpx.Response(200, content=b"")
+        return_value=httpx.Response(200, content=b"", headers={"content-type": "text/event-stream"})
     )
 
     with Isola(base_url="http://localhost:8080") as client:
@@ -160,7 +162,9 @@ def test_command_stdout_streams_text(sandbox_response_copy: dict[str, object]) -
         return_value=httpx.Response(202, json={"commandId": "cmd-1"})
     )
     respx.get("http://localhost:8080/sandboxes/sandbox-123/commands/cmd-1/stdout").mock(
-        return_value=httpx.Response(200, content=b"data: hello world\ndata: \nid: 12\n\n")
+        return_value=httpx.Response(
+            200, content=b"data: hello world\ndata: \nid: 12\n\n", headers={"content-type": "text/event-stream"}
+        )
     )
 
     with Isola(base_url="http://localhost:8080") as client:
@@ -180,7 +184,9 @@ def test_command_stderr_streams_text(sandbox_response_copy: dict[str, object]) -
         return_value=httpx.Response(202, json={"commandId": "cmd-2"})
     )
     respx.get("http://localhost:8080/sandboxes/sandbox-123/commands/cmd-2/stderr").mock(
-        return_value=httpx.Response(200, content=b"data: error output\ndata: \nid: 13\n\n")
+        return_value=httpx.Response(
+            200, content=b"data: error output\ndata: \nid: 13\n\n", headers={"content-type": "text/event-stream"}
+        )
     )
 
     with Isola(base_url="http://localhost:8080") as client:
@@ -201,7 +207,9 @@ async def test_async_command_stdout_streams_text(sandbox_response_copy: dict[str
         return_value=httpx.Response(202, json={"commandId": "cmd-4"})
     )
     respx.get("http://localhost:8080/sandboxes/sandbox-123/commands/cmd-4/stdout").mock(
-        return_value=httpx.Response(200, content=b"data: async output\ndata: \nid: 13\n\n")
+        return_value=httpx.Response(
+            200, content=b"data: async output\ndata: \nid: 13\n\n", headers={"content-type": "text/event-stream"}
+        )
     )
 
     async with AsyncIsola(base_url="http://localhost:8080") as client:
@@ -223,7 +231,9 @@ def test_command_stdout_text_mode_default(sandbox_response_copy: dict[str, objec
         return_value=httpx.Response(202, json={"commandId": "cmd-text"})
     )
     respx.get("http://localhost:8080/sandboxes/sandbox-123/commands/cmd-text/stdout").mock(
-        return_value=httpx.Response(200, content=b"data: hello text\ndata: \nid: 11\n\n")
+        return_value=httpx.Response(
+            200, content=b"data: hello text\ndata: \nid: 11\n\n", headers={"content-type": "text/event-stream"}
+        )
     )
 
     with Isola(base_url="http://localhost:8080") as client:
@@ -337,10 +347,12 @@ async def test_async_run_returns_command_result(sandbox_response_copy: dict[str,
     )
     respx.get(url__regex=r".*/commands/cmd-ar/status.*").mock(return_value=httpx.Response(200, json={"exitCode": 0}))
     respx.get("http://localhost:8080/sandboxes/sandbox-123/commands/cmd-ar/stdout").mock(
-        return_value=httpx.Response(200, content=b"data: async result\ndata: \nid: 13\n\n")
+        return_value=httpx.Response(
+            200, content=b"data: async result\ndata: \nid: 13\n\n", headers={"content-type": "text/event-stream"}
+        )
     )
     respx.get("http://localhost:8080/sandboxes/sandbox-123/commands/cmd-ar/stderr").mock(
-        return_value=httpx.Response(200, content=b"")
+        return_value=httpx.Response(200, content=b"", headers={"content-type": "text/event-stream"})
     )
 
     async with AsyncIsola(base_url="http://localhost:8080") as client:
@@ -389,10 +401,12 @@ def test_run_with_input(sandbox_response_copy: dict[str, object]) -> None:
     )
     respx.get(url__regex=r".*/commands/cmd-input/status.*").mock(return_value=httpx.Response(200, json={"exitCode": 0}))
     respx.get("http://localhost:8080/sandboxes/sandbox-123/commands/cmd-input/stdout").mock(
-        return_value=httpx.Response(200, content=b"data: hello\ndata: \nid: 6\n\n")
+        return_value=httpx.Response(
+            200, content=b"data: hello\ndata: \nid: 6\n\n", headers={"content-type": "text/event-stream"}
+        )
     )
     respx.get("http://localhost:8080/sandboxes/sandbox-123/commands/cmd-input/stderr").mock(
-        return_value=httpx.Response(200, content=b"")
+        return_value=httpx.Response(200, content=b"", headers={"content-type": "text/event-stream"})
     )
 
     with Isola(base_url="http://localhost:8080") as client:

--- a/sdks/python/tests/test_streaming.py
+++ b/sdks/python/tests/test_streaming.py
@@ -22,22 +22,30 @@ import pytest
 from isola import APIConnectionError, IsolaError, NotFoundError
 from isola._streaming import MAX_RECONNECTS, AsyncStreamReader, StreamReader
 
+_SSE_HEADERS: dict[str, str] = {"content-type": "text/event-stream"}
 
-def _sse_event(data: str, event_id: int) -> bytes:
-    """Format a single SSE data event as wire bytes."""
+
+def _sse_event(data: str, event_id: int) -> str:
+    """Format a single SSE data event as wire text."""
     lines = [f"data: {line}" for line in data.split("\n")]
     lines.append(f"id: {event_id}")
     lines.append("")  # blank line terminates event
-    return ("\n".join(lines) + "\n").encode("utf-8")
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
 
 
 class _FakeSyncResponse:
-    def __init__(self, chunks: list[bytes], *, raise_after: Exception | None = None, status_code: int = 200) -> None:
+    def __init__(self, chunks: list[str], *, raise_after: Exception | None = None, status_code: int = 200) -> None:
         self.status_code = status_code
+        self.headers = _SSE_HEADERS
         self._chunks = chunks
         self._raise_after = raise_after
 
-    def iter_bytes(self) -> Iterator[bytes]:
+    def iter_text(self) -> Iterator[str]:
         yield from self._chunks
         if self._raise_after is not None:
             raise self._raise_after
@@ -81,12 +89,13 @@ class _FakeSyncAPI:
 
 
 class _FakeAsyncResponse:
-    def __init__(self, chunks: list[bytes], *, raise_after: Exception | None = None, status_code: int = 200) -> None:
+    def __init__(self, chunks: list[str], *, raise_after: Exception | None = None, status_code: int = 200) -> None:
         self.status_code = status_code
+        self.headers = _SSE_HEADERS
         self._chunks = chunks
         self._raise_after = raise_after
 
-    async def aiter_bytes(self) -> AsyncIterator[bytes]:
+    async def aiter_text(self) -> AsyncIterator[str]:
         for chunk in self._chunks:
             yield chunk
         if self._raise_after is not None:
@@ -130,406 +139,25 @@ class _FakeAsyncAPI:
         return self._sequence.pop(0)
 
 
-# --- Reconnect tests ---
+# ---------------------------------------------------------------------------
+# Sync: core behavior
+# ---------------------------------------------------------------------------
 
 
-def test_sync_stream_reconnects_and_resumes_offset(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("isola._streaming.time.sleep", lambda _: None)
+def test_sync_stream_yields_data() -> None:
+    api = _FakeSyncAPI([_FakeSyncCM(_FakeSyncResponse([_sse_event("hello ", 6), _sse_event("world", 11)]))])
 
-    api = _FakeSyncAPI(
-        [
-            _FakeSyncCM(_FakeSyncResponse([_sse_event("ab", 2)], raise_after=httpx.ConnectError("disconnect"))),
-            _FakeSyncCM(_FakeSyncResponse([_sse_event("cd", 4)])),
-        ]
-    )
+    assert list(StreamReader(api, "/path")) == ["hello ", "world"]
 
-    stream = StreamReader(api, "/sandboxes/s-1/commands/c-1/stdout")
 
-    output = "".join(stream)
+def test_sync_stream_read() -> None:
+    api = _FakeSyncAPI([_FakeSyncCM(_FakeSyncResponse([_sse_event("hello ", 6), _sse_event("world", 11)]))])
 
-    assert output == "abcd"
-    assert api.calls == [0, 2]
+    assert StreamReader(api, "/path").read() == "hello world"
 
 
-@pytest.mark.parametrize(
-    "error",
-    [
-        httpx.ConnectError("connection refused"),
-        httpx.ReadError("server dropped"),
-        httpx.WriteError("broken pipe"),
-        httpx.CloseError("close failed"),
-        httpx.ConnectTimeout("connect timed out"),
-        httpx.ProxyError("proxy down"),
-    ],
-    ids=["ConnectError", "ReadError", "WriteError", "CloseError", "ConnectTimeout", "ProxyError"],
-)
-def test_sync_stream_reconnects_on_network_error(monkeypatch: pytest.MonkeyPatch, error: Exception) -> None:
-    monkeypatch.setattr("isola._streaming.time.sleep", lambda _: None)
-
-    api = _FakeSyncAPI(
-        [
-            _FakeSyncCM(_FakeSyncResponse([_sse_event("ab", 2)], raise_after=error)),
-            _FakeSyncCM(_FakeSyncResponse([_sse_event("cd", 4)])),
-        ]
-    )
-
-    stream = StreamReader(api, "/sandboxes/s-1/commands/c-1/stdout")
-
-    output = "".join(stream)
-
-    assert output == "abcd"
-    assert api.calls == [0, 2]
-
-
-@pytest.mark.asyncio
-async def test_async_stream_reconnects_and_resumes_offset(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def _no_sleep(_seconds: float) -> None:
-        return None
-
-    monkeypatch.setattr("isola._streaming.asyncio.sleep", _no_sleep)
-
-    api = _FakeAsyncAPI(
-        [
-            _FakeAsyncCM(_FakeAsyncResponse([_sse_event("a", 1)], raise_after=httpx.ConnectError("disconnect"))),
-            _FakeAsyncCM(_FakeAsyncResponse([_sse_event("b", 2), _sse_event("c", 3)])),
-        ]
-    )
-
-    stream = AsyncStreamReader(api, "/sandboxes/s-1/commands/c-1/stdout")
-
-    chunks_list: list[str] = []
-    async for chunk in stream:
-        chunks_list.append(chunk)
-
-    assert "".join(chunks_list) == "abc"
-    assert api.calls == [0, 1]
-
-
-def test_sync_stream_max_reconnects_exhausted(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("isola._streaming.time.sleep", lambda _: None)
-
-    api = _FakeSyncAPI([_FakeSyncCM(enter_exc=httpx.ConnectError("down")) for _ in range(MAX_RECONNECTS + 1)])
-
-    stream = StreamReader(api, "/sandboxes/s-1/commands/c-1/stdout")
-
-    with pytest.raises(APIConnectionError):
-        list(stream)
-
-
-def test_sync_stream_connect_error_during_enter(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("isola._streaming.time.sleep", lambda _: None)
-
-    api = _FakeSyncAPI(
-        [
-            _FakeSyncCM(enter_exc=httpx.ConnectError("refused")),
-            _FakeSyncCM(_FakeSyncResponse([_sse_event("hello", 5)])),
-        ]
-    )
-
-    stream = StreamReader(api, "/sandboxes/s-1/commands/c-1/stdout")
-
-    output = "".join(stream)
-
-    assert output == "hello"
-    assert api.calls == [0, 0]
-
-
-def test_sync_stream_connect_timeout_during_enter(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("isola._streaming.time.sleep", lambda _: None)
-
-    api = _FakeSyncAPI(
-        [
-            _FakeSyncCM(enter_exc=httpx.ConnectTimeout("connect timed out")),
-            _FakeSyncCM(_FakeSyncResponse([_sse_event("hello", 5)])),
-        ]
-    )
-
-    stream = StreamReader(api, "/sandboxes/s-1/commands/c-1/stdout")
-
-    output = "".join(stream)
-
-    assert output == "hello"
-    assert api.calls == [0, 0]
-
-
-def test_sync_stream_connect_timeout_max_reconnects_exhausted(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("isola._streaming.time.sleep", lambda _: None)
-
-    api = _FakeSyncAPI([_FakeSyncCM(enter_exc=httpx.ConnectTimeout("down")) for _ in range(MAX_RECONNECTS + 1)])
-
-    stream = StreamReader(api, "/sandboxes/s-1/commands/c-1/stdout")
-
-    with pytest.raises(APIConnectionError):
-        list(stream)
-
-
-def test_sync_stream_http_error_propagates(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("isola._streaming.time.sleep", lambda _: None)
-
-    api = _FakeSyncAPI(
-        [
-            _FakeSyncCM(_FakeSyncResponse([], status_code=404)),
-        ]
-    )
-
-    stream = StreamReader(api, "/sandboxes/s-1/commands/c-1/stdout")
-
-    with pytest.raises(NotFoundError):
-        list(stream)
-
-
-@pytest.mark.asyncio
-async def test_async_stream_max_reconnects_exhausted(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def _no_sleep(_seconds: float) -> None:
-        return None
-
-    monkeypatch.setattr("isola._streaming.asyncio.sleep", _no_sleep)
-
-    api = _FakeAsyncAPI([_FakeAsyncCM(enter_exc=httpx.ConnectError("down")) for _ in range(MAX_RECONNECTS + 1)])
-
-    stream = AsyncStreamReader(api, "/sandboxes/s-1/commands/c-1/stdout")
-
-    with pytest.raises(APIConnectionError):
-        async for _ in stream:
-            pass
-
-
-@pytest.mark.asyncio
-async def test_async_stream_connect_error_during_enter(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def _no_sleep(_seconds: float) -> None:
-        return None
-
-    monkeypatch.setattr("isola._streaming.asyncio.sleep", _no_sleep)
-
-    api = _FakeAsyncAPI(
-        [
-            _FakeAsyncCM(enter_exc=httpx.ConnectError("refused")),
-            _FakeAsyncCM(_FakeAsyncResponse([_sse_event("hello", 5)])),
-        ]
-    )
-
-    stream = AsyncStreamReader(api, "/sandboxes/s-1/commands/c-1/stdout")
-
-    chunks_list: list[str] = []
-    async for chunk in stream:
-        chunks_list.append(chunk)
-
-    assert "".join(chunks_list) == "hello"
-    assert api.calls == [0, 0]
-
-
-@pytest.mark.asyncio
-async def test_async_stream_connect_timeout_during_enter(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def _no_sleep(_seconds: float) -> None:
-        return None
-
-    monkeypatch.setattr("isola._streaming.asyncio.sleep", _no_sleep)
-
-    api = _FakeAsyncAPI(
-        [
-            _FakeAsyncCM(enter_exc=httpx.ConnectTimeout("connect timed out")),
-            _FakeAsyncCM(_FakeAsyncResponse([_sse_event("hello", 5)])),
-        ]
-    )
-
-    stream = AsyncStreamReader(api, "/sandboxes/s-1/commands/c-1/stdout")
-
-    chunks_list: list[str] = []
-    async for chunk in stream:
-        chunks_list.append(chunk)
-
-    assert "".join(chunks_list) == "hello"
-    assert api.calls == [0, 0]
-
-
-@pytest.mark.asyncio
-async def test_async_stream_connect_timeout_max_reconnects_exhausted(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def _no_sleep(_seconds: float) -> None:
-        return None
-
-    monkeypatch.setattr("isola._streaming.asyncio.sleep", _no_sleep)
-
-    api = _FakeAsyncAPI([_FakeAsyncCM(enter_exc=httpx.ConnectTimeout("down")) for _ in range(MAX_RECONNECTS + 1)])
-
-    stream = AsyncStreamReader(api, "/sandboxes/s-1/commands/c-1/stdout")
-
-    with pytest.raises(APIConnectionError):
-        async for _ in stream:
-            pass
-
-
-@pytest.mark.asyncio
-async def test_async_stream_http_error_propagates(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def _no_sleep(_seconds: float) -> None:
-        return None
-
-    monkeypatch.setattr("isola._streaming.asyncio.sleep", _no_sleep)
-
-    api = _FakeAsyncAPI(
-        [
-            _FakeAsyncCM(_FakeAsyncResponse([], status_code=404)),
-        ]
-    )
-
-    stream = AsyncStreamReader(api, "/sandboxes/s-1/commands/c-1/stdout")
-
-    with pytest.raises(NotFoundError):
-        async for _ in stream:
-            pass
-
-
-# --- SSE parsing tests ---
-
-
-def test_sync_stream_parses_multiline_sse_data() -> None:
-    """Multiple data: lines in one event are joined with newlines."""
-    api = _FakeSyncAPI(
-        [
-            _FakeSyncCM(_FakeSyncResponse([b"data: hello\ndata: world\nid: 11\n\n"])),
-        ]
-    )
-
-    stream = StreamReader(api, "/path")
-    assert "".join(stream) == "hello\nworld"
-
-
-def test_sync_stream_filters_keepalive_comments() -> None:
-    """SSE comments (: keepalive) are invisible to the parser."""
-    api = _FakeSyncAPI(
-        [
-            _FakeSyncCM(
-                _FakeSyncResponse(
-                    [
-                        _sse_event("hello", 5),
-                        b": keepalive\n\n",
-                        _sse_event("world", 10),
-                    ]
-                )
-            ),
-        ]
-    )
-
-    stream = StreamReader(api, "/path")
-    assert "".join(stream) == "helloworld"
-
-
-def test_sync_stream_preserves_trailing_newline() -> None:
-    """Output ending with a newline round-trips through SSE correctly."""
-    # "hello\n" → data: hello\ndata: \nid: 6\n\n
-    api = _FakeSyncAPI(
-        [
-            _FakeSyncCM(_FakeSyncResponse([b"data: hello\ndata: \nid: 6\n\n"])),
-        ]
-    )
-
-    stream = StreamReader(api, "/path")
-    assert "".join(stream) == "hello\n"
-
-
-@pytest.mark.asyncio
-async def test_async_stream_parses_multiline_sse_data() -> None:
-    api = _FakeAsyncAPI(
-        [
-            _FakeAsyncCM(_FakeAsyncResponse([b"data: hello\ndata: world\nid: 11\n\n"])),
-        ]
-    )
-
-    stream = AsyncStreamReader(api, "/path")
-    assert "".join([c async for c in stream]) == "hello\nworld"
-
-
-@pytest.mark.asyncio
-async def test_async_stream_filters_keepalive_comments() -> None:
-    api = _FakeAsyncAPI(
-        [
-            _FakeAsyncCM(
-                _FakeAsyncResponse(
-                    [
-                        _sse_event("hello", 5),
-                        b": keepalive\n\n",
-                        _sse_event("world", 10),
-                    ]
-                )
-            ),
-        ]
-    )
-
-    stream = AsyncStreamReader(api, "/path")
-    assert "".join([c async for c in stream]) == "helloworld"
-
-
-# --- UTF-8 defense-in-depth tests ---
-
-
-def test_sync_stream_decodes_utf8() -> None:
-    api = _FakeSyncAPI(
-        [
-            _FakeSyncCM(_FakeSyncResponse([_sse_event("hello ", 6), _sse_event("world", 11)])),
-        ]
-    )
-
-    stream = StreamReader(api, "/path")
-    assert "".join(stream) == "hello world"
-
-
-def test_sync_stream_handles_split_multibyte() -> None:
-    # "café" in UTF-8: b"caf\xc3\xa9"
-    # Split é (0xc3 0xa9) across two chunks within one SSE event
-    api = _FakeSyncAPI(
-        [
-            _FakeSyncCM(_FakeSyncResponse([b"data: caf\xc3", b"\xa9\nid: 5\n\n"])),
-        ]
-    )
-
-    stream = StreamReader(api, "/path")
-    assert "".join(stream) == "caf\u00e9"
-
-
-def test_sync_stream_handles_replacement_character() -> None:
-    # Server replaces invalid UTF-8 with U+FFFD before sending SSE
-    api = _FakeSyncAPI(
-        [
-            _FakeSyncCM(_FakeSyncResponse([_sse_event("hello\ufffdworld", 11)])),
-        ]
-    )
-
-    stream = StreamReader(api, "/path")
-    assert "".join(stream) == "hello\ufffdworld"
-
-
-@pytest.mark.asyncio
-async def test_async_stream_decodes_utf8() -> None:
-    api = _FakeAsyncAPI(
-        [
-            _FakeAsyncCM(_FakeAsyncResponse([_sse_event("hello ", 6), _sse_event("world", 11)])),
-        ]
-    )
-
-    stream = AsyncStreamReader(api, "/path")
-    assert "".join([c async for c in stream]) == "hello world"
-
-
-@pytest.mark.asyncio
-async def test_async_stream_handles_split_multibyte() -> None:
-    api = _FakeAsyncAPI(
-        [
-            _FakeAsyncCM(_FakeAsyncResponse([b"data: caf\xc3", b"\xa9\nid: 5\n\n"])),
-        ]
-    )
-
-    stream = AsyncStreamReader(api, "/path")
-    assert "".join([c async for c in stream]) == "caf\u00e9"
-
-
-# --- Single-use guard tests ---
-
-
-def test_sync_stream_single_use_guard() -> None:
-    api = _FakeSyncAPI(
-        [
-            _FakeSyncCM(_FakeSyncResponse([_sse_event("data", 4)])),
-        ]
-    )
+def test_sync_stream_single_use() -> None:
+    api = _FakeSyncAPI([_FakeSyncCM(_FakeSyncResponse([_sse_event("x", 1)]))])
 
     stream = StreamReader(api, "/path")
     list(stream)
@@ -538,13 +166,156 @@ def test_sync_stream_single_use_guard() -> None:
         list(stream)
 
 
+# ---------------------------------------------------------------------------
+# Sync: SSE integration
+# ---------------------------------------------------------------------------
+
+
+def test_sync_stream_multiline_data() -> None:
+    """Multiple data: lines in one event are joined with newlines."""
+    api = _FakeSyncAPI([_FakeSyncCM(_FakeSyncResponse(["data: hello\ndata: world\nid: 11\n\n"]))])
+
+    assert StreamReader(api, "/path").read() == "hello\nworld"
+
+
+def test_sync_stream_filters_keepalive() -> None:
+    """SSE comment lines are invisible to the consumer."""
+    api = _FakeSyncAPI([
+        _FakeSyncCM(_FakeSyncResponse([
+            _sse_event("hello", 5),
+            ": keepalive\n\n",
+            _sse_event("world", 10),
+        ]))
+    ])
+
+    assert StreamReader(api, "/path").read() == "helloworld"
+
+
+def test_sync_stream_preserves_trailing_newline() -> None:
+    """Output ending with \\n round-trips through SSE (extra empty data: line)."""
+    api = _FakeSyncAPI([_FakeSyncCM(_FakeSyncResponse(["data: hello\ndata: \nid: 6\n\n"]))])
+
+    assert StreamReader(api, "/path").read() == "hello\n"
+
+
+# ---------------------------------------------------------------------------
+# Sync: reconnection
+# ---------------------------------------------------------------------------
+
+
+def test_sync_stream_reconnects_and_resumes(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("isola._streaming.time.sleep", lambda _: None)
+
+    api = _FakeSyncAPI([
+        _FakeSyncCM(_FakeSyncResponse([_sse_event("ab", 2)], raise_after=httpx.ConnectError("drop"))),
+        _FakeSyncCM(_FakeSyncResponse([_sse_event("cd", 4)])),
+    ])
+
+    assert StreamReader(api, "/path").read() == "abcd"
+    assert api.calls == [0, 2]
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        httpx.ConnectError("refused"),
+        httpx.ReadError("reset"),
+        httpx.WriteError("broken pipe"),
+        httpx.ConnectTimeout("timeout"),
+    ],
+    ids=["ConnectError", "ReadError", "WriteError", "ConnectTimeout"],
+)
+def test_sync_stream_reconnects_on_network_error(monkeypatch: pytest.MonkeyPatch, error: Exception) -> None:
+    monkeypatch.setattr("isola._streaming.time.sleep", lambda _: None)
+
+    api = _FakeSyncAPI([
+        _FakeSyncCM(_FakeSyncResponse([_sse_event("ab", 2)], raise_after=error)),
+        _FakeSyncCM(_FakeSyncResponse([_sse_event("cd", 4)])),
+    ])
+
+    assert StreamReader(api, "/path").read() == "abcd"
+    assert api.calls == [0, 2]
+
+
+def test_sync_stream_reconnects_on_enter_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("isola._streaming.time.sleep", lambda _: None)
+
+    api = _FakeSyncAPI([
+        _FakeSyncCM(enter_exc=httpx.ConnectError("refused")),
+        _FakeSyncCM(_FakeSyncResponse([_sse_event("hello", 5)])),
+    ])
+
+    assert StreamReader(api, "/path").read() == "hello"
+    assert api.calls == [0, 0]
+
+
+def test_sync_stream_max_reconnects_exhausted(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("isola._streaming.time.sleep", lambda _: None)
+
+    api = _FakeSyncAPI([_FakeSyncCM(enter_exc=httpx.ConnectError("down")) for _ in range(MAX_RECONNECTS + 1)])
+
+    with pytest.raises(APIConnectionError):
+        list(StreamReader(api, "/path"))
+
+
+# ---------------------------------------------------------------------------
+# Sync: HTTP error handling
+# ---------------------------------------------------------------------------
+
+
+def test_sync_stream_http_error_propagates() -> None:
+    api = _FakeSyncAPI([_FakeSyncCM(_FakeSyncResponse([], status_code=404))])
+
+    with pytest.raises(NotFoundError):
+        list(StreamReader(api, "/path"))
+
+
+@pytest.mark.parametrize("status", [502, 503, 504], ids=["502", "503", "504"])
+def test_sync_stream_retries_transient_http_error(monkeypatch: pytest.MonkeyPatch, status: int) -> None:
+    monkeypatch.setattr("isola._streaming.time.sleep", lambda _: None)
+
+    api = _FakeSyncAPI([
+        _FakeSyncCM(_FakeSyncResponse([_sse_event("ab", 2)], raise_after=httpx.ReadError("reset"))),
+        _FakeSyncCM(_FakeSyncResponse([], status_code=status)),
+        _FakeSyncCM(_FakeSyncResponse([_sse_event("cd", 4)])),
+    ])
+
+    assert StreamReader(api, "/path").read() == "abcd"
+    assert api.calls == [0, 2, 2]
+
+
+@pytest.mark.parametrize("status", [502, 503, 504], ids=["502", "503", "504"])
+def test_sync_stream_transient_http_max_reconnects(monkeypatch: pytest.MonkeyPatch, status: int) -> None:
+    monkeypatch.setattr("isola._streaming.time.sleep", lambda _: None)
+
+    api = _FakeSyncAPI([_FakeSyncCM(_FakeSyncResponse([], status_code=status)) for _ in range(MAX_RECONNECTS + 1)])
+
+    with pytest.raises(IsolaError):
+        list(StreamReader(api, "/path"))
+
+
+# ---------------------------------------------------------------------------
+# Async: core behavior
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
-async def test_async_stream_single_use_guard() -> None:
-    api = _FakeAsyncAPI(
-        [
-            _FakeAsyncCM(_FakeAsyncResponse([_sse_event("data", 4)])),
-        ]
-    )
+async def test_async_stream_yields_data() -> None:
+    api = _FakeAsyncAPI([_FakeAsyncCM(_FakeAsyncResponse([_sse_event("hello ", 6), _sse_event("world", 11)]))])
+
+    assert [c async for c in AsyncStreamReader(api, "/path")] == ["hello ", "world"]
+
+
+@pytest.mark.asyncio
+async def test_async_stream_read() -> None:
+    api = _FakeAsyncAPI([_FakeAsyncCM(_FakeAsyncResponse([_sse_event("hello ", 6), _sse_event("world", 11)]))])
+
+    assert await AsyncStreamReader(api, "/path").read() == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_async_stream_single_use() -> None:
+    api = _FakeAsyncAPI([_FakeAsyncCM(_FakeAsyncResponse([_sse_event("x", 1)]))])
 
     stream = AsyncStreamReader(api, "/path")
     async for _ in stream:
@@ -555,144 +326,68 @@ async def test_async_stream_single_use_guard() -> None:
             pass
 
 
-# --- read() convenience tests ---
-
-
-def test_sync_stream_read_text() -> None:
-    api = _FakeSyncAPI(
-        [
-            _FakeSyncCM(_FakeSyncResponse([_sse_event("hello ", 6), _sse_event("world", 11)])),
-        ]
-    )
-
-    stream = StreamReader(api, "/path")
-    assert stream.read() == "hello world"
+# ---------------------------------------------------------------------------
+# Async: reconnection
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_async_stream_read_text() -> None:
-    api = _FakeAsyncAPI(
-        [
-            _FakeAsyncCM(_FakeAsyncResponse([_sse_event("hello ", 6), _sse_event("world", 11)])),
-        ]
-    )
-
-    stream = AsyncStreamReader(api, "/path")
-    assert await stream.read() == "hello world"
-
-
-# --- Transient HTTP error retry tests ---
-
-
-@pytest.mark.parametrize("status", [502, 503, 504], ids=["502", "503", "504"])
-def test_sync_stream_retries_transient_http_error_on_reconnect(monkeypatch: pytest.MonkeyPatch, status: int) -> None:
-    """A transient HTTP error during stream reconnect should be retried, not raised."""
-    monkeypatch.setattr("isola._streaming.time.sleep", lambda _: None)
-
-    api = _FakeSyncAPI(
-        [
-            _FakeSyncCM(_FakeSyncResponse([_sse_event("ab", 2)], raise_after=httpx.ReadError("connection reset"))),
-            _FakeSyncCM(_FakeSyncResponse([], status_code=status)),
-            _FakeSyncCM(_FakeSyncResponse([_sse_event("cd", 4)])),
-        ]
-    )
-
-    stream = StreamReader(api, "/sandboxes/s-1/commands/c-1/stdout")
-
-    output = "".join(stream)
-
-    assert output == "abcd"
-    assert api.calls == [0, 2, 2]
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("status", [502, 503, 504], ids=["502", "503", "504"])
-async def test_async_stream_retries_transient_http_error_on_reconnect(
-    monkeypatch: pytest.MonkeyPatch, status: int
-) -> None:
-    """A transient HTTP error during async stream reconnect should be retried, not raised."""
-
-    async def _no_sleep(_seconds: float) -> None:
-        return None
+async def test_async_stream_reconnects_and_resumes(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _no_sleep(_: float) -> None:
+        pass
 
     monkeypatch.setattr("isola._streaming.asyncio.sleep", _no_sleep)
 
-    api = _FakeAsyncAPI(
-        [
-            _FakeAsyncCM(_FakeAsyncResponse([_sse_event("ab", 2)], raise_after=httpx.ReadError("connection reset"))),
-            _FakeAsyncCM(_FakeAsyncResponse([], status_code=status)),
-            _FakeAsyncCM(_FakeAsyncResponse([_sse_event("cd", 4)])),
-        ]
-    )
+    api = _FakeAsyncAPI([
+        _FakeAsyncCM(_FakeAsyncResponse([_sse_event("a", 1)], raise_after=httpx.ConnectError("drop"))),
+        _FakeAsyncCM(_FakeAsyncResponse([_sse_event("b", 2), _sse_event("c", 3)])),
+    ])
 
-    stream = AsyncStreamReader(api, "/sandboxes/s-1/commands/c-1/stdout")
-
-    chunks_list: list[str] = []
-    async for chunk in stream:
-        chunks_list.append(chunk)
-
-    assert "".join(chunks_list) == "abcd"
-    assert api.calls == [0, 2, 2]
-
-
-@pytest.mark.parametrize("status", [502, 503, 504], ids=["502", "503", "504"])
-def test_sync_stream_transient_http_error_max_reconnects_exhausted(
-    monkeypatch: pytest.MonkeyPatch, status: int
-) -> None:
-    """Repeated transient HTTP errors should eventually give up after MAX_RECONNECTS."""
-    monkeypatch.setattr("isola._streaming.time.sleep", lambda _: None)
-
-    api = _FakeSyncAPI([_FakeSyncCM(_FakeSyncResponse([], status_code=status)) for _ in range(MAX_RECONNECTS + 1)])
-
-    stream = StreamReader(api, "/sandboxes/s-1/commands/c-1/stdout")
-
-    with pytest.raises(IsolaError):
-        list(stream)
+    assert await AsyncStreamReader(api, "/path").read() == "abc"
+    assert api.calls == [0, 1]
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("status", [502, 503, 504], ids=["502", "503", "504"])
-async def test_async_stream_transient_http_error_max_reconnects_exhausted(
-    monkeypatch: pytest.MonkeyPatch, status: int
-) -> None:
-    """Repeated transient HTTP errors should eventually give up after MAX_RECONNECTS."""
-
-    async def _no_sleep(_seconds: float) -> None:
-        return None
+async def test_async_stream_max_reconnects_exhausted(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _no_sleep(_: float) -> None:
+        pass
 
     monkeypatch.setattr("isola._streaming.asyncio.sleep", _no_sleep)
 
-    api = _FakeAsyncAPI([_FakeAsyncCM(_FakeAsyncResponse([], status_code=status)) for _ in range(MAX_RECONNECTS + 1)])
+    api = _FakeAsyncAPI([_FakeAsyncCM(enter_exc=httpx.ConnectError("down")) for _ in range(MAX_RECONNECTS + 1)])
 
-    stream = AsyncStreamReader(api, "/sandboxes/s-1/commands/c-1/stdout")
-
-    with pytest.raises(IsolaError):
-        async for _ in stream:
+    with pytest.raises(APIConnectionError):
+        async for _ in AsyncStreamReader(api, "/path"):
             pass
 
 
-# --- Stream natural termination tests ---
+# ---------------------------------------------------------------------------
+# Async: HTTP error handling
+# ---------------------------------------------------------------------------
 
 
-def test_sync_stream_read_completes_on_response_end() -> None:
-    """read() completes when the HTTP response body ends naturally (no error)."""
-    api = _FakeSyncAPI(
-        [
-            _FakeSyncCM(_FakeSyncResponse([_sse_event("hello", 5)])),
-        ]
-    )
+@pytest.mark.asyncio
+async def test_async_stream_http_error_propagates() -> None:
+    api = _FakeAsyncAPI([_FakeAsyncCM(_FakeAsyncResponse([], status_code=404))])
 
-    stream = StreamReader(api, "/path")
-    assert stream.read() == "hello"
+    with pytest.raises(NotFoundError):
+        async for _ in AsyncStreamReader(api, "/path"):
+            pass
 
 
-def test_sync_stream_iter_completes_on_response_end() -> None:
-    """Iteration completes when the HTTP response body ends naturally."""
-    api = _FakeSyncAPI(
-        [
-            _FakeSyncCM(_FakeSyncResponse([_sse_event("hello", 5)])),
-        ]
-    )
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [502, 503, 504], ids=["502", "503", "504"])
+async def test_async_stream_retries_transient_http_error(monkeypatch: pytest.MonkeyPatch, status: int) -> None:
+    async def _no_sleep(_: float) -> None:
+        pass
 
-    stream = StreamReader(api, "/path")
-    assert list(stream) == ["hello"]
+    monkeypatch.setattr("isola._streaming.asyncio.sleep", _no_sleep)
+
+    api = _FakeAsyncAPI([
+        _FakeAsyncCM(_FakeAsyncResponse([_sse_event("ab", 2)], raise_after=httpx.ReadError("reset"))),
+        _FakeAsyncCM(_FakeAsyncResponse([], status_code=status)),
+        _FakeAsyncCM(_FakeAsyncResponse([_sse_event("cd", 4)])),
+    ])
+
+    assert await AsyncStreamReader(api, "/path").read() == "abcd"
+    assert api.calls == [0, 2, 2]

--- a/sdks/python/tests/test_streaming.py
+++ b/sdks/python/tests/test_streaming.py
@@ -180,13 +180,19 @@ def test_sync_stream_multiline_data() -> None:
 
 def test_sync_stream_filters_keepalive() -> None:
     """SSE comment lines are invisible to the consumer."""
-    api = _FakeSyncAPI([
-        _FakeSyncCM(_FakeSyncResponse([
-            _sse_event("hello", 5),
-            ": keepalive\n\n",
-            _sse_event("world", 10),
-        ]))
-    ])
+    api = _FakeSyncAPI(
+        [
+            _FakeSyncCM(
+                _FakeSyncResponse(
+                    [
+                        _sse_event("hello", 5),
+                        ": keepalive\n\n",
+                        _sse_event("world", 10),
+                    ]
+                )
+            )
+        ]
+    )
 
     assert StreamReader(api, "/path").read() == "helloworld"
 
@@ -206,10 +212,12 @@ def test_sync_stream_preserves_trailing_newline() -> None:
 def test_sync_stream_reconnects_and_resumes(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("isola._streaming.time.sleep", lambda _: None)
 
-    api = _FakeSyncAPI([
-        _FakeSyncCM(_FakeSyncResponse([_sse_event("ab", 2)], raise_after=httpx.ConnectError("drop"))),
-        _FakeSyncCM(_FakeSyncResponse([_sse_event("cd", 4)])),
-    ])
+    api = _FakeSyncAPI(
+        [
+            _FakeSyncCM(_FakeSyncResponse([_sse_event("ab", 2)], raise_after=httpx.ConnectError("drop"))),
+            _FakeSyncCM(_FakeSyncResponse([_sse_event("cd", 4)])),
+        ]
+    )
 
     assert StreamReader(api, "/path").read() == "abcd"
     assert api.calls == [0, 2]
@@ -228,10 +236,12 @@ def test_sync_stream_reconnects_and_resumes(monkeypatch: pytest.MonkeyPatch) -> 
 def test_sync_stream_reconnects_on_network_error(monkeypatch: pytest.MonkeyPatch, error: Exception) -> None:
     monkeypatch.setattr("isola._streaming.time.sleep", lambda _: None)
 
-    api = _FakeSyncAPI([
-        _FakeSyncCM(_FakeSyncResponse([_sse_event("ab", 2)], raise_after=error)),
-        _FakeSyncCM(_FakeSyncResponse([_sse_event("cd", 4)])),
-    ])
+    api = _FakeSyncAPI(
+        [
+            _FakeSyncCM(_FakeSyncResponse([_sse_event("ab", 2)], raise_after=error)),
+            _FakeSyncCM(_FakeSyncResponse([_sse_event("cd", 4)])),
+        ]
+    )
 
     assert StreamReader(api, "/path").read() == "abcd"
     assert api.calls == [0, 2]
@@ -240,10 +250,12 @@ def test_sync_stream_reconnects_on_network_error(monkeypatch: pytest.MonkeyPatch
 def test_sync_stream_reconnects_on_enter_error(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("isola._streaming.time.sleep", lambda _: None)
 
-    api = _FakeSyncAPI([
-        _FakeSyncCM(enter_exc=httpx.ConnectError("refused")),
-        _FakeSyncCM(_FakeSyncResponse([_sse_event("hello", 5)])),
-    ])
+    api = _FakeSyncAPI(
+        [
+            _FakeSyncCM(enter_exc=httpx.ConnectError("refused")),
+            _FakeSyncCM(_FakeSyncResponse([_sse_event("hello", 5)])),
+        ]
+    )
 
     assert StreamReader(api, "/path").read() == "hello"
     assert api.calls == [0, 0]
@@ -274,11 +286,13 @@ def test_sync_stream_http_error_propagates() -> None:
 def test_sync_stream_retries_transient_http_error(monkeypatch: pytest.MonkeyPatch, status: int) -> None:
     monkeypatch.setattr("isola._streaming.time.sleep", lambda _: None)
 
-    api = _FakeSyncAPI([
-        _FakeSyncCM(_FakeSyncResponse([_sse_event("ab", 2)], raise_after=httpx.ReadError("reset"))),
-        _FakeSyncCM(_FakeSyncResponse([], status_code=status)),
-        _FakeSyncCM(_FakeSyncResponse([_sse_event("cd", 4)])),
-    ])
+    api = _FakeSyncAPI(
+        [
+            _FakeSyncCM(_FakeSyncResponse([_sse_event("ab", 2)], raise_after=httpx.ReadError("reset"))),
+            _FakeSyncCM(_FakeSyncResponse([], status_code=status)),
+            _FakeSyncCM(_FakeSyncResponse([_sse_event("cd", 4)])),
+        ]
+    )
 
     assert StreamReader(api, "/path").read() == "abcd"
     assert api.calls == [0, 2, 2]
@@ -338,10 +352,12 @@ async def test_async_stream_reconnects_and_resumes(monkeypatch: pytest.MonkeyPat
 
     monkeypatch.setattr("isola._streaming.asyncio.sleep", _no_sleep)
 
-    api = _FakeAsyncAPI([
-        _FakeAsyncCM(_FakeAsyncResponse([_sse_event("a", 1)], raise_after=httpx.ConnectError("drop"))),
-        _FakeAsyncCM(_FakeAsyncResponse([_sse_event("b", 2), _sse_event("c", 3)])),
-    ])
+    api = _FakeAsyncAPI(
+        [
+            _FakeAsyncCM(_FakeAsyncResponse([_sse_event("a", 1)], raise_after=httpx.ConnectError("drop"))),
+            _FakeAsyncCM(_FakeAsyncResponse([_sse_event("b", 2), _sse_event("c", 3)])),
+        ]
+    )
 
     assert await AsyncStreamReader(api, "/path").read() == "abc"
     assert api.calls == [0, 1]
@@ -383,11 +399,13 @@ async def test_async_stream_retries_transient_http_error(monkeypatch: pytest.Mon
 
     monkeypatch.setattr("isola._streaming.asyncio.sleep", _no_sleep)
 
-    api = _FakeAsyncAPI([
-        _FakeAsyncCM(_FakeAsyncResponse([_sse_event("ab", 2)], raise_after=httpx.ReadError("reset"))),
-        _FakeAsyncCM(_FakeAsyncResponse([], status_code=status)),
-        _FakeAsyncCM(_FakeAsyncResponse([_sse_event("cd", 4)])),
-    ])
+    api = _FakeAsyncAPI(
+        [
+            _FakeAsyncCM(_FakeAsyncResponse([_sse_event("ab", 2)], raise_after=httpx.ReadError("reset"))),
+            _FakeAsyncCM(_FakeAsyncResponse([], status_code=status)),
+            _FakeAsyncCM(_FakeAsyncResponse([_sse_event("cd", 4)])),
+        ]
+    )
 
     assert await AsyncStreamReader(api, "/path").read() == "abcd"
     assert api.calls == [0, 2, 2]

--- a/sdks/python/tests/test_streaming.py
+++ b/sdks/python/tests/test_streaming.py
@@ -23,6 +23,14 @@ from isola import APIConnectionError, IsolaError, NotFoundError
 from isola._streaming import MAX_RECONNECTS, AsyncStreamReader, StreamReader
 
 
+def _sse_event(data: str, event_id: int) -> bytes:
+    """Format a single SSE data event as wire bytes."""
+    lines = [f"data: {line}" for line in data.split("\n")]
+    lines.append(f"id: {event_id}")
+    lines.append("")  # blank line terminates event
+    return ("\n".join(lines) + "\n").encode("utf-8")
+
+
 class _FakeSyncResponse:
     def __init__(self, chunks: list[bytes], *, raise_after: Exception | None = None, status_code: int = 200) -> None:
         self.status_code = status_code
@@ -58,10 +66,17 @@ class _FakeSyncAPI:
         self._sequence = sequence
         self.calls: list[int] = []
 
-    def open_stream(self, path: str, *, params: dict[str, int] | None = None, timeout: object = None) -> _FakeSyncCM:
-        del path, timeout
-        assert params is not None
-        self.calls.append(params["offset"])
+    def open_stream(
+        self,
+        path: str,
+        *,
+        params: dict[str, int] | None = None,
+        headers: dict[str, str] | None = None,
+        timeout: object = None,
+    ) -> _FakeSyncCM:
+        del path, params, timeout
+        offset = int(headers["Last-Event-ID"]) if headers and "Last-Event-ID" in headers else 0
+        self.calls.append(offset)
         return self._sequence.pop(0)
 
 
@@ -101,11 +116,21 @@ class _FakeAsyncAPI:
         self._sequence = sequence
         self.calls: list[int] = []
 
-    def open_stream(self, path: str, *, params: dict[str, int] | None = None, timeout: object = None) -> _FakeAsyncCM:
-        del path, timeout
-        assert params is not None
-        self.calls.append(params["offset"])
+    def open_stream(
+        self,
+        path: str,
+        *,
+        params: dict[str, int] | None = None,
+        headers: dict[str, str] | None = None,
+        timeout: object = None,
+    ) -> _FakeAsyncCM:
+        del path, params, timeout
+        offset = int(headers["Last-Event-ID"]) if headers and "Last-Event-ID" in headers else 0
+        self.calls.append(offset)
         return self._sequence.pop(0)
+
+
+# --- Reconnect tests ---
 
 
 def test_sync_stream_reconnects_and_resumes_offset(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -113,8 +138,8 @@ def test_sync_stream_reconnects_and_resumes_offset(monkeypatch: pytest.MonkeyPat
 
     api = _FakeSyncAPI(
         [
-            _FakeSyncCM(_FakeSyncResponse([b"ab"], raise_after=httpx.ConnectError("disconnect"))),
-            _FakeSyncCM(_FakeSyncResponse([b"cd"])),
+            _FakeSyncCM(_FakeSyncResponse([_sse_event("ab", 2)], raise_after=httpx.ConnectError("disconnect"))),
+            _FakeSyncCM(_FakeSyncResponse([_sse_event("cd", 4)])),
         ]
     )
 
@@ -143,8 +168,8 @@ def test_sync_stream_reconnects_on_network_error(monkeypatch: pytest.MonkeyPatch
 
     api = _FakeSyncAPI(
         [
-            _FakeSyncCM(_FakeSyncResponse([b"ab"], raise_after=error)),
-            _FakeSyncCM(_FakeSyncResponse([b"cd"])),
+            _FakeSyncCM(_FakeSyncResponse([_sse_event("ab", 2)], raise_after=error)),
+            _FakeSyncCM(_FakeSyncResponse([_sse_event("cd", 4)])),
         ]
     )
 
@@ -165,8 +190,8 @@ async def test_async_stream_reconnects_and_resumes_offset(monkeypatch: pytest.Mo
 
     api = _FakeAsyncAPI(
         [
-            _FakeAsyncCM(_FakeAsyncResponse([b"a"], raise_after=httpx.ConnectError("disconnect"))),
-            _FakeAsyncCM(_FakeAsyncResponse([b"b", b"c"])),
+            _FakeAsyncCM(_FakeAsyncResponse([_sse_event("a", 1)], raise_after=httpx.ConnectError("disconnect"))),
+            _FakeAsyncCM(_FakeAsyncResponse([_sse_event("b", 2), _sse_event("c", 3)])),
         ]
     )
 
@@ -197,7 +222,7 @@ def test_sync_stream_connect_error_during_enter(monkeypatch: pytest.MonkeyPatch)
     api = _FakeSyncAPI(
         [
             _FakeSyncCM(enter_exc=httpx.ConnectError("refused")),
-            _FakeSyncCM(_FakeSyncResponse([b"hello"])),
+            _FakeSyncCM(_FakeSyncResponse([_sse_event("hello", 5)])),
         ]
     )
 
@@ -215,7 +240,7 @@ def test_sync_stream_connect_timeout_during_enter(monkeypatch: pytest.MonkeyPatc
     api = _FakeSyncAPI(
         [
             _FakeSyncCM(enter_exc=httpx.ConnectTimeout("connect timed out")),
-            _FakeSyncCM(_FakeSyncResponse([b"hello"])),
+            _FakeSyncCM(_FakeSyncResponse([_sse_event("hello", 5)])),
         ]
     )
 
@@ -279,7 +304,7 @@ async def test_async_stream_connect_error_during_enter(monkeypatch: pytest.Monke
     api = _FakeAsyncAPI(
         [
             _FakeAsyncCM(enter_exc=httpx.ConnectError("refused")),
-            _FakeAsyncCM(_FakeAsyncResponse([b"hello"])),
+            _FakeAsyncCM(_FakeAsyncResponse([_sse_event("hello", 5)])),
         ]
     )
 
@@ -303,7 +328,7 @@ async def test_async_stream_connect_timeout_during_enter(monkeypatch: pytest.Mon
     api = _FakeAsyncAPI(
         [
             _FakeAsyncCM(enter_exc=httpx.ConnectTimeout("connect timed out")),
-            _FakeAsyncCM(_FakeAsyncResponse([b"hello"])),
+            _FakeAsyncCM(_FakeAsyncResponse([_sse_event("hello", 5)])),
         ]
     )
 
@@ -353,106 +378,147 @@ async def test_async_stream_http_error_propagates(monkeypatch: pytest.MonkeyPatc
             pass
 
 
-# --- Text mode tests ---
+# --- SSE parsing tests ---
 
 
-def test_sync_stream_text_mode_decodes_utf8() -> None:
+def test_sync_stream_parses_multiline_sse_data() -> None:
+    """Multiple data: lines in one event are joined with newlines."""
     api = _FakeSyncAPI(
         [
-            _FakeSyncCM(_FakeSyncResponse([b"hello ", b"world"])),
+            _FakeSyncCM(_FakeSyncResponse([b"data: hello\ndata: world\nid: 11\n\n"])),
         ]
     )
 
     stream = StreamReader(api, "/path")
-
-    output = "".join(stream)
-
-    assert output == "hello world"
+    assert "".join(stream) == "hello\nworld"
 
 
-def test_sync_stream_text_mode_handles_split_multibyte() -> None:
-    # "cafe\u0301\n" in UTF-8: b"caf\xc3\xa9\n"
-    # Split the e\u0301 (0xc3 0xa9) across two chunks
+def test_sync_stream_filters_keepalive_comments() -> None:
+    """SSE comments (: keepalive) are invisible to the parser."""
     api = _FakeSyncAPI(
         [
-            _FakeSyncCM(_FakeSyncResponse([b"caf\xc3", b"\xa9\n"])),
+            _FakeSyncCM(
+                _FakeSyncResponse(
+                    [
+                        _sse_event("hello", 5),
+                        b": keepalive\n\n",
+                        _sse_event("world", 10),
+                    ]
+                )
+            ),
         ]
     )
 
     stream = StreamReader(api, "/path")
-
-    output = "".join(stream)
-
-    assert output == "caf\u00e9\n"
+    assert "".join(stream) == "helloworld"
 
 
-@pytest.mark.asyncio
-async def test_async_stream_text_mode_decodes_utf8() -> None:
-    api = _FakeAsyncAPI(
-        [
-            _FakeAsyncCM(_FakeAsyncResponse([b"hello ", b"world"])),
-        ]
-    )
-
-    stream = AsyncStreamReader(api, "/path")
-
-    chunks_list: list[str] = []
-    async for chunk in stream:
-        chunks_list.append(chunk)
-
-    assert "".join(chunks_list) == "hello world"
-
-
-@pytest.mark.asyncio
-async def test_async_stream_text_mode_handles_split_multibyte() -> None:
-    # "cafe\u0301\n" in UTF-8: b"caf\xc3\xa9\n"
-    # Split the e\u0301 (0xc3 0xa9) across two chunks
-    api = _FakeAsyncAPI(
-        [
-            _FakeAsyncCM(_FakeAsyncResponse([b"caf\xc3", b"\xa9\n"])),
-        ]
-    )
-
-    stream = AsyncStreamReader(api, "/path")
-
-    chunks_list: list[str] = []
-    async for chunk in stream:
-        chunks_list.append(chunk)
-
-    assert "".join(chunks_list) == "caf\u00e9\n"
-
-
-def test_sync_stream_text_mode_flushes_incomplete_sequence_at_eof() -> None:
-    # Stream ends with 0xc3 -- the first byte of a 2-byte UTF-8 character
-    # with no second byte. The decoder should flush it as U+FFFD (replacement).
+def test_sync_stream_preserves_trailing_newline() -> None:
+    """Output ending with a newline round-trips through SSE correctly."""
+    # "hello\n" → data: hello\ndata: \nid: 6\n\n
     api = _FakeSyncAPI(
         [
-            _FakeSyncCM(_FakeSyncResponse([b"hello\xc3"])),
+            _FakeSyncCM(_FakeSyncResponse([b"data: hello\ndata: \nid: 6\n\n"])),
         ]
     )
 
     stream = StreamReader(api, "/path")
-
-    output = "".join(stream)
-
-    assert output == "hello\ufffd"
+    assert "".join(stream) == "hello\n"
 
 
 @pytest.mark.asyncio
-async def test_async_stream_text_mode_flushes_incomplete_sequence_at_eof() -> None:
+async def test_async_stream_parses_multiline_sse_data() -> None:
     api = _FakeAsyncAPI(
         [
-            _FakeAsyncCM(_FakeAsyncResponse([b"hello\xc3"])),
+            _FakeAsyncCM(_FakeAsyncResponse([b"data: hello\ndata: world\nid: 11\n\n"])),
         ]
     )
 
     stream = AsyncStreamReader(api, "/path")
+    assert "".join([c async for c in stream]) == "hello\nworld"
 
-    chunks_list: list[str] = []
-    async for chunk in stream:
-        chunks_list.append(chunk)
 
-    assert "".join(chunks_list) == "hello\ufffd"
+@pytest.mark.asyncio
+async def test_async_stream_filters_keepalive_comments() -> None:
+    api = _FakeAsyncAPI(
+        [
+            _FakeAsyncCM(
+                _FakeAsyncResponse(
+                    [
+                        _sse_event("hello", 5),
+                        b": keepalive\n\n",
+                        _sse_event("world", 10),
+                    ]
+                )
+            ),
+        ]
+    )
+
+    stream = AsyncStreamReader(api, "/path")
+    assert "".join([c async for c in stream]) == "helloworld"
+
+
+# --- UTF-8 defense-in-depth tests ---
+
+
+def test_sync_stream_decodes_utf8() -> None:
+    api = _FakeSyncAPI(
+        [
+            _FakeSyncCM(_FakeSyncResponse([_sse_event("hello ", 6), _sse_event("world", 11)])),
+        ]
+    )
+
+    stream = StreamReader(api, "/path")
+    assert "".join(stream) == "hello world"
+
+
+def test_sync_stream_handles_split_multibyte() -> None:
+    # "café" in UTF-8: b"caf\xc3\xa9"
+    # Split é (0xc3 0xa9) across two chunks within one SSE event
+    api = _FakeSyncAPI(
+        [
+            _FakeSyncCM(_FakeSyncResponse([b"data: caf\xc3", b"\xa9\nid: 5\n\n"])),
+        ]
+    )
+
+    stream = StreamReader(api, "/path")
+    assert "".join(stream) == "caf\u00e9"
+
+
+def test_sync_stream_handles_replacement_character() -> None:
+    # Server replaces invalid UTF-8 with U+FFFD before sending SSE
+    api = _FakeSyncAPI(
+        [
+            _FakeSyncCM(_FakeSyncResponse([_sse_event("hello\ufffdworld", 11)])),
+        ]
+    )
+
+    stream = StreamReader(api, "/path")
+    assert "".join(stream) == "hello\ufffdworld"
+
+
+@pytest.mark.asyncio
+async def test_async_stream_decodes_utf8() -> None:
+    api = _FakeAsyncAPI(
+        [
+            _FakeAsyncCM(_FakeAsyncResponse([_sse_event("hello ", 6), _sse_event("world", 11)])),
+        ]
+    )
+
+    stream = AsyncStreamReader(api, "/path")
+    assert "".join([c async for c in stream]) == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_async_stream_handles_split_multibyte() -> None:
+    api = _FakeAsyncAPI(
+        [
+            _FakeAsyncCM(_FakeAsyncResponse([b"data: caf\xc3", b"\xa9\nid: 5\n\n"])),
+        ]
+    )
+
+    stream = AsyncStreamReader(api, "/path")
+    assert "".join([c async for c in stream]) == "caf\u00e9"
 
 
 # --- Single-use guard tests ---
@@ -461,7 +527,7 @@ async def test_async_stream_text_mode_flushes_incomplete_sequence_at_eof() -> No
 def test_sync_stream_single_use_guard() -> None:
     api = _FakeSyncAPI(
         [
-            _FakeSyncCM(_FakeSyncResponse([b"data"])),
+            _FakeSyncCM(_FakeSyncResponse([_sse_event("data", 4)])),
         ]
     )
 
@@ -476,7 +542,7 @@ def test_sync_stream_single_use_guard() -> None:
 async def test_async_stream_single_use_guard() -> None:
     api = _FakeAsyncAPI(
         [
-            _FakeAsyncCM(_FakeAsyncResponse([b"data"])),
+            _FakeAsyncCM(_FakeAsyncResponse([_sse_event("data", 4)])),
         ]
     )
 
@@ -495,7 +561,7 @@ async def test_async_stream_single_use_guard() -> None:
 def test_sync_stream_read_text() -> None:
     api = _FakeSyncAPI(
         [
-            _FakeSyncCM(_FakeSyncResponse([b"hello ", b"world"])),
+            _FakeSyncCM(_FakeSyncResponse([_sse_event("hello ", 6), _sse_event("world", 11)])),
         ]
     )
 
@@ -507,7 +573,7 @@ def test_sync_stream_read_text() -> None:
 async def test_async_stream_read_text() -> None:
     api = _FakeAsyncAPI(
         [
-            _FakeAsyncCM(_FakeAsyncResponse([b"hello ", b"world"])),
+            _FakeAsyncCM(_FakeAsyncResponse([_sse_event("hello ", 6), _sse_event("world", 11)])),
         ]
     )
 
@@ -515,7 +581,7 @@ async def test_async_stream_read_text() -> None:
     assert await stream.read() == "hello world"
 
 
-# --- Stream natural termination tests ---
+# --- Transient HTTP error retry tests ---
 
 
 @pytest.mark.parametrize("status", [502, 503, 504], ids=["502", "503", "504"])
@@ -525,9 +591,9 @@ def test_sync_stream_retries_transient_http_error_on_reconnect(monkeypatch: pyte
 
     api = _FakeSyncAPI(
         [
-            _FakeSyncCM(_FakeSyncResponse([b"ab"], raise_after=httpx.ReadError("connection reset"))),
+            _FakeSyncCM(_FakeSyncResponse([_sse_event("ab", 2)], raise_after=httpx.ReadError("connection reset"))),
             _FakeSyncCM(_FakeSyncResponse([], status_code=status)),
-            _FakeSyncCM(_FakeSyncResponse([b"cd"])),
+            _FakeSyncCM(_FakeSyncResponse([_sse_event("cd", 4)])),
         ]
     )
 
@@ -553,9 +619,9 @@ async def test_async_stream_retries_transient_http_error_on_reconnect(
 
     api = _FakeAsyncAPI(
         [
-            _FakeAsyncCM(_FakeAsyncResponse([b"ab"], raise_after=httpx.ReadError("connection reset"))),
+            _FakeAsyncCM(_FakeAsyncResponse([_sse_event("ab", 2)], raise_after=httpx.ReadError("connection reset"))),
             _FakeAsyncCM(_FakeAsyncResponse([], status_code=status)),
-            _FakeAsyncCM(_FakeAsyncResponse([b"cd"])),
+            _FakeAsyncCM(_FakeAsyncResponse([_sse_event("cd", 4)])),
         ]
     )
 
@@ -605,11 +671,14 @@ async def test_async_stream_transient_http_error_max_reconnects_exhausted(
             pass
 
 
+# --- Stream natural termination tests ---
+
+
 def test_sync_stream_read_completes_on_response_end() -> None:
     """read() completes when the HTTP response body ends naturally (no error)."""
     api = _FakeSyncAPI(
         [
-            _FakeSyncCM(_FakeSyncResponse([b"hello"])),
+            _FakeSyncCM(_FakeSyncResponse([_sse_event("hello", 5)])),
         ]
     )
 
@@ -621,7 +690,7 @@ def test_sync_stream_iter_completes_on_response_end() -> None:
     """Iteration completes when the HTTP response body ends naturally."""
     api = _FakeSyncAPI(
         [
-            _FakeSyncCM(_FakeSyncResponse([b"hello"])),
+            _FakeSyncCM(_FakeSyncResponse([_sse_event("hello", 5)])),
         ]
     )
 

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -102,6 +102,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -125,6 +134,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
+    { name = "httpx-sse" },
     { name = "pydantic" },
 ]
 
@@ -140,6 +150,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.25.0" },
+    { name = "httpx-sse", specifier = ">=0.4.3" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },


### PR DESCRIPTION
stream stdout/stderr with SSE utf-8 stream instead of binary stream to have a robust way of knowing when stream ended (as opposed to a random disconnect / just no data from the server), ability to keepalive to avoid proxies dropping the connection (binary streams have no natural sentinel value to send as keepalive while SSE is structured and allows that), and natural support from browsers and clients if/when we need it. UTF-8 is not a big restriction, non utf-8 bytes in stdout/stderr are replaced. if the user wants some non utf-8 bytes in their stdout/stderr they can always redirect the stream to a file and download it as a file, so there's an escape hatch.