### PR TITLE
Reduce code duplication across api-gateway, tests, and SDK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,25 +117,27 @@ test-sidecar: ## Run sandbox-sidecar tests (supports FOCUS=pattern)
 
 ##@ Python SDK
 
+UV_SDK = cd sdks/python && uv run --frozen --extra dev
+
 .PHONY: sdk-python-sync
 sdk-python-sync: ## Sync Python SDK dependencies from lockfile
 	cd sdks/python && uv sync --frozen --extra dev
 
 .PHONY: sdk-python-fmt
 sdk-python-fmt: ## Format Python SDK
-	cd sdks/python && uv run --frozen --extra dev ruff format .
+	$(UV_SDK) ruff format .
 
 .PHONY: sdk-python-lint
 sdk-python-lint: ## Lint Python SDK
-	cd sdks/python && uv run --frozen --extra dev ruff check .
+	$(UV_SDK) ruff check .
 
 .PHONY: sdk-python-lint-fix
 sdk-python-lint-fix: ## Lint Python SDK with auto-fix
-	cd sdks/python && uv run --frozen --extra dev ruff check --fix .
+	$(UV_SDK) ruff check --fix .
 
 .PHONY: sdk-python-typecheck
 sdk-python-typecheck: ## Type-check Python SDK
-	cd sdks/python && uv run --frozen --extra dev mypy src
+	$(UV_SDK) mypy src
 
 .PHONY: sdk-python-check-all
 sdk-python-check-all: ## Run all Python SDK checks (no tests)
@@ -149,11 +151,11 @@ sdk-python-fix-all: ## Fix all auto-fixable Python SDK issues
 
 .PHONY: test-sdk-python
 test-sdk-python: ## Run Python SDK tests
-	cd sdks/python && uv run --frozen --extra dev pytest -q
+	$(UV_SDK) pytest -q
 
 .PHONY: test-sdk-python-verbose
 test-sdk-python-verbose: ## Run Python SDK tests with verbose output
-	cd sdks/python && uv run --frozen --extra dev pytest -v
+	$(UV_SDK) pytest -v
 
 ##@ E2E Testing
 

--- a/internal/api-gateway/command/command.go
+++ b/internal/api-gateway/command/command.go
@@ -118,6 +118,37 @@ func New(logger *slog.Logger, sandboxNamespace string, k8sClient client.Client, 
 	}
 }
 
+// sidecarURL builds a URL for the given sandbox pod and path.
+func (h *Handlers) sidecarURL(podIP, path string) string {
+	return fmt.Sprintf("http://%s:%d%s", podIP, h.sidecarPort, path)
+}
+
+// doSidecarRoundTrip builds a request, executes it, checks for errors, and returns the response.
+// On success the caller must close resp.Body. On sidecar HTTP errors the body is already closed.
+func (h *Handlers) doSidecarRoundTrip(ctx context.Context, sandboxID, method, sidecarURL string, body io.Reader, headers map[string]string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, sidecarURL, body)
+	if err != nil {
+		h.logger.Error("failed to build sidecar request", "error", err)
+		return nil, huma.Error500InternalServerError("failed to build sidecar request")
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		h.logger.Error("sidecar request failed", "error", err, "id", sandboxID)
+		return nil, huma.Error502BadGateway("failed to reach sidecar")
+	}
+
+	if resp.StatusCode >= 400 {
+		defer func() { _ = resp.Body.Close() }()
+		return nil, apigateway.HandleSidecarError(resp, sandboxID, h.logger)
+	}
+
+	return resp, nil
+}
+
 func (h *Handlers) PostCommand(ctx context.Context, input *CreateSandboxCommandInput) (*CreateSandboxCommandOutput, error) {
 	sb, err := apigateway.GetReadySandbox(ctx, h.k8sClient, h.sandboxNamespace, input.ID, h.logger)
 	if err != nil {
@@ -128,7 +159,6 @@ func (h *Handlers) PostCommand(ctx context.Context, input *CreateSandboxCommandI
 	if input.Container != "" {
 		params.Set("container", input.Container)
 	}
-	sidecarURL := fmt.Sprintf("http://%s:%d/commands?%s", sb.Status.PodIP, h.sidecarPort, params.Encode())
 
 	_ = sidecarapi.CreateCommandRequest(CreateCommandRequest{}) // assert field compatibility
 	body, err := json.Marshal(input.Body)
@@ -137,23 +167,13 @@ func (h *Handlers) PostCommand(ctx context.Context, input *CreateSandboxCommandI
 		return nil, huma.Error500InternalServerError("failed to marshal command request")
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, sidecarURL, bytes.NewReader(body))
+	resp, err := h.doSidecarRoundTrip(ctx, input.ID, http.MethodPost,
+		h.sidecarURL(sb.Status.PodIP, "/commands?"+params.Encode()),
+		bytes.NewReader(body), map[string]string{"Content-Type": "application/json"})
 	if err != nil {
-		h.logger.Error("failed to build sidecar request", "error", err)
-		return nil, huma.Error500InternalServerError("failed to build sidecar request")
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := h.httpClient.Do(req)
-	if err != nil {
-		h.logger.Error("sidecar request failed", "error", err, "id", input.ID)
-		return nil, huma.Error502BadGateway("failed to reach sidecar")
+		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode >= 400 {
-		return nil, apigateway.HandleSidecarError(resp, input.ID, h.logger)
-	}
 
 	_ = sidecarapi.CreateCommandResponse(CreateCommandResponse{}) // assert field compatibility
 	var sidecarResp sidecarapi.CreateCommandResponse
@@ -173,27 +193,17 @@ func (h *Handlers) GetCommandStatus(ctx context.Context, input *GetSandboxComman
 		return nil, err
 	}
 
-	sidecarURL := fmt.Sprintf("http://%s:%d/commands/%s/status", sb.Status.PodIP, h.sidecarPort, input.CmdID)
+	path := fmt.Sprintf("/commands/%s/status", input.CmdID)
 	if input.WaitSeconds > 0 {
-		sidecarURL += fmt.Sprintf("?waitSeconds=%d", input.WaitSeconds)
+		path += fmt.Sprintf("?waitSeconds=%d", input.WaitSeconds)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, sidecarURL, nil)
+	resp, err := h.doSidecarRoundTrip(ctx, input.ID, http.MethodGet,
+		h.sidecarURL(sb.Status.PodIP, path), nil, nil)
 	if err != nil {
-		h.logger.Error("failed to build sidecar request", "error", err)
-		return nil, huma.Error500InternalServerError("failed to build sidecar request")
-	}
-
-	resp, err := h.httpClient.Do(req)
-	if err != nil {
-		h.logger.Error("sidecar request failed", "error", err, "id", input.ID)
-		return nil, huma.Error502BadGateway("failed to reach sidecar")
+		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode >= 400 {
-		return nil, apigateway.HandleSidecarError(resp, input.ID, h.logger)
-	}
 
 	_ = sidecarapi.CommandStatusResponse(CommandStatusResponse{}) // assert field compatibility
 	var sidecarResp sidecarapi.CommandStatusResponse
@@ -221,9 +231,8 @@ func (h *Handlers) proxyStream(ctx context.Context, sandboxID, cmdID, stream, la
 		return nil, err
 	}
 
-	sidecarURL := fmt.Sprintf("http://%s:%d/commands/%s/%s", sb.Status.PodIP, h.sidecarPort, cmdID, stream)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, sidecarURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		h.sidecarURL(sb.Status.PodIP, fmt.Sprintf("/commands/%s/%s", cmdID, stream)), nil)
 	if err != nil {
 		h.logger.Error("failed to build sidecar request", "error", err)
 		return nil, huma.Error500InternalServerError("failed to build sidecar request")
@@ -276,28 +285,15 @@ func (h *Handlers) PostCommandStdin(ctx context.Context, input *PostSandboxComma
 		return nil, err
 	}
 
-	sidecarURL := fmt.Sprintf("http://%s:%d/commands/%s/stdin", sb.Status.PodIP, h.sidecarPort, input.CmdID)
-
 	stream := httputil.NewDeadlineReader(input.Stream, input.ResponseController, httputil.StreamTimeout)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, sidecarURL, stream)
+	resp, err := h.doSidecarRoundTrip(ctx, input.ID, http.MethodPost,
+		h.sidecarURL(sb.Status.PodIP, fmt.Sprintf("/commands/%s/stdin", input.CmdID)),
+		stream, map[string]string{"Content-Type": "application/octet-stream"})
 	if err != nil {
-		h.logger.Error("failed to build sidecar request", "error", err)
-		return nil, huma.Error500InternalServerError("failed to build sidecar request")
+		return nil, err
 	}
-	req.Header.Set("Content-Type", "application/octet-stream")
-
-	resp, err := h.httpClient.Do(req)
-	if err != nil {
-		h.logger.Error("sidecar request failed", "error", err, "id", input.ID)
-		return nil, huma.Error502BadGateway("failed to reach sidecar")
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode >= 400 {
-		return nil, apigateway.HandleSidecarError(resp, input.ID, h.logger)
-	}
-
+	_ = resp.Body.Close()
 	return nil, nil
 }
 
@@ -307,25 +303,13 @@ func (h *Handlers) CloseCommandStdin(ctx context.Context, input *CloseSandboxCom
 		return nil, err
 	}
 
-	sidecarURL := fmt.Sprintf("http://%s:%d/commands/%s/stdin/close", sb.Status.PodIP, h.sidecarPort, input.CmdID)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, sidecarURL, nil)
+	resp, err := h.doSidecarRoundTrip(ctx, input.ID, http.MethodPost,
+		h.sidecarURL(sb.Status.PodIP, fmt.Sprintf("/commands/%s/stdin/close", input.CmdID)),
+		nil, nil)
 	if err != nil {
-		h.logger.Error("failed to build sidecar request", "error", err)
-		return nil, huma.Error500InternalServerError("failed to build sidecar request")
+		return nil, err
 	}
-
-	resp, err := h.httpClient.Do(req)
-	if err != nil {
-		h.logger.Error("sidecar request failed", "error", err, "id", input.ID)
-		return nil, huma.Error502BadGateway("failed to reach sidecar")
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode >= 400 {
-		return nil, apigateway.HandleSidecarError(resp, input.ID, h.logger)
-	}
-
+	_ = resp.Body.Close()
 	return nil, nil
 }
 
@@ -335,25 +319,13 @@ func (h *Handlers) DeleteCommand(ctx context.Context, input *DeleteSandboxComman
 		return nil, err
 	}
 
-	sidecarURL := fmt.Sprintf("http://%s:%d/commands/%s", sb.Status.PodIP, h.sidecarPort, input.CmdID)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, sidecarURL, nil)
+	resp, err := h.doSidecarRoundTrip(ctx, input.ID, http.MethodDelete,
+		h.sidecarURL(sb.Status.PodIP, fmt.Sprintf("/commands/%s", input.CmdID)),
+		nil, nil)
 	if err != nil {
-		h.logger.Error("failed to build sidecar request", "error", err)
-		return nil, huma.Error500InternalServerError("failed to build sidecar request")
+		return nil, err
 	}
-
-	resp, err := h.httpClient.Do(req)
-	if err != nil {
-		h.logger.Error("sidecar request failed", "error", err, "id", input.ID)
-		return nil, huma.Error502BadGateway("failed to reach sidecar")
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode >= 400 {
-		return nil, apigateway.HandleSidecarError(resp, input.ID, h.logger)
-	}
-
+	_ = resp.Body.Close()
 	return nil, nil
 }
 

--- a/internal/api-gateway/filesystem/filesystem.go
+++ b/internal/api-gateway/filesystem/filesystem.go
@@ -78,38 +78,54 @@ func New(logger *slog.Logger, sandboxNamespace string, k8sClient client.Client, 
 	}
 }
 
+func (h *Handlers) filesystemURL(podIP, path, container string) string {
+	params := url.Values{}
+	params.Set("path", path)
+	if container != "" {
+		params.Set("container", container)
+	}
+	return fmt.Sprintf("http://%s:%d/filesystem?%s", podIP, h.sidecarPort, params.Encode())
+}
+
+func (h *Handlers) doSidecarRoundTrip(ctx context.Context, sandboxID, method, sidecarURL string, body io.Reader, headers map[string]string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, sidecarURL, body)
+	if err != nil {
+		h.logger.Error("failed to build sidecar request", "error", err)
+		return nil, huma.Error500InternalServerError("failed to build sidecar request")
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		h.logger.Error("sidecar request failed", "error", err, "id", sandboxID)
+		return nil, huma.Error502BadGateway("failed to reach sidecar")
+	}
+
+	if resp.StatusCode >= 400 {
+		defer func() { _ = resp.Body.Close() }()
+		return nil, apigateway.HandleSidecarError(resp, sandboxID, h.logger)
+	}
+
+	return resp, nil
+}
+
 func (h *Handlers) PostFilesystem(ctx context.Context, input *FilesystemWriteInput) (*FilesystemWriteOutput, error) {
 	sb, err := apigateway.GetReadySandbox(ctx, h.k8sClient, h.sandboxNamespace, input.ID, h.logger)
 	if err != nil {
 		return nil, err
 	}
 
-	params := url.Values{}
-	params.Set("path", input.Path)
-	if input.Container != "" {
-		params.Set("container", input.Container)
-	}
-	sidecarURL := fmt.Sprintf("http://%s:%d/filesystem?%s", sb.Status.PodIP, h.sidecarPort, params.Encode())
-
 	stream := httputil.NewDeadlineReader(input.Stream, input.ResponseController, httputil.StreamTimeout)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, sidecarURL, stream)
+	resp, err := h.doSidecarRoundTrip(ctx, input.ID, http.MethodPost,
+		h.filesystemURL(sb.Status.PodIP, input.Path, input.Container),
+		stream, map[string]string{"Content-Type": "application/octet-stream"})
 	if err != nil {
-		h.logger.Error("failed to build sidecar request", "error", err)
-		return nil, huma.Error500InternalServerError("failed to build sidecar request")
-	}
-	req.Header.Set("Content-Type", "application/octet-stream")
-
-	resp, err := h.httpClient.Do(req)
-	if err != nil {
-		h.logger.Error("sidecar request failed", "error", err, "id", input.ID)
-		return nil, huma.Error502BadGateway("failed to reach sidecar")
+		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode >= 400 {
-		return nil, apigateway.HandleSidecarError(resp, input.ID, h.logger)
-	}
 
 	_ = sidecarapi.FilesystemWriteResponse(FilesystemWriteResponse{}) // assert field compatibility
 	var sidecarResp sidecarapi.FilesystemWriteResponse
@@ -132,14 +148,8 @@ func (h *Handlers) GetFilesystem(ctx context.Context, input *FilesystemReadInput
 		return nil, err
 	}
 
-	params := url.Values{}
-	params.Set("path", input.Path)
-	if input.Container != "" {
-		params.Set("container", input.Container)
-	}
-	sidecarURL := fmt.Sprintf("http://%s:%d/filesystem?%s", sb.Status.PodIP, h.sidecarPort, params.Encode())
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, sidecarURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		h.filesystemURL(sb.Status.PodIP, input.Path, input.Container), nil)
 	if err != nil {
 		h.logger.Error("failed to build sidecar request", "error", err)
 		return nil, huma.Error500InternalServerError("failed to build sidecar request")

--- a/internal/operator/controller/rootfssnapshot_controller_helpers_test.go
+++ b/internal/operator/controller/rootfssnapshot_controller_helpers_test.go
@@ -45,72 +45,48 @@ func createRuntimeClassForSnapshot(ctx context.Context, name, handler string) {
 }
 
 func deleteRuntimeClassForSnapshot(ctx context.Context, name string) {
-	rc := &nodev1.RuntimeClass{}
-	err := k8sClient.Get(ctx, types.NamespacedName{Name: name}, rc)
-	if errors.IsNotFound(err) {
-		return // Already deleted
+	deleteResource(ctx, name, "", &nodev1.RuntimeClass{})
+}
+
+func createSnapshotPodWithStatus(ctx context.Context, name, runtimeClassName string, containers []corev1.Container, phase corev1.PodPhase, readyStatus corev1.ConditionStatus, containerStatuses []corev1.ContainerStatus) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+		Spec: corev1.PodSpec{
+			RuntimeClassName: &runtimeClassName,
+			Containers:       containers,
+		},
 	}
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-	ExpectWithOffset(1, client.IgnoreNotFound(k8sClient.Delete(ctx, rc))).NotTo(HaveOccurred())
+	ExpectWithOffset(2, k8sClient.Create(ctx, pod)).To(Succeed())
+
+	// Bind the pod to a node via the binding subresource (mirroring the real scheduler)
+	binding := &corev1.Binding{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+		Target:     corev1.ObjectReference{Name: "test-node"},
+	}
+	ExpectWithOffset(2, k8sClient.SubResource("binding").Create(ctx, pod, binding)).To(Succeed())
+
+	// Re-fetch after binding to get updated spec
+	ExpectWithOffset(2, k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: testNamespace}, pod)).To(Succeed())
+	pod.Status.Phase = phase
+	cond := corev1.PodCondition{Type: corev1.PodReady, Status: readyStatus}
+	if readyStatus == corev1.ConditionFalse {
+		cond.Reason = "ContainersNotReady"
+	}
+	pod.Status.Conditions = []corev1.PodCondition{cond}
+	pod.Status.ContainerStatuses = containerStatuses
+	ExpectWithOffset(2, k8sClient.Status().Update(ctx, pod)).To(Succeed())
 }
 
 func createSnapshotPod(ctx context.Context, name, runtimeClassName string, containers []corev1.Container, containerStatuses []corev1.ContainerStatus) {
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
-		Spec: corev1.PodSpec{
-			RuntimeClassName: &runtimeClassName,
-			Containers:       containers,
-		},
-	}
-	ExpectWithOffset(1, k8sClient.Create(ctx, pod)).To(Succeed())
-
-	// Bind the pod to a node via the binding subresource (mirroring the real scheduler)
-	binding := &corev1.Binding{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
-		Target:     corev1.ObjectReference{Name: "test-node"},
-	}
-	ExpectWithOffset(1, k8sClient.SubResource("binding").Create(ctx, pod, binding)).To(Succeed())
-
-	// Re-fetch after binding to get updated spec
-	ExpectWithOffset(1, k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: testNamespace}, pod)).To(Succeed())
-	pod.Status.Phase = corev1.PodRunning
-	pod.Status.Conditions = []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}
-	pod.Status.ContainerStatuses = containerStatuses
-	ExpectWithOffset(1, k8sClient.Status().Update(ctx, pod)).To(Succeed())
+	createSnapshotPodWithStatus(ctx, name, runtimeClassName, containers, corev1.PodRunning, corev1.ConditionTrue, containerStatuses)
 }
 
 func createSnapshotPodNotReady(ctx context.Context, name, runtimeClassName string, containers []corev1.Container) {
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
-		Spec: corev1.PodSpec{
-			RuntimeClassName: &runtimeClassName,
-			Containers:       containers,
-		},
-	}
-	ExpectWithOffset(1, k8sClient.Create(ctx, pod)).To(Succeed())
-
-	// Bind the pod to a node via the binding subresource (mirroring the real scheduler)
-	binding := &corev1.Binding{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
-		Target:     corev1.ObjectReference{Name: "test-node"},
-	}
-	ExpectWithOffset(1, k8sClient.SubResource("binding").Create(ctx, pod, binding)).To(Succeed())
-
-	// Re-fetch after binding to get updated spec
-	ExpectWithOffset(1, k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: testNamespace}, pod)).To(Succeed())
-	pod.Status.Phase = corev1.PodPending
-	pod.Status.Conditions = []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionFalse, Reason: "ContainersNotReady"}}
-	ExpectWithOffset(1, k8sClient.Status().Update(ctx, pod)).To(Succeed())
+	createSnapshotPodWithStatus(ctx, name, runtimeClassName, containers, corev1.PodPending, corev1.ConditionFalse, nil)
 }
 
 func deleteSnapshotPod(ctx context.Context, name string) {
-	pod := &corev1.Pod{}
-	err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: testNamespace}, pod)
-	if errors.IsNotFound(err) {
-		return // Already deleted
-	}
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-	ExpectWithOffset(1, client.IgnoreNotFound(k8sClient.Delete(ctx, pod))).NotTo(HaveOccurred())
+	deleteResource(ctx, name, testNamespace, &corev1.Pod{})
 }
 
 func createRootfsSnapshotCR(ctx context.Context, name, sandboxName string) {
@@ -133,13 +109,7 @@ func createRootfsSnapshotCRWithContainer(ctx context.Context, name, sandboxName,
 }
 
 func deleteRootfsSnapshotCR(ctx context.Context, name string) {
-	snap := &sandboxv1alpha1.RootfsSnapshot{}
-	err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: testNamespace}, snap)
-	if errors.IsNotFound(err) {
-		return // Already deleted
-	}
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-	ExpectWithOffset(1, client.IgnoreNotFound(k8sClient.Delete(ctx, snap))).NotTo(HaveOccurred())
+	deleteResource(ctx, name, testNamespace, &sandboxv1alpha1.RootfsSnapshot{})
 }
 
 func getRootfsSnapshotCR(ctx context.Context, name string) *sandboxv1alpha1.RootfsSnapshot {
@@ -245,11 +215,5 @@ func createSnapshotJobPodWithTerminationMessage(ctx context.Context, jobName str
 }
 
 func deleteSnapshotJobPod(ctx context.Context, jobName string) {
-	pod := &corev1.Pod{}
-	err := k8sClient.Get(ctx, types.NamespacedName{Name: jobName + "-pod", Namespace: testNamespace}, pod)
-	if errors.IsNotFound(err) {
-		return // Already deleted
-	}
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-	ExpectWithOffset(1, client.IgnoreNotFound(k8sClient.Delete(ctx, pod))).NotTo(HaveOccurred())
+	deleteResource(ctx, jobName+"-pod", testNamespace, &corev1.Pod{})
 }

--- a/internal/operator/controller/sandbox_controller_events_test.go
+++ b/internal/operator/controller/sandbox_controller_events_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Sandbox Controller", func() {
 		BeforeEach(func() {
 			fakeClock = NewFakeClock(time.Now())
 			recorder = events.NewFakeRecorder(100)
-			reconciler = newTestReconcilerWithRecorder(fakeClock, recorder)
+			reconciler = newTestReconciler(fakeClock, withRecorder(recorder))
 		})
 
 		It("should record PodCreated event when pod is created", func() {

--- a/internal/operator/controller/sandbox_controller_finalizer_test.go
+++ b/internal/operator/controller/sandbox_controller_finalizer_test.go
@@ -115,7 +115,7 @@ var _ = Describe("Sandbox Controller", func() {
 			runtimeClassName := "gvisor-delete"
 
 			recorder := events.NewFakeRecorder(10)
-			reconciler = newTestReconcilerWithRecorder(fakeClock, recorder)
+			reconciler = newTestReconciler(fakeClock, withRecorder(recorder))
 
 			createRuntimeClass(ctx, runtimeClassName, "runsc")
 			defer deleteRuntimeClass(ctx, runtimeClassName)

--- a/internal/operator/controller/sandbox_controller_helpers_test.go
+++ b/internal/operator/controller/sandbox_controller_helpers_test.go
@@ -87,34 +87,27 @@ func getPod(ctx context.Context, name string) *corev1.Pod {
 	return pod
 }
 
-func deleteSandbox(ctx context.Context, name string) {
-	sandbox := &sandboxv1alpha1.Sandbox{}
-	err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: testNamespace}, sandbox)
+// deleteResource fetches a resource by name and deletes it. No-op if already gone.
+// Cluster-scoped resources (e.g. RuntimeClass) should pass "" for namespace.
+func deleteResource(ctx context.Context, name, namespace string, obj client.Object) {
+	err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, obj)
 	if errors.IsNotFound(err) {
-		return // Already deleted
+		return
 	}
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-	ExpectWithOffset(1, client.IgnoreNotFound(k8sClient.Delete(ctx, sandbox))).NotTo(HaveOccurred())
+	ExpectWithOffset(2, err).NotTo(HaveOccurred())
+	ExpectWithOffset(2, client.IgnoreNotFound(k8sClient.Delete(ctx, obj))).NotTo(HaveOccurred())
+}
+
+func deleteSandbox(ctx context.Context, name string) {
+	deleteResource(ctx, name, testNamespace, &sandboxv1alpha1.Sandbox{})
 }
 
 func deleteRuntimeClass(ctx context.Context, name string) {
-	rc := &nodev1.RuntimeClass{}
-	err := k8sClient.Get(ctx, types.NamespacedName{Name: name}, rc)
-	if errors.IsNotFound(err) {
-		return // Already deleted
-	}
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-	ExpectWithOffset(1, client.IgnoreNotFound(k8sClient.Delete(ctx, rc))).NotTo(HaveOccurred())
+	deleteResource(ctx, name, "", &nodev1.RuntimeClass{})
 }
 
 func deletePod(ctx context.Context, name string) {
-	pod := &corev1.Pod{}
-	err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: testNamespace}, pod)
-	if errors.IsNotFound(err) {
-		return // Already deleted
-	}
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-	ExpectWithOffset(1, client.IgnoreNotFound(k8sClient.Delete(ctx, pod))).NotTo(HaveOccurred())
+	deleteResource(ctx, name, testNamespace, &corev1.Pod{})
 }
 
 func getRootfsSnapshot(ctx context.Context, name string) *sandboxv1alpha1.RootfsSnapshot {
@@ -131,11 +124,7 @@ func getShutdownSnapshot(ctx context.Context, sandboxName string) *sandboxv1alph
 }
 
 func deleteShutdownSnapshot(ctx context.Context, sandboxName string) {
-	snap := getShutdownSnapshot(ctx, sandboxName)
-	if snap == nil {
-		return // Already deleted
-	}
-	ExpectWithOffset(1, client.IgnoreNotFound(k8sClient.Delete(ctx, snap))).NotTo(HaveOccurred())
+	deleteResource(ctx, sandboxName+"-shutdown", testNamespace, &sandboxv1alpha1.RootfsSnapshot{})
 }
 
 func setRootfsSnapshotReady(ctx context.Context, name string, ready bool, reason, message string) {
@@ -143,23 +132,17 @@ func setRootfsSnapshotReady(ctx context.Context, name string, ready bool, reason
 	if snap == nil {
 		return
 	}
+	condType := string(sandboxv1alpha1.RootfsSnapshotFailed)
 	if ready {
-		meta.SetStatusCondition(&snap.Status.Conditions, metav1.Condition{
-			Type:               string(sandboxv1alpha1.RootfsSnapshotComplete),
-			Status:             metav1.ConditionTrue,
-			Reason:             reason,
-			Message:            message,
-			ObservedGeneration: snap.Generation,
-		})
-	} else {
-		meta.SetStatusCondition(&snap.Status.Conditions, metav1.Condition{
-			Type:               string(sandboxv1alpha1.RootfsSnapshotFailed),
-			Status:             metav1.ConditionTrue,
-			Reason:             reason,
-			Message:            message,
-			ObservedGeneration: snap.Generation,
-		})
+		condType = string(sandboxv1alpha1.RootfsSnapshotComplete)
 	}
+	meta.SetStatusCondition(&snap.Status.Conditions, metav1.Condition{
+		Type:               condType,
+		Status:             metav1.ConditionTrue,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: snap.Generation,
+	})
 	now := metav1.Now()
 	snap.Status.CompletionTime = &now
 	ExpectWithOffset(1, k8sClient.Status().Update(ctx, snap)).To(Succeed())
@@ -230,11 +213,5 @@ func getNetworkPolicy(ctx context.Context, name string) *networkingv1.NetworkPol
 }
 
 func deleteNetworkPolicy(ctx context.Context, name string) {
-	np := &networkingv1.NetworkPolicy{}
-	err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: testNamespace}, np)
-	if errors.IsNotFound(err) {
-		return // Already deleted
-	}
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-	ExpectWithOffset(1, client.IgnoreNotFound(k8sClient.Delete(ctx, np))).NotTo(HaveOccurred())
+	deleteResource(ctx, name, testNamespace, &networkingv1.NetworkPolicy{})
 }

--- a/internal/operator/controller/sandbox_controller_pod_test.go
+++ b/internal/operator/controller/sandbox_controller_pod_test.go
@@ -141,7 +141,7 @@ var _ = Describe("Sandbox Controller", func() {
 			defer deleteRuntimeClass(ctx, runtimeClassName)
 
 			// Use reconciler with RuntimeClassName configured
-			reconcilerWithRuntime := newTestReconcilerWithRuntimeClass(fakeClock, runtimeClassName)
+			reconcilerWithRuntime := newTestReconciler(fakeClock, withRuntimeClass(runtimeClassName))
 
 			createSandbox(ctx, sandboxName)
 			defer deleteSandbox(ctx, sandboxName)

--- a/internal/operator/controller/sandbox_controller_snapshot_test.go
+++ b/internal/operator/controller/sandbox_controller_snapshot_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Sandbox Controller", func() {
 			sandboxName := "sandbox-no-runtimeclass"
 
 			recorder := events.NewFakeRecorder(10)
-			reconciler = newTestReconcilerWithRecorder(fakeClock, recorder)
+			reconciler = newTestReconciler(fakeClock, withRecorder(recorder))
 
 			timeout := int64(1)
 			createSandbox(ctx, sandboxName, func(s *sandboxv1alpha1.Sandbox) {
@@ -83,7 +83,7 @@ var _ = Describe("Sandbox Controller", func() {
 			runtimeClassName := "unsupported-runtime"
 
 			recorder := events.NewFakeRecorder(10)
-			reconciler = newTestReconcilerWithRecorder(fakeClock, recorder)
+			reconciler = newTestReconciler(fakeClock, withRecorder(recorder))
 
 			createRuntimeClass(ctx, runtimeClassName, "runc") // runc is not supported for snapshotting
 			defer deleteRuntimeClass(ctx, runtimeClassName)
@@ -207,7 +207,7 @@ var _ = Describe("Sandbox Controller", func() {
 			runtimeClassName := "gvisor-success"
 
 			recorder := events.NewFakeRecorder(10)
-			reconciler = newTestReconcilerWithRecorder(fakeClock, recorder)
+			reconciler = newTestReconciler(fakeClock, withRecorder(recorder))
 
 			createRuntimeClass(ctx, runtimeClassName, "runsc")
 			defer deleteRuntimeClass(ctx, runtimeClassName)

--- a/internal/operator/controller/suite_test.go
+++ b/internal/operator/controller/suite_test.go
@@ -152,44 +152,29 @@ var _ = AfterSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 })
 
+type reconcilerOption func(*SandboxReconciler)
+
+func withRecorder(rec events.EventRecorder) reconcilerOption {
+	return func(r *SandboxReconciler) { r.Recorder = rec }
+}
+
+func withRuntimeClass(name string) reconcilerOption {
+	return func(r *SandboxReconciler) { r.RuntimeClassName = name }
+}
+
 // newTestReconciler creates a SandboxReconciler configured for testing.
 // Uses direct k8sClient for immediate consistency in tests.
 // ControllerNamespace is not set, so it defaults to sandbox's namespace (single-namespace deployment).
-func newTestReconciler(clock Clock) *SandboxReconciler {
-	rec := events.NewFakeRecorder(100)
-	return &SandboxReconciler{
+func newTestReconciler(clock Clock, opts ...reconcilerOption) *SandboxReconciler {
+	r := &SandboxReconciler{
 		Client:              k8sClient,
 		Scheme:              scheme.Scheme,
-		Recorder:            rec,
-		SandboxSidecarImage: "sandbox-sidecar:test",
-		Clock:               clock,
-		// ControllerNamespace not set - defaults to sandbox namespace
-		// ControllerLabels not set - defaults to {"app.kubernetes.io/name": "isola-controller"}
-	}
-}
-
-// newTestReconcilerWithRecorder creates a SandboxReconciler with a specific recorder for event testing.
-// Uses direct k8sClient for immediate consistency in tests.
-func newTestReconcilerWithRecorder(clock Clock, recorder events.EventRecorder) *SandboxReconciler {
-	return &SandboxReconciler{
-		Client:              k8sClient,
-		Scheme:              scheme.Scheme,
-		Recorder:            recorder,
+		Recorder:            events.NewFakeRecorder(100),
 		SandboxSidecarImage: "sandbox-sidecar:test",
 		Clock:               clock,
 	}
-}
-
-// newTestReconcilerWithRuntimeClass creates a SandboxReconciler with RuntimeClassName set.
-// Used for testing gvisor-specific features like overlay2 annotation.
-func newTestReconcilerWithRuntimeClass(clock Clock, runtimeClassName string) *SandboxReconciler {
-	rec := events.NewFakeRecorder(100)
-	return &SandboxReconciler{
-		Client:              k8sClient,
-		Scheme:              scheme.Scheme,
-		Recorder:            rec,
-		SandboxSidecarImage: "sandbox-sidecar:test",
-		Clock:               clock,
-		RuntimeClassName:    runtimeClassName,
+	for _, opt := range opts {
+		opt(r)
 	}
+	return r
 }

--- a/sdks/python/src/isola/_filesystem.py
+++ b/sdks/python/src/isola/_filesystem.py
@@ -25,33 +25,31 @@ def _filesystem_path(sandbox_id: str) -> str:
     return f"/sandboxes/{quote(sandbox_id, safe='')}/filesystem"
 
 
+def _fs_params(path: str, container: str | None) -> dict[str, str]:
+    params = {"path": path}
+    if container:
+        params["container"] = container
+    return params
+
+
 class Filesystem:
     def __init__(self, api: _SyncAPI, sandbox_id: str) -> None:
         self._api = api
         self._sandbox_id = sandbox_id
 
     def write(self, path: str, data: str | bytes | BinaryIO, *, container: str | None = None) -> FileWriteResult:
-        params = {"path": path}
-        if container:
-            params["container"] = container
-
         content: bytes | BinaryIO = data.encode() if isinstance(data, str) else data
-        result = self._api.request_model(
+        return self._api.request_model(
             "POST",
             _filesystem_path(self._sandbox_id),
             FileWriteResult,
-            params=params,
+            params=_fs_params(path, container),
             content=content,
             headers={"Content-Type": "application/octet-stream"},
         )
-        return result
 
     def read(self, path: str, *, container: str | None = None) -> bytes:
-        params = {"path": path}
-        if container:
-            params["container"] = container
-
-        return self._api.request_bytes("GET", _filesystem_path(self._sandbox_id), params=params)
+        return self._api.request_bytes("GET", _filesystem_path(self._sandbox_id), params=_fs_params(path, container))
 
 
 class AsyncFilesystem:
@@ -60,24 +58,17 @@ class AsyncFilesystem:
         self._sandbox_id = sandbox_id
 
     async def write(self, path: str, data: str | bytes | BinaryIO, *, container: str | None = None) -> FileWriteResult:
-        params = {"path": path}
-        if container:
-            params["container"] = container
-
         content: bytes | BinaryIO = data.encode() if isinstance(data, str) else data
-        result = await self._api.request_model(
+        return await self._api.request_model(
             "POST",
             _filesystem_path(self._sandbox_id),
             FileWriteResult,
-            params=params,
+            params=_fs_params(path, container),
             content=content,
             headers={"Content-Type": "application/octet-stream"},
         )
-        return result
 
     async def read(self, path: str, *, container: str | None = None) -> bytes:
-        params = {"path": path}
-        if container:
-            params["container"] = container
-
-        return await self._api.request_bytes("GET", _filesystem_path(self._sandbox_id), params=params)
+        return await self._api.request_bytes(
+            "GET", _filesystem_path(self._sandbox_id), params=_fs_params(path, container)
+        )

--- a/sdks/python/src/isola/_sandbox.py
+++ b/sdks/python/src/isola/_sandbox.py
@@ -53,6 +53,33 @@ def _build_resources(cpu: str | None, memory: str | None, ephemeral_storage: str
     return ResourcesSpec(limits=resource_list, requests=resource_list)
 
 
+def _build_create_payload(
+    image: str,
+    command: list[str] | None,
+    env: dict[str, str] | None,
+    cpu: str | None,
+    memory: str | None,
+    ephemeral_storage: str | None,
+    timeout: int | None,
+    network: NetworkSpec | None,
+    rootfs_snapshot_source: str | None,
+) -> dict[str, object]:
+    payload = CreateSandboxPayload(
+        pod_template=PodTemplate(
+            container=ContainerSpec(
+                image=image,
+                command=command,
+                env=env,
+                resources=_build_resources(cpu, memory, ephemeral_storage),
+            )
+        ),
+        timeout=timeout,
+        network=network,
+        rootfs_snapshot_sources=_build_rootfs_snapshot_sources(rootfs_snapshot_source),
+    )
+    return payload.model_dump(by_alias=True, exclude_none=True)
+
+
 class Sandboxes:
     def __init__(self, api: _SyncAPI) -> None:
         self._api = api
@@ -70,26 +97,12 @@ class Sandboxes:
         network: NetworkSpec | None = None,
         rootfs_snapshot_source: str | None = None,
     ) -> Sandbox:
-        resources = _build_resources(cpu, memory, ephemeral_storage)
-        payload = CreateSandboxPayload(
-            pod_template=PodTemplate(
-                container=ContainerSpec(
-                    image=image,
-                    command=command,
-                    env=env,
-                    resources=resources,
-                )
-            ),
-            timeout=timeout,
-            network=network,
-            rootfs_snapshot_sources=_build_rootfs_snapshot_sources(rootfs_snapshot_source),
-        )
-
         data = self._api.request_model(
-            "POST",
-            "/sandboxes",
-            SandboxData,
-            json_body=payload.model_dump(by_alias=True, exclude_none=True),
+            "POST", "/sandboxes", SandboxData,
+            json_body=_build_create_payload(
+                image, command, env, cpu, memory, ephemeral_storage,
+                timeout, network, rootfs_snapshot_source,
+            ),
         )
         return Sandbox(self._api, data)
 
@@ -119,26 +132,12 @@ class AsyncSandboxes:
         network: NetworkSpec | None = None,
         rootfs_snapshot_source: str | None = None,
     ) -> AsyncSandbox:
-        resources = _build_resources(cpu, memory, ephemeral_storage)
-        payload = CreateSandboxPayload(
-            pod_template=PodTemplate(
-                container=ContainerSpec(
-                    image=image,
-                    command=command,
-                    env=env,
-                    resources=resources,
-                )
-            ),
-            timeout=timeout,
-            network=network,
-            rootfs_snapshot_sources=_build_rootfs_snapshot_sources(rootfs_snapshot_source),
-        )
-
         data = await self._api.request_model(
-            "POST",
-            "/sandboxes",
-            SandboxData,
-            json_body=payload.model_dump(by_alias=True, exclude_none=True),
+            "POST", "/sandboxes", SandboxData,
+            json_body=_build_create_payload(
+                image, command, env, cpu, memory, ephemeral_storage,
+                timeout, network, rootfs_snapshot_source,
+            ),
         )
         return AsyncSandbox(self._api, data)
 
@@ -151,12 +150,8 @@ class AsyncSandboxes:
         return AsyncSandbox(self._api, data)
 
 
-class Sandbox:
-    def __init__(self, api: _SyncAPI, data: SandboxData) -> None:
-        self._api = api
-        self._data = data
-        self.commands = Commands(api, data.id)
-        self.filesystem = Filesystem(api, data.id)
+class _SandboxBase:
+    _data: SandboxData
 
     @property
     def id(self) -> str:
@@ -181,6 +176,14 @@ class Sandbox:
     @property
     def rootfs_snapshot_sources(self) -> list[RootfsSnapshotSource] | None:
         return self._data.rootfs_snapshot_sources
+
+
+class Sandbox(_SandboxBase):
+    def __init__(self, api: _SyncAPI, data: SandboxData) -> None:
+        self._api = api
+        self._data = data
+        self.commands = Commands(api, data.id)
+        self.filesystem = Filesystem(api, data.id)
 
     def __enter__(self) -> Sandbox:
         return self
@@ -192,36 +195,12 @@ class Sandbox:
         self._api.request_no_content("DELETE", _sandbox_path(self._data.id))
 
 
-class AsyncSandbox:
+class AsyncSandbox(_SandboxBase):
     def __init__(self, api: _AsyncAPI, data: SandboxData) -> None:
         self._api = api
         self._data = data
         self.commands = AsyncCommands(api, data.id)
         self.filesystem = AsyncFilesystem(api, data.id)
-
-    @property
-    def id(self) -> str:
-        return self._data.id
-
-    @property
-    def status(self) -> SandboxStatus:
-        return self._data.status
-
-    @property
-    def creation_timestamp(self) -> datetime:
-        return self._data.creation_timestamp
-
-    @property
-    def network(self) -> NetworkSpec | None:
-        return self._data.network
-
-    @property
-    def timeout(self) -> int | None:
-        return self._data.timeout
-
-    @property
-    def rootfs_snapshot_sources(self) -> list[RootfsSnapshotSource] | None:
-        return self._data.rootfs_snapshot_sources
 
     async def __aenter__(self) -> AsyncSandbox:
         return self


### PR DESCRIPTION
## Summary

- **api-gateway command/filesystem handlers**: Extract `doSidecarRoundTrip` and `sidecarURL`/`filesystemURL` helpers to eliminate repeated request-build/execute/error-check boilerplate (~40 lines saved)
- **operator test helpers**: Consolidate 5 nearly-identical `delete*` functions into generic `deleteResource`, merge 3 reconciler constructors into functional options pattern, merge `createSnapshotPod`/`createSnapshotPodNotReady` into shared helper, simplify `setRootfsSnapshotReady` condition logic
- **Python SDK**: Extract `_fs_params` and `_build_create_payload` helpers, extract `_SandboxBase` mixin to share 6 properties between `Sandbox`/`AsyncSandbox`
- **Makefile**: Introduce `UV_SDK` variable to deduplicate Python SDK command prefixes

Net reduction: **120 lines** across 12 files (229 insertions, 349 deletions).

## Test plan

- [x] All 105 Python SDK tests pass
- [x] Python ruff lint clean
- [x] Python mypy typecheck clean
- [ ] Go tests pass (requires Go 1.26.1 toolchain — verify in CI)

https://claude.ai/code/session_01Xx3XEu2jdHGdKetC5i3R84