### PR TITLE
Add TypeScript SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,6 +215,9 @@ coverage.html
 # Worktrees
 .worktrees/
 
+# Node.js / TypeScript
+node_modules/
+
 # Go
 bin/
 *.exe

--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,28 @@ test-sdk-python: ## Run Python SDK tests
 test-sdk-python-verbose: ## Run Python SDK tests with verbose output
 	cd sdks/python && uv run --frozen --extra dev pytest -v
 
+##@ TypeScript SDK
+
+.PHONY: sdk-typescript-install
+sdk-typescript-install: ## Install TypeScript SDK dependencies
+	cd sdks/typescript && npm ci
+
+.PHONY: sdk-typescript-typecheck
+sdk-typescript-typecheck: ## Type-check TypeScript SDK
+	cd sdks/typescript && npx tsc --noEmit
+
+.PHONY: sdk-typescript-check-all
+sdk-typescript-check-all: ## Run all TypeScript SDK checks (no tests)
+	$(MAKE) sdk-typescript-typecheck
+
+.PHONY: test-sdk-typescript
+test-sdk-typescript: ## Run TypeScript SDK tests
+	cd sdks/typescript && npx vitest run
+
+.PHONY: test-sdk-typescript-verbose
+test-sdk-typescript-verbose: ## Run TypeScript SDK tests with verbose output
+	cd sdks/typescript && npx vitest run --reporter=verbose
+
 ##@ E2E Testing
 
 E2E_WORKERS ?= 20

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,0 +1,1622 @@
+{
+  "name": "isola",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "isola",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^20.11.0",
+        "typescript": "^5.4.0",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
+      "integrity": "sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.0.tgz",
+      "integrity": "sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.0.tgz",
+      "integrity": "sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.0.tgz",
+      "integrity": "sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.0.tgz",
+      "integrity": "sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.0.tgz",
+      "integrity": "sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.0.tgz",
+      "integrity": "sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.0.tgz",
+      "integrity": "sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.0.tgz",
+      "integrity": "sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.0.tgz",
+      "integrity": "sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.0.tgz",
+      "integrity": "sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.0.tgz",
+      "integrity": "sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.0.tgz",
+      "integrity": "sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.0.tgz",
+      "integrity": "sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.0.tgz",
+      "integrity": "sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.0.tgz",
+      "integrity": "sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.0.tgz",
+      "integrity": "sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.0.tgz",
+      "integrity": "sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.0.tgz",
+      "integrity": "sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.0.tgz",
+      "integrity": "sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.0.tgz",
+      "integrity": "sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.0.tgz",
+      "integrity": "sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.0.tgz",
+      "integrity": "sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.0.tgz",
+      "integrity": "sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.0.tgz",
+      "integrity": "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
+      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
+      "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.0",
+        "@rollup/rollup-android-arm64": "4.60.0",
+        "@rollup/rollup-darwin-arm64": "4.60.0",
+        "@rollup/rollup-darwin-x64": "4.60.0",
+        "@rollup/rollup-freebsd-arm64": "4.60.0",
+        "@rollup/rollup-freebsd-x64": "4.60.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.0",
+        "@rollup/rollup-linux-arm64-musl": "4.60.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.0",
+        "@rollup/rollup-linux-loong64-musl": "4.60.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.0",
+        "@rollup/rollup-linux-x64-gnu": "4.60.0",
+        "@rollup/rollup-linux-x64-musl": "4.60.0",
+        "@rollup/rollup-openbsd-x64": "4.60.0",
+        "@rollup/rollup-openharmony-arm64": "4.60.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.0",
+        "@rollup/rollup-win32-x64-gnu": "4.60.0",
+        "@rollup/rollup-win32-x64-msvc": "4.60.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "isola",
+  "version": "0.1.0",
+  "description": "TypeScript SDK for the Isola sandbox API",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "test": "vitest run",
+    "test:verbose": "vitest run --reporter=verbose",
+    "lint": "tsc --noEmit",
+    "check-all": "tsc --noEmit && vitest run"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "typescript": "^5.4.0",
+    "vitest": "^3.0.0"
+  },
+  "license": "MIT"
+}

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -1,0 +1,273 @@
+import {
+  APIError,
+  APIConnectionError,
+  type IsolaError,
+  isTransient,
+} from "./errors.js";
+import type { StreamAPI } from "./streaming.js";
+import { VERSION } from "./version.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_RETRIES = 5;
+const INITIAL_RETRY_DELAY_S = 0.5;
+const MAX_RETRY_DELAY_S = 8.0;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+// ---------------------------------------------------------------------------
+// Request options
+// ---------------------------------------------------------------------------
+
+export interface RequestOptions {
+  /** JSON-serializable body (mutually exclusive with `content`). */
+  body?: unknown;
+  /** Raw body for binary uploads (mutually exclusive with `body`). */
+  content?: Uint8Array | Blob | ReadableStream<Uint8Array> | string;
+  /** URL query parameters. */
+  params?: Record<string, string>;
+  /** Additional request headers. */
+  headers?: Record<string, string>;
+  /** Per-request timeout override in milliseconds. */
+  timeout?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Client options
+// ---------------------------------------------------------------------------
+
+export interface APIClientOptions {
+  /** Base URL of the API (required). */
+  baseURL: string;
+  /** Default request timeout in milliseconds (default: 30000). */
+  timeout?: number;
+  /** Maximum number of retries on transient errors (default: 5). */
+  maxRetries?: number;
+  /** Headers sent with every request. Per-request headers take precedence. */
+  defaultHeaders?: Record<string, string>;
+  /**
+   * Custom `fetch` implementation. Defaults to the global `fetch`.
+   *
+   * Useful for testing or for environments where the global is unavailable.
+   */
+  fetch?: typeof globalThis.fetch;
+}
+
+// ---------------------------------------------------------------------------
+// APIClient
+// ---------------------------------------------------------------------------
+
+/**
+ * Low-level HTTP client used internally by every resource class.
+ *
+ * All public methods include automatic retry on transient errors
+ * (connection failures, 408/429/502/503/504) with exponential backoff
+ * and jitter, up to {@link DEFAULT_MAX_RETRIES} times by default.
+ *
+ * @internal
+ */
+export class APIClient implements StreamAPI {
+  private readonly baseURL: string;
+  private readonly timeout: number;
+  private readonly maxRetries: number;
+  private readonly defaultHeaders: Record<string, string>;
+  private readonly fetchFn: typeof globalThis.fetch;
+
+  constructor(options: APIClientOptions) {
+    this.baseURL = options.baseURL.replace(/\/+$/, "");
+    if (!this.baseURL) {
+      throw new Error("baseURL must be a non-empty string");
+    }
+    this.timeout = options.timeout ?? DEFAULT_TIMEOUT_MS;
+    this.maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+    this.defaultHeaders = options.defaultHeaders ?? {};
+    this.fetchFn = options.fetch ?? globalThis.fetch;
+  }
+
+  // -----------------------------------------------------------------------
+  // Public (with retry)
+  // -----------------------------------------------------------------------
+
+  /** Send a request and parse the JSON response. */
+  async request<T>(
+    method: HttpMethod,
+    path: string,
+    options?: RequestOptions,
+  ): Promise<T> {
+    return this.withRetry(async (retryCount) => {
+      const res = await this.rawFetch(method, path, options, retryCount);
+      return (await res.json()) as T;
+    });
+  }
+
+  /** Send a request that returns no body (204 / fire-and-forget). */
+  async requestNoContent(
+    method: HttpMethod,
+    path: string,
+    options?: RequestOptions,
+  ): Promise<void> {
+    await this.withRetry(async (retryCount) => {
+      await this.rawFetch(method, path, options, retryCount);
+    });
+  }
+
+  /** Send a request and return the response as raw bytes. */
+  async requestBytes(
+    method: HttpMethod,
+    path: string,
+    options?: RequestOptions,
+  ): Promise<Uint8Array> {
+    return this.withRetry(async (retryCount) => {
+      const res = await this.rawFetch(method, path, options, retryCount);
+      return new Uint8Array(await res.arrayBuffer());
+    });
+  }
+
+  /**
+   * Open an SSE stream connection (no retry — {@link StreamReader} manages
+   * its own reconnection).
+   */
+  async openStream(
+    path: string,
+    options?: { headers?: Record<string, string> },
+  ): Promise<Response> {
+    return this.rawFetch("GET", path, {
+      headers: {
+        Accept: "text/event-stream",
+        ...options?.headers,
+      },
+      // No timeout for long-lived streams.
+      timeout: 0,
+    });
+  }
+
+  // -----------------------------------------------------------------------
+  // Internals
+  // -----------------------------------------------------------------------
+
+  private async rawFetch(
+    method: HttpMethod,
+    path: string,
+    options?: RequestOptions,
+    retryCount?: number,
+  ): Promise<Response> {
+    let url = this.baseURL + path;
+    if (options?.params && Object.keys(options.params).length > 0) {
+      url += "?" + new URLSearchParams(options.params).toString();
+    }
+
+    const headers: Record<string, string> = {
+      "User-Agent": `isola-typescript/${VERSION}`,
+      ...this.defaultHeaders,
+      ...options?.headers,
+    };
+
+    if (retryCount !== undefined && retryCount > 0) {
+      headers["X-Retry-Count"] = String(retryCount);
+    }
+
+    let body: Uint8Array | Blob | ReadableStream<Uint8Array> | string | undefined;
+    if (options?.content !== undefined) {
+      body = options.content;
+    } else if (options?.body !== undefined) {
+      headers["Content-Type"] = "application/json";
+      body = JSON.stringify(options.body);
+    }
+
+    const timeout = options?.timeout ?? this.timeout;
+    const signal = timeout > 0 ? AbortSignal.timeout(timeout) : undefined;
+
+    let response: Response;
+    try {
+      response = await this.fetchFn.call(undefined, url, {
+        method,
+        headers,
+        body,
+        signal,
+      });
+    } catch (error) {
+      throw APIConnectionError.fromError(error, method, path);
+    }
+
+    if (!response.ok) {
+      const responseBody = await response.text();
+      throw APIError.fromResponse(
+        response.status,
+        responseBody,
+        response.headers,
+        method,
+        path,
+      );
+    }
+
+    return response;
+  }
+
+  /**
+   * Exponential backoff with jitter, matching Anthropic/OpenAI SDK patterns.
+   *
+   * Delay: min(initialDelay * 2^attempt, maxDelay) * jitter
+   * where jitter is uniform in [0.75, 1.0].
+   *
+   * Respects `Retry-After` / `Retry-After-Ms` headers when present.
+   */
+  private retryDelay(attempt: number, responseHeaders?: Headers): number {
+    if (responseHeaders) {
+      const retryAfterMs = responseHeaders.get("retry-after-ms");
+      if (retryAfterMs) {
+        const ms = parseFloat(retryAfterMs);
+        if (!Number.isNaN(ms)) return ms;
+      }
+
+      const retryAfter = responseHeaders.get("retry-after");
+      if (retryAfter) {
+        const seconds = parseFloat(retryAfter);
+        if (!Number.isNaN(seconds)) return seconds * 1_000;
+        const date = Date.parse(retryAfter);
+        if (!Number.isNaN(date)) return Math.max(0, date - Date.now());
+      }
+    }
+
+    const sleepSeconds = Math.min(
+      INITIAL_RETRY_DELAY_S * Math.pow(2, attempt),
+      MAX_RETRY_DELAY_S,
+    );
+    const jitter = 1 - Math.random() * 0.25;
+    return sleepSeconds * jitter * 1_000;
+  }
+
+  private async withRetry<T>(
+    fn: (retryCount: number) => Promise<T>,
+  ): Promise<T> {
+    let lastError: IsolaError | undefined;
+    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+      try {
+        return await fn(attempt);
+      } catch (error) {
+        if (
+          error instanceof APIError ||
+          error instanceof APIConnectionError
+        ) {
+          if (isTransient(error) && attempt < this.maxRetries) {
+            lastError = error;
+            const headers =
+              error instanceof APIError ? error.headers : undefined;
+            const delay = this.retryDelay(attempt, headers);
+            await new Promise((r) => setTimeout(r, delay));
+            continue;
+          }
+        }
+        throw error;
+      }
+    }
+    // Unreachable in practice — the last attempt throws.
+    throw lastError!;
+  }
+}

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -103,7 +103,11 @@ export class APIClient implements StreamAPI {
   ): Promise<T> {
     return this.withRetry(async (retryCount) => {
       const res = await this.rawFetch(method, path, options, retryCount);
-      return (await res.json()) as T;
+      try {
+        return (await res.json()) as T;
+      } catch (error) {
+        throw APIConnectionError.fromError(error, method, path);
+      }
     });
   }
 
@@ -114,7 +118,9 @@ export class APIClient implements StreamAPI {
     options?: RequestOptions,
   ): Promise<void> {
     await this.withRetry(async (retryCount) => {
-      await this.rawFetch(method, path, options, retryCount);
+      const res = await this.rawFetch(method, path, options, retryCount);
+      // Consume the body so the connection can be reused.
+      await res.body?.cancel();
     });
   }
 
@@ -126,7 +132,11 @@ export class APIClient implements StreamAPI {
   ): Promise<Uint8Array> {
     return this.withRetry(async (retryCount) => {
       const res = await this.rawFetch(method, path, options, retryCount);
-      return new Uint8Array(await res.arrayBuffer());
+      try {
+        return new Uint8Array(await res.arrayBuffer());
+      } catch (error) {
+        throw APIConnectionError.fromError(error, method, path);
+      }
     });
   }
 

--- a/sdks/typescript/src/commands.ts
+++ b/sdks/typescript/src/commands.ts
@@ -1,0 +1,228 @@
+import type { APIClient } from "./client.js";
+import type {
+  CommandResult,
+  CommandStatusResponse,
+  CreateCommandPayload,
+  CreateCommandResponse,
+} from "./models.js";
+import { StreamReader } from "./streaming.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Must be <= gateway max (25s). */
+const LONG_POLL_WAIT_SECONDS = 20;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function commandBasePath(sandboxId: string): string {
+  return `/v1/sandboxes/${encodeURIComponent(sandboxId)}/commands`;
+}
+
+function commandPath(sandboxId: string, commandId: string): string {
+  return `${commandBasePath(sandboxId)}/${encodeURIComponent(commandId)}`;
+}
+
+// ---------------------------------------------------------------------------
+// SpawnOptions / RunOptions
+// ---------------------------------------------------------------------------
+
+export interface SpawnOptions {
+  /** Environment variables for the command. */
+  env?: Record<string, string>;
+  /** Working directory inside the sandbox. */
+  cwd?: string;
+  /** Command timeout in seconds (server-enforced). */
+  timeout?: number;
+  /** Target container (multi-container sandboxes). */
+  container?: string;
+}
+
+export interface RunOptions extends SpawnOptions {
+  /** Data to write to stdin before waiting. Strings are UTF-8 encoded. */
+  input?: string | Uint8Array;
+}
+
+// ---------------------------------------------------------------------------
+// Command
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle to a running (or finished) command inside a sandbox.
+ *
+ * Obtained via {@link Commands.spawn}.
+ */
+export class Command {
+  readonly id: string;
+  private _stdout: StreamReader | null = null;
+  private _stderr: StreamReader | null = null;
+
+  /** @internal */
+  constructor(
+    private readonly api: APIClient,
+    private readonly sandboxId: string,
+    commandId: string,
+  ) {
+    this.id = commandId;
+  }
+
+  private get basePath(): string {
+    return commandPath(this.sandboxId, this.id);
+  }
+
+  // -----------------------------------------------------------------------
+  // Streaming output (lazy, single-use)
+  // -----------------------------------------------------------------------
+
+  /** SSE stream of the command's stdout. */
+  get stdout(): StreamReader {
+    if (!this._stdout) {
+      this._stdout = new StreamReader(this.api, `${this.basePath}/stdout`);
+    }
+    return this._stdout;
+  }
+
+  /** SSE stream of the command's stderr. */
+  get stderr(): StreamReader {
+    if (!this._stderr) {
+      this._stderr = new StreamReader(this.api, `${this.basePath}/stderr`);
+    }
+    return this._stderr;
+  }
+
+  // -----------------------------------------------------------------------
+  // Status
+  // -----------------------------------------------------------------------
+
+  /** Poll the exit code once (returns `null` if still running). */
+  async exitCode(): Promise<number | null> {
+    const resp = await this.api.request<CommandStatusResponse>(
+      "GET",
+      `${this.basePath}/status`,
+    );
+    return resp.exitCode;
+  }
+
+  /** Long-poll until the command exits, then return its exit code. */
+  async wait(): Promise<number> {
+    for (;;) {
+      const resp = await this.api.request<CommandStatusResponse>(
+        "GET",
+        `${this.basePath}/status`,
+        { params: { waitSeconds: String(LONG_POLL_WAIT_SECONDS) } },
+      );
+      if (resp.exitCode !== null) {
+        return resp.exitCode;
+      }
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // stdin
+  // -----------------------------------------------------------------------
+
+  /** Write data to the command's stdin. */
+  async writeStdin(data: string | Uint8Array): Promise<void> {
+    const content =
+      typeof data === "string" ? new TextEncoder().encode(data) : data;
+    await this.api.requestNoContent("POST", `${this.basePath}/stdin`, {
+      content,
+      headers: { "Content-Type": "application/octet-stream" },
+    });
+  }
+
+  /** Close the command's stdin pipe. */
+  async closeStdin(): Promise<void> {
+    await this.api.requestNoContent("POST", `${this.basePath}/stdin/close`);
+  }
+
+  // -----------------------------------------------------------------------
+  // Lifecycle
+  // -----------------------------------------------------------------------
+
+  /** Kill the command (idempotent). */
+  async kill(): Promise<void> {
+    await this.api.requestNoContent("DELETE", this.basePath);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Commands
+// ---------------------------------------------------------------------------
+
+/**
+ * Command execution on a sandbox.
+ *
+ * Obtained via {@link Sandbox.commands}.
+ */
+export class Commands {
+  /** @internal */
+  constructor(
+    private readonly api: APIClient,
+    private readonly sandboxId: string,
+  ) {}
+
+  /**
+   * Start a command without waiting for it to finish.
+   *
+   * @param args - Command and arguments (e.g. `["ls", "-la"]`).
+   *               At least one element is required.
+   * @returns A {@link Command} handle for polling status and reading output.
+   */
+  async spawn(
+    args: readonly [string, ...string[]],
+    options?: SpawnOptions,
+  ): Promise<Command> {
+    const payload: CreateCommandPayload = {
+      args,
+      env: options?.env,
+      cwd: options?.cwd,
+      timeout: options?.timeout,
+    };
+
+    const params: Record<string, string> = {};
+    if (options?.container) {
+      params.container = options.container;
+    }
+
+    const resp = await this.api.request<CreateCommandResponse>(
+      "POST",
+      commandBasePath(this.sandboxId),
+      {
+        body: payload,
+        params: Object.keys(params).length > 0 ? params : undefined,
+      },
+    );
+
+    return new Command(this.api, this.sandboxId, resp.commandId);
+  }
+
+  /**
+   * Run a command to completion and collect its output.
+   *
+   * Optionally writes {@link RunOptions.input | input} to stdin before
+   * waiting. Reads stdout, stderr, and exit code concurrently.
+   */
+  async run(
+    args: readonly [string, ...string[]],
+    options?: RunOptions,
+  ): Promise<CommandResult> {
+    const cmd = await this.spawn(args, options);
+
+    if (options?.input !== undefined) {
+      await cmd.writeStdin(options.input);
+      await cmd.closeStdin();
+    }
+
+    const [exitCode, stdout, stderr] = await Promise.all([
+      cmd.wait(),
+      cmd.stdout.read(),
+      cmd.stderr.read(),
+    ]);
+
+    return { commandId: cmd.id, stdout, stderr, exitCode };
+  }
+}

--- a/sdks/typescript/src/commands.ts
+++ b/sdks/typescript/src/commands.ts
@@ -108,11 +108,16 @@ export class Command {
 
   /** Long-poll until the command exits, then return its exit code. */
   async wait(): Promise<number> {
+    // Timeout must exceed the long-poll wait to avoid spurious timeouts.
+    const pollTimeoutMs = (LONG_POLL_WAIT_SECONDS + 15) * 1_000;
     for (;;) {
       const resp = await this.api.request<CommandStatusResponse>(
         "GET",
         `${this.basePath}/status`,
-        { params: { waitSeconds: String(LONG_POLL_WAIT_SECONDS) } },
+        {
+          params: { waitSeconds: String(LONG_POLL_WAIT_SECONDS) },
+          timeout: pollTimeoutMs,
+        },
       );
       if (resp.exitCode !== null) {
         return resp.exitCode;
@@ -217,12 +222,18 @@ export class Commands {
       await cmd.closeStdin();
     }
 
-    const [exitCode, stdout, stderr] = await Promise.all([
-      cmd.wait(),
-      cmd.stdout.read(),
-      cmd.stderr.read(),
-    ]);
+    try {
+      const [exitCode, stdout, stderr] = await Promise.all([
+        cmd.wait(),
+        cmd.stdout.read(),
+        cmd.stderr.read(),
+      ]);
 
-    return { commandId: cmd.id, stdout, stderr, exitCode };
+      return { commandId: cmd.id, stdout, stderr, exitCode };
+    } catch (error) {
+      // Kill the command to prevent dangling long-poll promises.
+      await cmd.kill().catch(() => {});
+      throw error;
+    }
   }
 }

--- a/sdks/typescript/src/errors.ts
+++ b/sdks/typescript/src/errors.ts
@@ -122,7 +122,7 @@ export class APIConnectionError extends IsolaError {
 }
 
 /** Returns true for errors that are safe to retry (connection failures, 408/429/502/503/504). */
-export function isTransient(error: IsolaError): boolean {
+export function isTransient(error: unknown): boolean {
   if (error instanceof APIConnectionError) return true;
   if (error instanceof APIError) {
     return (

--- a/sdks/typescript/src/errors.ts
+++ b/sdks/typescript/src/errors.ts
@@ -1,0 +1,137 @@
+/**
+ * Error hierarchy for the Isola SDK.
+ *
+ * IsolaError
+ * ├── APIError (status code from server)
+ * │   ├── BadRequestError (400)
+ * │   ├── NotFoundError (404)
+ * │   ├── ConflictError (409)
+ * │   ├── ValidationError (422)
+ * │   ├── InternalError (500)
+ * │   └── BadGatewayError (502)
+ * └── APIConnectionError (transport / network)
+ */
+
+export class IsolaError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "IsolaError";
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export class APIError extends IsolaError {
+  readonly status: number;
+  readonly headers: Headers;
+
+  constructor(status: number, message: string, headers: Headers) {
+    super(message);
+    this.name = "APIError";
+    this.status = status;
+    this.headers = headers;
+  }
+
+  /** Build the appropriate error subclass from an HTTP response. */
+  static fromResponse(
+    status: number,
+    body: string,
+    headers: Headers,
+    method: string,
+    path: string,
+  ): APIError {
+    let detail: string;
+    try {
+      const parsed = JSON.parse(body) as Record<string, unknown>;
+      detail =
+        typeof parsed.detail === "string"
+          ? parsed.detail
+          : typeof parsed.message === "string"
+            ? parsed.message
+            : body;
+    } catch {
+      detail = body || `request failed with status ${status}`;
+    }
+
+    const message = `${method} ${path}: ${detail}`;
+
+    switch (status) {
+      case 400:
+        return new BadRequestError(status, message, headers);
+      case 404:
+        return new NotFoundError(status, message, headers);
+      case 409:
+        return new ConflictError(status, message, headers);
+      case 422:
+        return new ValidationError(status, message, headers);
+      case 500:
+        return new InternalError(status, message, headers);
+      case 502:
+        return new BadGatewayError(status, message, headers);
+      default:
+        return new APIError(status, message, headers);
+    }
+  }
+}
+
+export class BadRequestError extends APIError {
+  override readonly name = "BadRequestError";
+}
+
+export class NotFoundError extends APIError {
+  override readonly name = "NotFoundError";
+}
+
+export class ConflictError extends APIError {
+  override readonly name = "ConflictError";
+}
+
+export class ValidationError extends APIError {
+  override readonly name = "ValidationError";
+}
+
+export class InternalError extends APIError {
+  override readonly name = "InternalError";
+}
+
+export class BadGatewayError extends APIError {
+  override readonly name = "BadGatewayError";
+}
+
+export class APIConnectionError extends IsolaError {
+  override readonly cause: Error | undefined;
+
+  constructor(message: string, cause?: Error) {
+    super(message);
+    this.name = "APIConnectionError";
+    this.cause = cause;
+  }
+
+  /** Wrap a transport-level error with request context. */
+  static fromError(
+    error: unknown,
+    method: string,
+    path: string,
+  ): APIConnectionError {
+    const cause = error instanceof Error ? error : undefined;
+    const detail = error instanceof Error ? error.message : String(error);
+    return new APIConnectionError(
+      `${method} ${path}: connection error: ${detail}`,
+      cause,
+    );
+  }
+}
+
+/** Returns true for errors that are safe to retry (connection failures, 408/429/502/503/504). */
+export function isTransient(error: IsolaError): boolean {
+  if (error instanceof APIConnectionError) return true;
+  if (error instanceof APIError) {
+    return (
+      error.status === 408 ||
+      error.status === 429 ||
+      error.status === 502 ||
+      error.status === 503 ||
+      error.status === 504
+    );
+  }
+  return false;
+}

--- a/sdks/typescript/src/filesystem.ts
+++ b/sdks/typescript/src/filesystem.ts
@@ -1,0 +1,75 @@
+import type { APIClient } from "./client.js";
+import type { FileWriteResult } from "./models.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function filesystemPath(sandboxId: string): string {
+  return `/v1/sandboxes/${encodeURIComponent(sandboxId)}/filesystem`;
+}
+
+// ---------------------------------------------------------------------------
+// Filesystem
+// ---------------------------------------------------------------------------
+
+/**
+ * File I/O operations on a sandbox's filesystem.
+ *
+ * Obtained via {@link Sandbox.filesystem}.
+ */
+export class Filesystem {
+  /** @internal */
+  constructor(
+    private readonly api: APIClient,
+    private readonly sandboxId: string,
+  ) {}
+
+  /**
+   * Upload a file into the sandbox.
+   *
+   * @param path     - Absolute path inside the sandbox.
+   * @param data     - File content. Strings are UTF-8 encoded.
+   * @param options  - Optional container name for multi-container sandboxes.
+   */
+  async write(
+    path: string,
+    data: string | Uint8Array | Blob | ReadableStream<Uint8Array>,
+    options?: { container?: string },
+  ): Promise<FileWriteResult> {
+    const params: Record<string, string> = { path };
+    if (options?.container) {
+      params.container = options.container;
+    }
+
+    const content =
+      typeof data === "string" ? new TextEncoder().encode(data) : data;
+
+    return this.api.request<FileWriteResult>("POST", filesystemPath(this.sandboxId), {
+      content,
+      headers: { "Content-Type": "application/octet-stream" },
+      params,
+    });
+  }
+
+  /**
+   * Download a file from the sandbox.
+   *
+   * @param path     - Absolute path inside the sandbox.
+   * @param options  - Optional container name for multi-container sandboxes.
+   * @returns Raw file bytes.
+   */
+  async read(
+    path: string,
+    options?: { container?: string },
+  ): Promise<Uint8Array> {
+    const params: Record<string, string> = { path };
+    if (options?.container) {
+      params.container = options.container;
+    }
+
+    return this.api.requestBytes("GET", filesystemPath(this.sandboxId), {
+      params,
+    });
+  }
+}

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -1,0 +1,57 @@
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+export { Isola, type IsolaOptions } from "./isola.js";
+
+// ---------------------------------------------------------------------------
+// Resources
+// ---------------------------------------------------------------------------
+export { Sandboxes, Sandbox, type CreateSandboxOptions } from "./sandbox.js";
+export {
+  Commands,
+  Command,
+  type SpawnOptions,
+  type RunOptions,
+} from "./commands.js";
+export { Filesystem } from "./filesystem.js";
+export { StreamReader } from "./streaming.js";
+
+// ---------------------------------------------------------------------------
+// Models / types
+// ---------------------------------------------------------------------------
+export type {
+  SandboxStatus,
+  NetworkSpec,
+  RootfsSnapshotSource,
+  ResourceList,
+  ResourcesSpec,
+  ContainerSpec,
+  ContainerInfo,
+  PodTemplate,
+  PodTemplateInfo,
+  SandboxSummary,
+  SandboxData,
+  CommandResult,
+  FileWriteResult,
+} from "./models.js";
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+export {
+  IsolaError,
+  APIError,
+  BadRequestError,
+  NotFoundError,
+  ConflictError,
+  ValidationError,
+  InternalError,
+  BadGatewayError,
+  APIConnectionError,
+  isTransient,
+} from "./errors.js";
+
+// ---------------------------------------------------------------------------
+// Version
+// ---------------------------------------------------------------------------
+export { VERSION } from "./version.js";

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -19,8 +19,8 @@ export { StreamReader } from "./streaming.js";
 // ---------------------------------------------------------------------------
 // Models / types
 // ---------------------------------------------------------------------------
+export { SandboxStatus } from "./models.js";
 export type {
-  SandboxStatus,
   NetworkSpec,
   RootfsSnapshotSource,
   ResourceList,

--- a/sdks/typescript/src/isola.ts
+++ b/sdks/typescript/src/isola.ts
@@ -1,0 +1,81 @@
+import { APIClient } from "./client.js";
+import { Sandboxes } from "./sandbox.js";
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface IsolaOptions {
+  /**
+   * Base URL of the Isola API gateway.
+   *
+   * Falls back to the `ISOLA_BASE_URL` environment variable when omitted.
+   */
+  baseURL?: string;
+
+  /** Default request timeout in milliseconds (default: 30000). */
+  timeout?: number;
+
+  /** Maximum number of retries on transient errors (default: 5). */
+  maxRetries?: number;
+
+  /** Headers sent with every request. Per-request headers take precedence. */
+  defaultHeaders?: Record<string, string>;
+
+  /**
+   * Custom `fetch` implementation. Defaults to the global `fetch`.
+   *
+   * Useful for testing or for environments where the global is unavailable.
+   */
+  fetch?: typeof globalThis.fetch;
+}
+
+// ---------------------------------------------------------------------------
+// Isola (top-level client)
+// ---------------------------------------------------------------------------
+
+/**
+ * Entry point for the Isola SDK.
+ *
+ * ```ts
+ * const isola = new Isola({ baseURL: "http://localhost:8080" });
+ * const sandbox = await isola.sandboxes.create({ image: "ubuntu:24.04" });
+ * ```
+ */
+export class Isola {
+  readonly sandboxes: Sandboxes;
+
+  constructor(options?: IsolaOptions) {
+    const baseURL =
+      options?.baseURL ??
+      (typeof process !== "undefined" ? process.env.ISOLA_BASE_URL : undefined);
+
+    if (!baseURL) {
+      throw new Error(
+        "baseURL must be provided or set via the ISOLA_BASE_URL environment variable",
+      );
+    }
+
+    const api = new APIClient({
+      baseURL,
+      timeout: options?.timeout,
+      maxRetries: options?.maxRetries,
+      defaultHeaders: options?.defaultHeaders,
+      fetch: options?.fetch,
+    });
+    this.sandboxes = new Sandboxes(api);
+  }
+
+  /** Release any resources held by the client. */
+  close(): void {
+    // Reserved for future connection pool cleanup.
+  }
+
+  /**
+   * Support `using client = ...` (TC39 Explicit Resource Management).
+   * Calls {@link close} on disposal.
+   */
+  [Symbol.dispose](): void {
+    this.close();
+  }
+}

--- a/sdks/typescript/src/models.ts
+++ b/sdks/typescript/src/models.ts
@@ -1,0 +1,145 @@
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+export type SandboxStatus =
+  | "creating"
+  | "running"
+  | "shuttingDown"
+  | "failed"
+  | "stopped"
+  | "unknown";
+
+// ---------------------------------------------------------------------------
+// Network & Resources
+// ---------------------------------------------------------------------------
+
+export interface NetworkSpec {
+  allowInternetEgress?: boolean;
+  allowClusterDNS?: boolean;
+  allowedEgressCIDRs?: string[];
+  nameservers?: string[];
+}
+
+export interface ResourceList {
+  cpu?: string;
+  memory?: string;
+  ephemeralStorage?: string;
+}
+
+export interface ResourcesSpec {
+  limits?: ResourceList;
+  requests?: ResourceList;
+}
+
+// ---------------------------------------------------------------------------
+// Container
+// ---------------------------------------------------------------------------
+
+/** Container specification sent in create requests. */
+export interface ContainerSpec {
+  image: string;
+  command?: string[];
+  env?: Record<string, string>;
+  resources?: ResourcesSpec;
+}
+
+/** Container information returned in responses (env intentionally omitted). */
+export interface ContainerInfo {
+  image: string;
+  command?: string[];
+  resources?: ResourcesSpec;
+}
+
+// ---------------------------------------------------------------------------
+// Pod Template
+// ---------------------------------------------------------------------------
+
+export interface PodTemplate {
+  container: ContainerSpec;
+}
+
+export interface PodTemplateInfo {
+  container: ContainerInfo;
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot
+// ---------------------------------------------------------------------------
+
+export interface RootfsSnapshotSource {
+  snapshotName: string;
+  containerName?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Sandbox (request / response)
+// ---------------------------------------------------------------------------
+
+/** @internal Payload sent to POST /v1/sandboxes. */
+export interface CreateSandboxPayload {
+  podTemplate: PodTemplate;
+  activeDeadlineSeconds?: number;
+  network?: NetworkSpec;
+  rootfsSnapshotSources?: RootfsSnapshotSource[];
+}
+
+export interface SandboxSummary {
+  id: string;
+  status: SandboxStatus;
+  creationTimestamp: string;
+}
+
+export interface SandboxData {
+  id: string;
+  podTemplate: PodTemplateInfo;
+  status: SandboxStatus;
+  creationTimestamp: string;
+  activeDeadlineSeconds?: number;
+  network?: NetworkSpec;
+  rootfsSnapshotSources?: RootfsSnapshotSource[];
+}
+
+/** @internal Wrapper for the list endpoint response. */
+export interface ListSandboxesResponse {
+  sandboxes?: SandboxSummary[];
+}
+
+// ---------------------------------------------------------------------------
+// Command (request / response)
+// ---------------------------------------------------------------------------
+
+/** @internal Payload sent to POST /v1/sandboxes/{id}/commands. */
+export interface CreateCommandPayload {
+  args: readonly string[];
+  env?: Record<string, string>;
+  cwd?: string;
+  timeout?: number;
+}
+
+/** @internal Response from POST /v1/sandboxes/{id}/commands (202). */
+export interface CreateCommandResponse {
+  commandId: string;
+}
+
+/** @internal Response from GET .../commands/{id}/status. */
+export interface CommandStatusResponse {
+  exitCode: number | null;
+}
+
+/** Result returned by {@link Commands.run}. */
+export interface CommandResult {
+  readonly commandId: string;
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number;
+}
+
+// ---------------------------------------------------------------------------
+// Filesystem
+// ---------------------------------------------------------------------------
+
+export interface FileWriteResult {
+  absolutePath: string;
+  bytesWritten: number;
+}

--- a/sdks/typescript/src/models.ts
+++ b/sdks/typescript/src/models.ts
@@ -2,13 +2,16 @@
 // Enums
 // ---------------------------------------------------------------------------
 
-export type SandboxStatus =
-  | "creating"
-  | "running"
-  | "shuttingDown"
-  | "failed"
-  | "stopped"
-  | "unknown";
+export const SandboxStatus = {
+  Creating: "creating",
+  Running: "running",
+  ShuttingDown: "shuttingDown",
+  Failed: "failed",
+  Stopped: "stopped",
+  Unknown: "unknown",
+} as const;
+
+export type SandboxStatus = (typeof SandboxStatus)[keyof typeof SandboxStatus];
 
 // ---------------------------------------------------------------------------
 // Network & Resources

--- a/sdks/typescript/src/sandbox.ts
+++ b/sdks/typescript/src/sandbox.ts
@@ -1,0 +1,177 @@
+import type { APIClient } from "./client.js";
+import type {
+  CreateSandboxPayload,
+  ListSandboxesResponse,
+  NetworkSpec,
+  ResourceList,
+  ResourcesSpec,
+  RootfsSnapshotSource,
+  SandboxData,
+  SandboxStatus,
+  SandboxSummary,
+} from "./models.js";
+import { Commands } from "./commands.js";
+import { Filesystem } from "./filesystem.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function sandboxPath(sandboxId: string): string {
+  return `/v1/sandboxes/${encodeURIComponent(sandboxId)}`;
+}
+
+function buildResources(
+  cpu?: string,
+  memory?: string,
+  ephemeralStorage?: string,
+): ResourcesSpec | undefined {
+  if (cpu === undefined && memory === undefined && ephemeralStorage === undefined) {
+    return undefined;
+  }
+  const list: ResourceList = { cpu, memory, ephemeralStorage };
+  return { limits: list, requests: list };
+}
+
+function buildRootfsSnapshotSources(
+  source?: string,
+): RootfsSnapshotSource[] | undefined {
+  if (source === undefined) return undefined;
+  return [{ snapshotName: source }];
+}
+
+// ---------------------------------------------------------------------------
+// CreateSandboxOptions
+// ---------------------------------------------------------------------------
+
+export interface CreateSandboxOptions {
+  /** Container image (required). */
+  image: string;
+  /** Override the container entrypoint. */
+  command?: string[];
+  /** Environment variables injected into the container. */
+  env?: Record<string, string>;
+  /** CPU resource request/limit (e.g. `"1"`, `"500m"`). */
+  cpu?: string;
+  /** Memory resource request/limit (e.g. `"512Mi"`, `"1Gi"`). */
+  memory?: string;
+  /** Ephemeral storage request/limit (e.g. `"1Gi"`). */
+  ephemeralStorage?: string;
+  /** Maximum lifetime in seconds (`activeDeadlineSeconds`). */
+  timeout?: number;
+  /** Network isolation rules. */
+  network?: NetworkSpec;
+  /** Restore from a prior rootfs snapshot by name. */
+  rootfsSnapshotSource?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Sandboxes (resource collection)
+// ---------------------------------------------------------------------------
+
+/**
+ * CRUD operations on sandboxes.
+ *
+ * Obtained via {@link Isola.sandboxes}.
+ */
+export class Sandboxes {
+  /** @internal */
+  constructor(private readonly api: APIClient) {}
+
+  /** Create a new sandbox and return a {@link Sandbox} handle. */
+  async create(options: CreateSandboxOptions): Promise<Sandbox> {
+    const payload: CreateSandboxPayload = {
+      podTemplate: {
+        container: {
+          image: options.image,
+          command: options.command,
+          env: options.env,
+          resources: buildResources(
+            options.cpu,
+            options.memory,
+            options.ephemeralStorage,
+          ),
+        },
+      },
+      activeDeadlineSeconds: options.timeout,
+      network: options.network,
+      rootfsSnapshotSources: buildRootfsSnapshotSources(
+        options.rootfsSnapshotSource,
+      ),
+    };
+
+    const data = await this.api.request<SandboxData>(
+      "POST",
+      "/v1/sandboxes",
+      { body: payload },
+    );
+
+    return new Sandbox(this.api, data);
+  }
+
+  /** List all sandboxes. */
+  async list(): Promise<SandboxSummary[]> {
+    const resp = await this.api.request<ListSandboxesResponse>(
+      "GET",
+      "/v1/sandboxes",
+    );
+    return resp.sandboxes ?? [];
+  }
+
+  /** Get a sandbox by ID. */
+  async get(sandboxId: string): Promise<Sandbox> {
+    const data = await this.api.request<SandboxData>(
+      "GET",
+      sandboxPath(sandboxId),
+    );
+    return new Sandbox(this.api, data);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sandbox
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle to a single sandbox instance.
+ *
+ * Provides access to {@link commands} and {@link filesystem} sub-resources.
+ */
+export class Sandbox {
+  readonly id: string;
+  readonly status: SandboxStatus;
+  readonly creationTimestamp: string;
+  readonly network?: NetworkSpec;
+  readonly timeout?: number;
+  readonly rootfsSnapshotSources?: RootfsSnapshotSource[];
+  readonly commands: Commands;
+  readonly filesystem: Filesystem;
+
+  /** @internal */
+  constructor(
+    private readonly api: APIClient,
+    data: SandboxData,
+  ) {
+    this.id = data.id;
+    this.status = data.status;
+    this.creationTimestamp = data.creationTimestamp;
+    this.network = data.network;
+    this.timeout = data.activeDeadlineSeconds;
+    this.rootfsSnapshotSources = data.rootfsSnapshotSources;
+    this.commands = new Commands(api, data.id);
+    this.filesystem = new Filesystem(api, data.id);
+  }
+
+  /** Delete this sandbox (idempotent). */
+  async delete(): Promise<void> {
+    await this.api.requestNoContent("DELETE", sandboxPath(this.id));
+  }
+
+  /**
+   * Support `await using sandbox = ...` (TC39 Explicit Resource Management).
+   * Calls {@link delete} on disposal.
+   */
+  async [Symbol.asyncDispose](): Promise<void> {
+    await this.delete();
+  }
+}

--- a/sdks/typescript/src/sandbox.ts
+++ b/sdks/typescript/src/sandbox.ts
@@ -140,7 +140,7 @@ export class Sandboxes {
 export class Sandbox {
   readonly id: string;
   readonly status: SandboxStatus;
-  readonly creationTimestamp: string;
+  readonly creationTimestamp: Date;
   readonly network?: NetworkSpec;
   readonly timeout?: number;
   readonly rootfsSnapshotSources?: RootfsSnapshotSource[];
@@ -154,7 +154,7 @@ export class Sandbox {
   ) {
     this.id = data.id;
     this.status = data.status;
-    this.creationTimestamp = data.creationTimestamp;
+    this.creationTimestamp = new Date(data.creationTimestamp);
     this.network = data.network;
     this.timeout = data.activeDeadlineSeconds;
     this.rootfsSnapshotSources = data.rootfsSnapshotSources;

--- a/sdks/typescript/src/streaming.ts
+++ b/sdks/typescript/src/streaming.ts
@@ -1,0 +1,184 @@
+import {
+  type IsolaError,
+  APIError,
+  APIConnectionError,
+  isTransient,
+} from "./errors.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAX_RECONNECTS = 5;
+const RETRY_DELAY_MS = 1_000;
+
+// ---------------------------------------------------------------------------
+// StreamAPI interface (avoids circular dependency with client.ts)
+// ---------------------------------------------------------------------------
+
+/** Minimal contract that {@link StreamReader} needs from the HTTP layer. */
+export interface StreamAPI {
+  openStream(
+    path: string,
+    options?: { headers?: Record<string, string> },
+  ): Promise<Response>;
+}
+
+// ---------------------------------------------------------------------------
+// SSE parser
+// ---------------------------------------------------------------------------
+
+interface SSEEvent {
+  data?: string;
+  id?: string;
+}
+
+/** Parse a ReadableStream of bytes as an SSE event stream. */
+async function* parseSSE(
+  body: ReadableStream<Uint8Array>,
+): AsyncGenerator<SSEEvent> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let dataLines: string[] = [];
+  let currentId: string | undefined;
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      // Keep the last (potentially incomplete) line in the buffer.
+      buffer = lines.pop()!;
+
+      for (const rawLine of lines) {
+        const line = rawLine.endsWith("\r")
+          ? rawLine.slice(0, -1)
+          : rawLine;
+
+        if (line === "") {
+          // Blank line → dispatch event.
+          if (dataLines.length > 0) {
+            yield { data: dataLines.join("\n"), id: currentId };
+            dataLines = [];
+            currentId = undefined;
+          }
+          continue;
+        }
+
+        const colonIdx = line.indexOf(":");
+        if (colonIdx === 0) continue; // Comment (keepalive).
+
+        const field =
+          colonIdx > 0 ? line.slice(0, colonIdx) : line;
+        const val =
+          colonIdx > 0 ? line.slice(colonIdx + 1).replace(/^ /, "") : "";
+
+        switch (field) {
+          case "data":
+            dataLines.push(val);
+            break;
+          case "id":
+            currentId = val;
+            break;
+        }
+      }
+    }
+
+    // Flush any trailing data that wasn't terminated by a blank line.
+    if (dataLines.length > 0) {
+      yield { data: dataLines.join("\n"), id: currentId };
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// StreamReader
+// ---------------------------------------------------------------------------
+
+/**
+ * Async-iterable reader for an SSE stream with transparent reconnection.
+ *
+ * Tracks the last event `id` and sends it as `Last-Event-ID` on reconnect
+ * so the server can resume from the correct byte offset.
+ *
+ * Single-use: iterating a second time throws an error.
+ */
+export class StreamReader implements AsyncIterable<string> {
+  private readonly api: StreamAPI;
+  private readonly path: string;
+  private consumed = false;
+  private lastEventId: string | null = null;
+
+  /** @internal */
+  constructor(api: StreamAPI, path: string) {
+    this.api = api;
+    this.path = path;
+  }
+
+  async *[Symbol.asyncIterator](): AsyncIterableIterator<string> {
+    if (this.consumed) {
+      throw new Error("StreamReader has already been consumed");
+    }
+    this.consumed = true;
+
+    let reconnects = 0;
+
+    for (;;) {
+      try {
+        const headers: Record<string, string> = {};
+        if (this.lastEventId !== null) {
+          headers["Last-Event-ID"] = this.lastEventId;
+        }
+
+        const response = await this.api.openStream(this.path, { headers });
+
+        if (!response.body) {
+          throw new Error("Response body is not readable");
+        }
+
+        for await (const event of parseSSE(response.body)) {
+          if (event.id !== undefined) {
+            this.lastEventId = event.id;
+          }
+          if (event.data !== undefined) {
+            // Reset reconnect counter on successful data delivery,
+            // matching the Python SDK behavior.
+            reconnects = 0;
+            yield event.data;
+          }
+        }
+
+        // Stream completed normally.
+        return;
+      } catch (error) {
+        const isIsolaErr =
+          error instanceof APIError ||
+          error instanceof APIConnectionError;
+        if (
+          isIsolaErr &&
+          isTransient(error as IsolaError) &&
+          reconnects < MAX_RECONNECTS
+        ) {
+          reconnects++;
+          await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
+          continue;
+        }
+        throw error;
+      }
+    }
+  }
+
+  /** Consume the entire stream and return its content as a single string. */
+  async read(): Promise<string> {
+    const chunks: string[] = [];
+    for await (const chunk of this) {
+      chunks.push(chunk);
+    }
+    return chunks.join("");
+  }
+}

--- a/sdks/typescript/src/streaming.ts
+++ b/sdks/typescript/src/streaming.ts
@@ -87,6 +87,18 @@ async function* parseSSE(
       }
     }
 
+    // Process any remaining data left in the buffer.
+    if (buffer) {
+      const line = buffer.endsWith("\r") ? buffer.slice(0, -1) : buffer;
+      const colonIdx = line.indexOf(":");
+      if (colonIdx !== 0) {
+        const field = colonIdx > 0 ? line.slice(0, colonIdx) : line;
+        const val = colonIdx > 0 ? line.slice(colonIdx + 1).replace(/^ /, "") : "";
+        if (field === "data") dataLines.push(val);
+        else if (field === "id") currentId = val;
+      }
+    }
+
     // Flush any trailing data that wasn't terminated by a blank line.
     if (dataLines.length > 0) {
       yield { data: dataLines.join("\n"), id: currentId };

--- a/sdks/typescript/src/streaming.ts
+++ b/sdks/typescript/src/streaming.ts
@@ -92,7 +92,9 @@ async function* parseSSE(
       yield { data: dataLines.join("\n"), id: currentId };
     }
   } finally {
-    reader.releaseLock();
+    // cancel() both cancels the underlying stream and releases the lock,
+    // ensuring the connection is freed on error or early return.
+    await reader.cancel().catch(() => {});
   }
 }
 

--- a/sdks/typescript/src/streaming.ts
+++ b/sdks/typescript/src/streaming.ts
@@ -1,9 +1,4 @@
-import {
-  type IsolaError,
-  APIError,
-  APIConnectionError,
-  isTransient,
-} from "./errors.js";
+import { isTransient } from "./errors.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -170,12 +165,8 @@ export class StreamReader implements AsyncIterable<string> {
         // Stream completed normally.
         return;
       } catch (error) {
-        const isIsolaErr =
-          error instanceof APIError ||
-          error instanceof APIConnectionError;
         if (
-          isIsolaErr &&
-          isTransient(error as IsolaError) &&
+          isTransient(error) &&
           reconnects < MAX_RECONNECTS
         ) {
           reconnects++;

--- a/sdks/typescript/src/version.ts
+++ b/sdks/typescript/src/version.ts
@@ -1,0 +1,2 @@
+/** SDK version, kept in sync with package.json. */
+export const VERSION = "0.1.0";

--- a/sdks/typescript/tests/client.test.ts
+++ b/sdks/typescript/tests/client.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { APIClient } from "../src/client.js";
+import { Isola } from "../src/isola.js";
+import {
+  APIConnectionError,
+  BadRequestError,
+  BadGatewayError,
+} from "../src/errors.js";
+import {
+  mockFetch,
+  installMockFetch,
+  jsonResponse,
+  noContentResponse,
+  errorResponse,
+} from "./helpers.js";
+
+installMockFetch();
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// Isola client
+// ---------------------------------------------------------------------------
+
+describe("Isola", () => {
+  it("creates from explicit baseURL", () => {
+    const client = new Isola({ baseURL: "http://localhost:8080" });
+    expect(client.sandboxes).toBeDefined();
+    client.close();
+  });
+
+  it("creates from ISOLA_BASE_URL env var", () => {
+    const original = process.env.ISOLA_BASE_URL;
+    try {
+      process.env.ISOLA_BASE_URL = "http://env-url:8080";
+      const client = new Isola();
+      expect(client.sandboxes).toBeDefined();
+      client.close();
+    } finally {
+      if (original !== undefined) {
+        process.env.ISOLA_BASE_URL = original;
+      } else {
+        delete process.env.ISOLA_BASE_URL;
+      }
+    }
+  });
+
+  it("throws when no baseURL is available", () => {
+    const original = process.env.ISOLA_BASE_URL;
+    try {
+      delete process.env.ISOLA_BASE_URL;
+      expect(() => new Isola()).toThrow("baseURL");
+    } finally {
+      if (original !== undefined) {
+        process.env.ISOLA_BASE_URL = original;
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// APIClient — request
+// ---------------------------------------------------------------------------
+
+describe("APIClient.request", () => {
+  const api = new APIClient({ baseURL: "http://localhost:8080" });
+
+  it("sends JSON body and parses response", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ id: "123" }));
+
+    const result = await api.request<{ id: string }>("POST", "/v1/test", {
+      body: { name: "foo" },
+    });
+
+    expect(result).toEqual({ id: "123" });
+    expect(mockFetch).toHaveBeenCalledOnce();
+
+    const [url, init] = mockFetch.mock.calls[0]!;
+    expect(url).toBe("http://localhost:8080/v1/test");
+    expect(init?.method).toBe("POST");
+    expect(init?.headers).toEqual(
+      expect.objectContaining({ "Content-Type": "application/json" }),
+    );
+    expect(init?.body).toBe(JSON.stringify({ name: "foo" }));
+  });
+
+  it("appends query params", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({}));
+
+    await api.request("GET", "/v1/test", {
+      params: { path: "/tmp/file", container: "main" },
+    });
+
+    const [url] = mockFetch.mock.calls[0]!;
+    expect(url).toContain("path=%2Ftmp%2Ffile");
+    expect(url).toContain("container=main");
+  });
+
+  it("strips trailing slashes from baseURL", async () => {
+    const client = new APIClient({ baseURL: "http://localhost:8080///" });
+    mockFetch.mockResolvedValueOnce(jsonResponse({}));
+
+    await client.request("GET", "/v1/test");
+
+    const [url] = mockFetch.mock.calls[0]!;
+    expect(url).toBe("http://localhost:8080/v1/test");
+  });
+
+  it("throws APIError on non-OK status", async () => {
+    mockFetch.mockResolvedValueOnce(errorResponse(400, "invalid"));
+
+    await expect(api.request("POST", "/v1/test")).rejects.toThrow(
+      BadRequestError,
+    );
+  });
+
+  it("throws APIConnectionError on fetch failure", async () => {
+    // Use persistent mock — all retry attempts also fail
+    mockFetch.mockRejectedValue(new TypeError("fetch failed"));
+
+    await expect(api.request("GET", "/v1/test")).rejects.toThrow(
+      APIConnectionError,
+    );
+  }, 15_000);
+});
+
+// ---------------------------------------------------------------------------
+// Retry logic
+// ---------------------------------------------------------------------------
+
+describe("APIClient retry", () => {
+  const api = new APIClient({ baseURL: "http://localhost:8080" });
+
+  it("retries on transient 502 errors", async () => {
+    mockFetch
+      .mockResolvedValueOnce(errorResponse(502, "bad gateway"))
+      .mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+    const result = await api.request<{ ok: boolean }>("GET", "/v1/test");
+    expect(result).toEqual({ ok: true });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries on connection errors", async () => {
+    mockFetch
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+    const result = await api.request<{ ok: boolean }>("GET", "/v1/test");
+    expect(result).toEqual({ ok: true });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry on 4xx errors", async () => {
+    mockFetch.mockResolvedValue(errorResponse(400, "bad request"));
+
+    await expect(api.request("POST", "/v1/test")).rejects.toThrow(
+      BadRequestError,
+    );
+    expect(mockFetch).toHaveBeenCalledOnce();
+  });
+
+  it("gives up after max retries", async () => {
+    for (let i = 0; i < 6; i++) {
+      mockFetch.mockResolvedValueOnce(errorResponse(502, "bad gateway"));
+    }
+
+    await expect(api.request("GET", "/v1/test")).rejects.toThrow(
+      BadGatewayError,
+    );
+    expect(mockFetch).toHaveBeenCalledTimes(6);
+  }, 15_000);
+});
+
+// ---------------------------------------------------------------------------
+// Retry with fake timers
+// ---------------------------------------------------------------------------
+
+describe("APIClient retry (fake timers)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const api = new APIClient({ baseURL: "http://localhost:8080" });
+
+  it("retries with delay between attempts", async () => {
+    mockFetch
+      .mockResolvedValueOnce(errorResponse(503, "unavailable"))
+      .mockResolvedValueOnce(errorResponse(503, "unavailable"))
+      .mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+    const promise = api.request<{ ok: boolean }>("GET", "/v1/test");
+
+    // Advance through retry delays
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    const result = await promise;
+    expect(result).toEqual({ ok: true });
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// requestNoContent / requestBytes
+// ---------------------------------------------------------------------------
+
+describe("APIClient.requestNoContent", () => {
+  const api = new APIClient({ baseURL: "http://localhost:8080" });
+
+  it("returns void on success", async () => {
+    mockFetch.mockResolvedValueOnce(noContentResponse());
+    await expect(
+      api.requestNoContent("DELETE", "/v1/test"),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("APIClient.requestBytes", () => {
+  const api = new APIClient({ baseURL: "http://localhost:8080" });
+
+  it("returns Uint8Array", async () => {
+    const data = new TextEncoder().encode("file contents");
+    mockFetch.mockResolvedValueOnce(
+      new Response(data, { status: 200 }),
+    );
+
+    const result = await api.requestBytes("GET", "/v1/test");
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(new TextDecoder().decode(result)).toBe("file contents");
+  });
+});

--- a/sdks/typescript/tests/client.test.ts
+++ b/sdks/typescript/tests/client.test.ts
@@ -12,6 +12,7 @@ import {
   jsonResponse,
   noContentResponse,
   errorResponse,
+  sseResponse,
 } from "./helpers.js";
 
 installMockFetch();
@@ -234,4 +235,83 @@ describe("APIClient.requestBytes", () => {
     expect(result).toBeInstanceOf(Uint8Array);
     expect(new TextDecoder().decode(result)).toBe("file contents");
   });
+});
+
+// ---------------------------------------------------------------------------
+// APIClient.openStream
+// ---------------------------------------------------------------------------
+
+describe("APIClient.openStream", () => {
+  const api = new APIClient({ baseURL: "http://localhost:8080" });
+
+  it("sends Accept header and disables timeout", async () => {
+    mockFetch.mockResolvedValueOnce(sseResponse("data: hello\n\n"));
+
+    await api.openStream("/v1/stream");
+
+    const [url, init] = mockFetch.mock.calls[0]!;
+    expect(url).toBe("http://localhost:8080/v1/stream");
+    expect(init?.method).toBe("GET");
+    expect(init?.headers).toEqual(
+      expect.objectContaining({ Accept: "text/event-stream" }),
+    );
+    expect(init?.signal).toBeUndefined();
+  });
+
+  it("merges custom headers with Accept", async () => {
+    mockFetch.mockResolvedValueOnce(sseResponse("data: hello\n\n"));
+
+    await api.openStream("/v1/stream", {
+      headers: { "Last-Event-ID": "42" },
+    });
+
+    const [, init] = mockFetch.mock.calls[0]!;
+    expect(init?.headers).toEqual(
+      expect.objectContaining({
+        Accept: "text/event-stream",
+        "Last-Event-ID": "42",
+      }),
+    );
+  });
+
+  it("does not retry on failure", async () => {
+    mockFetch.mockRejectedValueOnce(new TypeError("fetch failed"));
+
+    await expect(api.openStream("/v1/stream")).rejects.toThrow(
+      APIConnectionError,
+    );
+    expect(mockFetch).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// APIClient constructor validation
+// ---------------------------------------------------------------------------
+
+describe("APIClient constructor", () => {
+  it("throws when baseURL is empty string", () => {
+    expect(() => new APIClient({ baseURL: "" })).toThrow("baseURL");
+  });
+
+  it("throws when baseURL is only slashes", () => {
+    expect(() => new APIClient({ baseURL: "///" })).toThrow("baseURL");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invalid response handling
+// ---------------------------------------------------------------------------
+
+describe("APIClient.request with invalid response", () => {
+  const api = new APIClient({ baseURL: "http://localhost:8080" });
+
+  it("wraps non-JSON 200 response as APIConnectionError", async () => {
+    mockFetch.mockResolvedValue(
+      new Response("<html>not json</html>", { status: 200 }),
+    );
+
+    await expect(api.request("GET", "/v1/test")).rejects.toThrow(
+      APIConnectionError,
+    );
+  }, 30_000);
 });

--- a/sdks/typescript/tests/commands.test.ts
+++ b/sdks/typescript/tests/commands.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Isola } from "../src/isola.js";
+import type { CommandStatusResponse, CreateCommandResponse } from "../src/models.js";
+import {
+  mockFetch,
+  installMockFetch,
+  jsonResponse,
+  noContentResponse,
+  sseResponse,
+  SANDBOX_DATA,
+} from "./helpers.js";
+
+installMockFetch();
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+const client = new Isola({ baseURL: "http://localhost:8080" });
+
+async function getSandbox() {
+  mockFetch.mockResolvedValueOnce(jsonResponse(SANDBOX_DATA));
+  return client.sandboxes.get("sbx-test-123");
+}
+
+describe("Commands.spawn", () => {
+  it("sends command and returns Command handle", async () => {
+    const sandbox = await getSandbox();
+
+    const cmdResp: CreateCommandResponse = { commandId: "cmd-abc" };
+    mockFetch.mockResolvedValueOnce(jsonResponse(cmdResp));
+
+    const cmd = await sandbox.commands.spawn(["ls", "-la"]);
+    expect(cmd.id).toBe("cmd-abc");
+
+    const [url, init] = mockFetch.mock.calls[1]!;
+    expect(url).toBe(
+      "http://localhost:8080/v1/sandboxes/sbx-test-123/commands",
+    );
+    expect(init?.method).toBe("POST");
+
+    const body = JSON.parse(init?.body as string);
+    expect(body).toEqual({ args: ["ls", "-la"] });
+  });
+
+  it("sends optional env, cwd, timeout", async () => {
+    const sandbox = await getSandbox();
+
+    const cmdResp: CreateCommandResponse = { commandId: "cmd-abc" };
+    mockFetch.mockResolvedValueOnce(jsonResponse(cmdResp));
+
+    await sandbox.commands.spawn(["python3", "app.py"], {
+      env: { DEBUG: "1" },
+      cwd: "/app",
+      timeout: 60,
+    });
+
+    const body = JSON.parse(mockFetch.mock.calls[1]![1]?.body as string);
+    expect(body).toEqual({
+      args: ["python3", "app.py"],
+      env: { DEBUG: "1" },
+      cwd: "/app",
+      timeout: 60,
+    });
+  });
+
+  it("sends container as query param", async () => {
+    const sandbox = await getSandbox();
+
+    const cmdResp: CreateCommandResponse = { commandId: "cmd-abc" };
+    mockFetch.mockResolvedValueOnce(jsonResponse(cmdResp));
+
+    await sandbox.commands.spawn(["ls"], { container: "sidecar" });
+
+    const [url] = mockFetch.mock.calls[1]!;
+    expect(url).toContain("container=sidecar");
+  });
+
+  it("rejects empty args at compile time", () => {
+    // Verify that empty args are rejected by the type system.
+    // @ts-expect-error -- empty array is not assignable to [string, ...string[]]
+    const _spawn: (args: readonly [string, ...string[]]) => void = (_: readonly []) => {};
+    void _spawn;
+  });
+});
+
+describe("Command.exitCode", () => {
+  it("returns exit code when available", async () => {
+    const sandbox = await getSandbox();
+
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ commandId: "cmd-1" } satisfies CreateCommandResponse),
+    );
+    const cmd = await sandbox.commands.spawn(["true"]);
+
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ exitCode: 0 } satisfies CommandStatusResponse),
+    );
+    const code = await cmd.exitCode();
+    expect(code).toBe(0);
+  });
+
+  it("returns null when still running", async () => {
+    const sandbox = await getSandbox();
+
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ commandId: "cmd-1" } satisfies CreateCommandResponse),
+    );
+    const cmd = await sandbox.commands.spawn(["sleep", "10"]);
+
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ exitCode: null } satisfies CommandStatusResponse),
+    );
+    const code = await cmd.exitCode();
+    expect(code).toBeNull();
+  });
+});
+
+describe("Command.wait", () => {
+  it("long-polls until exit code is available", async () => {
+    const sandbox = await getSandbox();
+
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ commandId: "cmd-1" } satisfies CreateCommandResponse),
+    );
+    const cmd = await sandbox.commands.spawn(["bash"]);
+
+    // First poll: still running
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ exitCode: null } satisfies CommandStatusResponse),
+    );
+    // Second poll: exited
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ exitCode: 42 } satisfies CommandStatusResponse),
+    );
+
+    const code = await cmd.wait();
+    expect(code).toBe(42);
+
+    // Verify waitSeconds query param
+    const statusCalls = mockFetch.mock.calls.slice(2);
+    for (const call of statusCalls) {
+      expect(call[0]).toContain("waitSeconds=20");
+    }
+  });
+});
+
+describe("Command.writeStdin / closeStdin", () => {
+  it("writes string to stdin", async () => {
+    const sandbox = await getSandbox();
+
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ commandId: "cmd-1" } satisfies CreateCommandResponse),
+    );
+    const cmd = await sandbox.commands.spawn(["cat"]);
+
+    mockFetch.mockResolvedValueOnce(noContentResponse());
+    await cmd.writeStdin("hello world");
+
+    const [url, init] = mockFetch.mock.calls[2]!;
+    expect(url).toContain("/commands/cmd-1/stdin");
+    expect(init?.method).toBe("POST");
+    expect(init?.headers).toEqual(
+      expect.objectContaining({ "Content-Type": "application/octet-stream" }),
+    );
+  });
+
+  it("writes bytes to stdin", async () => {
+    const sandbox = await getSandbox();
+
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ commandId: "cmd-1" } satisfies CreateCommandResponse),
+    );
+    const cmd = await sandbox.commands.spawn(["cat"]);
+
+    const bytes = new TextEncoder().encode("binary data");
+    mockFetch.mockResolvedValueOnce(noContentResponse());
+    await cmd.writeStdin(bytes);
+  });
+
+  it("closes stdin", async () => {
+    const sandbox = await getSandbox();
+
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ commandId: "cmd-1" } satisfies CreateCommandResponse),
+    );
+    const cmd = await sandbox.commands.spawn(["cat"]);
+
+    mockFetch.mockResolvedValueOnce(noContentResponse());
+    await cmd.closeStdin();
+
+    const [url, init] = mockFetch.mock.calls[2]!;
+    expect(url).toContain("/commands/cmd-1/stdin/close");
+    expect(init?.method).toBe("POST");
+  });
+});
+
+describe("Command.kill", () => {
+  it("sends DELETE request", async () => {
+    const sandbox = await getSandbox();
+
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ commandId: "cmd-1" } satisfies CreateCommandResponse),
+    );
+    const cmd = await sandbox.commands.spawn(["sleep", "999"]);
+
+    mockFetch.mockResolvedValueOnce(noContentResponse());
+    await cmd.kill();
+
+    const [url, init] = mockFetch.mock.calls[2]!;
+    expect(url).toContain("/commands/cmd-1");
+    expect(init?.method).toBe("DELETE");
+  });
+});
+
+describe("Command.stdout / stderr", () => {
+  it("returns lazy StreamReader for stdout", async () => {
+    const sandbox = await getSandbox();
+
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ commandId: "cmd-1" } satisfies CreateCommandResponse),
+    );
+    const cmd = await sandbox.commands.spawn(["echo", "hi"]);
+
+    // Accessing .stdout twice returns the same instance
+    const reader1 = cmd.stdout;
+    const reader2 = cmd.stdout;
+    expect(reader1).toBe(reader2);
+  });
+});
+
+describe("Commands.run", () => {
+  it("spawns, waits, and collects output", async () => {
+    const sandbox = await getSandbox();
+
+    // spawn
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ commandId: "cmd-1" } satisfies CreateCommandResponse),
+    );
+    // wait (exit code)
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ exitCode: 0 } satisfies CommandStatusResponse),
+    );
+    // stdout SSE
+    mockFetch.mockResolvedValueOnce(
+      sseResponse("id: 0\ndata: hello world\n\n"),
+    );
+    // stderr SSE
+    mockFetch.mockResolvedValueOnce(
+      sseResponse("id: 0\ndata: \n\n"),
+    );
+
+    const result = await sandbox.commands.run(["echo", "hello world"]);
+    expect(result.commandId).toBe("cmd-1");
+    expect(result.stdout).toBe("hello world");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("writes input to stdin before waiting", async () => {
+    const sandbox = await getSandbox();
+
+    // spawn
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ commandId: "cmd-1" } satisfies CreateCommandResponse),
+    );
+    // writeStdin
+    mockFetch.mockResolvedValueOnce(noContentResponse());
+    // closeStdin
+    mockFetch.mockResolvedValueOnce(noContentResponse());
+    // wait
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ exitCode: 0 } satisfies CommandStatusResponse),
+    );
+    // stdout
+    mockFetch.mockResolvedValueOnce(sseResponse("id: 0\ndata: echo\n\n"));
+    // stderr
+    mockFetch.mockResolvedValueOnce(sseResponse(""));
+
+    const result = await sandbox.commands.run(["cat"], { input: "echo" });
+    expect(result.stdout).toBe("echo");
+
+    // Verify stdin write was called
+    const stdinCall = mockFetch.mock.calls[2]!;
+    expect((stdinCall[0] as string)).toContain("/stdin");
+    expect(stdinCall[1]?.method).toBe("POST");
+  });
+});

--- a/sdks/typescript/tests/errors.test.ts
+++ b/sdks/typescript/tests/errors.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+import {
+  IsolaError,
+  APIError,
+  BadRequestError,
+  NotFoundError,
+  ConflictError,
+  ValidationError,
+  InternalError,
+  BadGatewayError,
+  APIConnectionError,
+  isTransient,
+} from "../src/errors.js";
+
+const emptyHeaders = new Headers();
+
+describe("APIError.fromResponse", () => {
+  it("parses detail from JSON body", () => {
+    const error = APIError.fromResponse(
+      400,
+      JSON.stringify({ detail: "bad input" }),
+      emptyHeaders,
+      "POST",
+      "/v1/sandboxes",
+    );
+    expect(error).toBeInstanceOf(BadRequestError);
+    expect(error.status).toBe(400);
+    expect(error.message).toContain("bad input");
+    expect(error.headers).toBe(emptyHeaders);
+  });
+
+  it("parses message field when detail is absent", () => {
+    const error = APIError.fromResponse(
+      500,
+      JSON.stringify({ message: "oops" }),
+      emptyHeaders,
+      "GET",
+      "/v1/sandboxes",
+    );
+    expect(error).toBeInstanceOf(InternalError);
+    expect(error.message).toContain("oops");
+  });
+
+  it("uses raw body when JSON parsing fails", () => {
+    const error = APIError.fromResponse(
+      404,
+      "not found",
+      emptyHeaders,
+      "GET",
+      "/v1/sandboxes/x",
+    );
+    expect(error).toBeInstanceOf(NotFoundError);
+    expect(error.message).toContain("not found");
+  });
+
+  it("maps status codes to the correct subclass", () => {
+    const cases: Array<[number, new (...args: never[]) => APIError]> = [
+      [400, BadRequestError],
+      [404, NotFoundError],
+      [409, ConflictError],
+      [422, ValidationError],
+      [500, InternalError],
+      [502, BadGatewayError],
+    ];
+
+    for (const [status, ErrorClass] of cases) {
+      const error = APIError.fromResponse(
+        status,
+        "{}",
+        emptyHeaders,
+        "GET",
+        "/test",
+      );
+      expect(error).toBeInstanceOf(ErrorClass);
+      expect(error.status).toBe(status);
+    }
+  });
+
+  it("returns base APIError for unmapped status codes", () => {
+    const error = APIError.fromResponse(
+      418,
+      "{}",
+      emptyHeaders,
+      "GET",
+      "/test",
+    );
+    expect(error).toBeInstanceOf(APIError);
+    expect(error).not.toBeInstanceOf(BadRequestError);
+    expect(error.status).toBe(418);
+  });
+});
+
+describe("APIConnectionError.fromError", () => {
+  it("wraps an Error instance and preserves cause", () => {
+    const cause = new Error("ECONNREFUSED");
+    const error = APIConnectionError.fromError(cause, "GET", "/test");
+    expect(error).toBeInstanceOf(APIConnectionError);
+    expect(error.message).toContain("ECONNREFUSED");
+    expect(error.message).toContain("GET /test");
+    expect(error.cause).toBe(cause);
+  });
+
+  it("wraps a non-Error value", () => {
+    const error = APIConnectionError.fromError("timeout", "POST", "/test");
+    expect(error).toBeInstanceOf(APIConnectionError);
+    expect(error.message).toContain("timeout");
+    expect(error.cause).toBeUndefined();
+  });
+});
+
+describe("isTransient", () => {
+  it("returns true for APIConnectionError", () => {
+    expect(isTransient(new APIConnectionError("fail"))).toBe(true);
+  });
+
+  it("returns true for 408, 429, 502, 503, 504", () => {
+    for (const status of [408, 429, 502, 503, 504]) {
+      expect(
+        isTransient(new APIError(status, "err", emptyHeaders)),
+      ).toBe(true);
+    }
+  });
+
+  it("returns false for non-transient 4xx errors", () => {
+    for (const status of [400, 404, 409, 422]) {
+      expect(
+        isTransient(new APIError(status, "err", emptyHeaders)),
+      ).toBe(false);
+    }
+  });
+
+  it("returns false for base IsolaError", () => {
+    expect(isTransient(new IsolaError("err"))).toBe(false);
+  });
+});
+
+describe("error instanceof chains", () => {
+  it("BadRequestError is an APIError, IsolaError, and Error", () => {
+    const err = new BadRequestError(400, "bad", emptyHeaders);
+    expect(err).toBeInstanceOf(BadRequestError);
+    expect(err).toBeInstanceOf(APIError);
+    expect(err).toBeInstanceOf(IsolaError);
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("APIConnectionError is an IsolaError and Error", () => {
+    const err = new APIConnectionError("fail");
+    expect(err).toBeInstanceOf(APIConnectionError);
+    expect(err).toBeInstanceOf(IsolaError);
+    expect(err).toBeInstanceOf(Error);
+  });
+});

--- a/sdks/typescript/tests/errors.test.ts
+++ b/sdks/typescript/tests/errors.test.ts
@@ -88,6 +88,24 @@ describe("APIError.fromResponse", () => {
     expect(error).not.toBeInstanceOf(BadRequestError);
     expect(error.status).toBe(418);
   });
+
+  it("uses fallback message when body is empty", () => {
+    const error = APIError.fromResponse(
+      503,
+      "",
+      emptyHeaders,
+      "GET",
+      "/v1/test",
+    );
+    expect(error.message).toContain("request failed with status 503");
+  });
+
+  it("prefers detail over message when both present", () => {
+    const body = JSON.stringify({ detail: "detail-text", message: "msg-text" });
+    const error = APIError.fromResponse(400, body, emptyHeaders, "POST", "/v1/test");
+    expect(error.message).toContain("detail-text");
+    expect(error.message).not.toContain("msg-text");
+  });
 });
 
 describe("APIConnectionError.fromError", () => {

--- a/sdks/typescript/tests/filesystem.test.ts
+++ b/sdks/typescript/tests/filesystem.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Isola } from "../src/isola.js";
+import type { FileWriteResult } from "../src/models.js";
+import {
+  mockFetch,
+  installMockFetch,
+  jsonResponse,
+  SANDBOX_DATA,
+} from "./helpers.js";
+
+installMockFetch();
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+const client = new Isola({ baseURL: "http://localhost:8080" });
+
+async function getSandbox() {
+  mockFetch.mockResolvedValueOnce(jsonResponse(SANDBOX_DATA));
+  return client.sandboxes.get("sbx-test-123");
+}
+
+describe("Filesystem.write", () => {
+  it("uploads string data", async () => {
+    const sandbox = await getSandbox();
+
+    const writeResult: FileWriteResult = {
+      absolutePath: "/tmp/hello.txt",
+      bytesWritten: 13,
+    };
+    mockFetch.mockResolvedValueOnce(jsonResponse(writeResult));
+
+    const result = await sandbox.filesystem.write(
+      "/tmp/hello.txt",
+      "hello, world!",
+    );
+
+    expect(result.absolutePath).toBe("/tmp/hello.txt");
+    expect(result.bytesWritten).toBe(13);
+
+    const [url, init] = mockFetch.mock.calls[1]!;
+    expect(url).toContain("/filesystem");
+    expect(url).toContain("path=%2Ftmp%2Fhello.txt");
+    expect(init?.method).toBe("POST");
+    expect(init?.headers).toEqual(
+      expect.objectContaining({ "Content-Type": "application/octet-stream" }),
+    );
+  });
+
+  it("uploads Uint8Array data", async () => {
+    const sandbox = await getSandbox();
+
+    const writeResult: FileWriteResult = {
+      absolutePath: "/tmp/data.bin",
+      bytesWritten: 4,
+    };
+    mockFetch.mockResolvedValueOnce(jsonResponse(writeResult));
+
+    const bytes = new Uint8Array([0x00, 0x01, 0x02, 0x03]);
+    const result = await sandbox.filesystem.write("/tmp/data.bin", bytes);
+
+    expect(result.bytesWritten).toBe(4);
+
+    const init = mockFetch.mock.calls[1]![1]!;
+    expect(init.body).toBeInstanceOf(Uint8Array);
+  });
+
+  it("sends container as query param", async () => {
+    const sandbox = await getSandbox();
+
+    const writeResult: FileWriteResult = {
+      absolutePath: "/tmp/test",
+      bytesWritten: 5,
+    };
+    mockFetch.mockResolvedValueOnce(jsonResponse(writeResult));
+
+    await sandbox.filesystem.write("/tmp/test", "hello", {
+      container: "sidecar",
+    });
+
+    const [url] = mockFetch.mock.calls[1]!;
+    expect(url).toContain("container=sidecar");
+  });
+});
+
+describe("Filesystem.read", () => {
+  it("downloads file as bytes", async () => {
+    const sandbox = await getSandbox();
+
+    const data = new TextEncoder().encode("file contents");
+    mockFetch.mockResolvedValueOnce(new Response(data, { status: 200 }));
+
+    const result = await sandbox.filesystem.read("/tmp/hello.txt");
+
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(new TextDecoder().decode(result)).toBe("file contents");
+
+    const [url] = mockFetch.mock.calls[1]!;
+    expect(url).toContain("/filesystem");
+    expect(url).toContain("path=%2Ftmp%2Fhello.txt");
+  });
+
+  it("sends container as query param", async () => {
+    const sandbox = await getSandbox();
+
+    mockFetch.mockResolvedValueOnce(
+      new Response(new Uint8Array(), { status: 200 }),
+    );
+
+    await sandbox.filesystem.read("/tmp/test", { container: "main" });
+
+    const [url] = mockFetch.mock.calls[1]!;
+    expect(url).toContain("container=main");
+  });
+});

--- a/sdks/typescript/tests/helpers.ts
+++ b/sdks/typescript/tests/helpers.ts
@@ -1,0 +1,93 @@
+import { vi } from "vitest";
+import type { SandboxData, SandboxSummary } from "../src/models.js";
+
+// ---------------------------------------------------------------------------
+// Mock fetch helper
+// ---------------------------------------------------------------------------
+
+export const mockFetch = vi.fn<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>();
+
+export function installMockFetch(): void {
+  vi.stubGlobal("fetch", mockFetch);
+}
+
+export function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export function noContentResponse(): Response {
+  return new Response(null, { status: 204 });
+}
+
+export function errorResponse(
+  status: number,
+  detail: string,
+): Response {
+  return new Response(JSON.stringify({ detail }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export function sseResponse(body: string): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(body));
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+export function sseResponseChunked(chunks: string[]): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+export const SANDBOX_DATA: SandboxData = {
+  id: "sbx-test-123",
+  podTemplate: {
+    container: {
+      image: "ubuntu:24.04",
+      command: ["sleep", "infinity"],
+      resources: {
+        limits: { cpu: "1", memory: "512Mi" },
+        requests: { cpu: "1", memory: "512Mi" },
+      },
+    },
+  },
+  status: "running",
+  creationTimestamp: "2025-01-01T00:00:00Z",
+  activeDeadlineSeconds: 3600,
+  network: {
+    allowInternetEgress: false,
+    allowClusterDNS: true,
+  },
+};
+
+export const SANDBOX_SUMMARIES: SandboxSummary[] = [
+  { id: "sbx-1", status: "running", creationTimestamp: "2025-01-01T00:00:00Z" },
+  { id: "sbx-2", status: "creating", creationTimestamp: "2025-01-01T00:01:00Z" },
+];

--- a/sdks/typescript/tests/sandbox.test.ts
+++ b/sdks/typescript/tests/sandbox.test.ts
@@ -118,7 +118,7 @@ describe("Sandboxes.get", () => {
     const sandbox = await client.sandboxes.get("sbx-test-123");
     expect(sandbox.id).toBe("sbx-test-123");
     expect(sandbox.status).toBe("running");
-    expect(sandbox.creationTimestamp).toBe("2025-01-01T00:00:00Z");
+    expect(sandbox.creationTimestamp).toEqual(new Date("2025-01-01T00:00:00Z"));
     expect(sandbox.timeout).toBe(3600);
     expect(sandbox.network).toEqual({
       allowInternetEgress: false,

--- a/sdks/typescript/tests/sandbox.test.ts
+++ b/sdks/typescript/tests/sandbox.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Isola } from "../src/isola.js";
+import type { SandboxData } from "../src/models.js";
+import {
+  mockFetch,
+  installMockFetch,
+  jsonResponse,
+  noContentResponse,
+  SANDBOX_DATA,
+  SANDBOX_SUMMARIES,
+} from "./helpers.js";
+
+installMockFetch();
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+const client = new Isola({ baseURL: "http://localhost:8080" });
+
+describe("Sandboxes.create", () => {
+  it("sends correct payload with resources", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(SANDBOX_DATA));
+
+    const sandbox = await client.sandboxes.create({
+      image: "ubuntu:24.04",
+      command: ["bash"],
+      env: { FOO: "bar" },
+      cpu: "1",
+      memory: "512Mi",
+      ephemeralStorage: "1Gi",
+      timeout: 3600,
+      network: { allowInternetEgress: false, allowClusterDNS: true },
+    });
+
+    expect(sandbox.id).toBe("sbx-test-123");
+    expect(sandbox.status).toBe("running");
+
+    const [url, init] = mockFetch.mock.calls[0]!;
+    expect(url).toBe("http://localhost:8080/v1/sandboxes");
+    expect(init?.method).toBe("POST");
+
+    const body = JSON.parse(init?.body as string) as Record<string, unknown>;
+    expect(body).toEqual({
+      podTemplate: {
+        container: {
+          image: "ubuntu:24.04",
+          command: ["bash"],
+          env: { FOO: "bar" },
+          resources: {
+            limits: { cpu: "1", memory: "512Mi", ephemeralStorage: "1Gi" },
+            requests: { cpu: "1", memory: "512Mi", ephemeralStorage: "1Gi" },
+          },
+        },
+      },
+      activeDeadlineSeconds: 3600,
+      network: { allowInternetEgress: false, allowClusterDNS: true },
+    });
+  });
+
+  it("omits optional fields when not provided", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(SANDBOX_DATA));
+
+    await client.sandboxes.create({ image: "alpine" });
+
+    const body = JSON.parse(
+      mockFetch.mock.calls[0]![1]?.body as string,
+    ) as Record<string, unknown>;
+
+    expect(body).toEqual({
+      podTemplate: { container: { image: "alpine" } },
+    });
+  });
+
+  it("serializes rootfsSnapshotSource as array", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(SANDBOX_DATA));
+
+    await client.sandboxes.create({
+      image: "alpine",
+      rootfsSnapshotSource: "my-snapshot",
+    });
+
+    const body = JSON.parse(
+      mockFetch.mock.calls[0]![1]?.body as string,
+    ) as Record<string, unknown>;
+
+    expect(body).toEqual({
+      podTemplate: { container: { image: "alpine" } },
+      rootfsSnapshotSources: [{ snapshotName: "my-snapshot" }],
+    });
+  });
+});
+
+describe("Sandboxes.list", () => {
+  it("returns sandbox summaries", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ sandboxes: SANDBOX_SUMMARIES }),
+    );
+
+    const list = await client.sandboxes.list();
+    expect(list).toHaveLength(2);
+    expect(list[0]!.id).toBe("sbx-1");
+    expect(list[1]!.status).toBe("creating");
+  });
+
+  it("returns empty array when sandboxes is null", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ sandboxes: null }));
+
+    const list = await client.sandboxes.list();
+    expect(list).toEqual([]);
+  });
+});
+
+describe("Sandboxes.get", () => {
+  it("returns a Sandbox instance", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(SANDBOX_DATA));
+
+    const sandbox = await client.sandboxes.get("sbx-test-123");
+    expect(sandbox.id).toBe("sbx-test-123");
+    expect(sandbox.status).toBe("running");
+    expect(sandbox.creationTimestamp).toBe("2025-01-01T00:00:00Z");
+    expect(sandbox.timeout).toBe(3600);
+    expect(sandbox.network).toEqual({
+      allowInternetEgress: false,
+      allowClusterDNS: true,
+    });
+  });
+});
+
+describe("Sandbox.delete", () => {
+  it("sends DELETE request", async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse(SANDBOX_DATA))
+      .mockResolvedValueOnce(noContentResponse());
+
+    const sandbox = await client.sandboxes.get("sbx-test-123");
+    await sandbox.delete();
+
+    const [url, init] = mockFetch.mock.calls[1]!;
+    expect(url).toBe("http://localhost:8080/v1/sandboxes/sbx-test-123");
+    expect(init?.method).toBe("DELETE");
+  });
+});
+
+describe("Sandbox properties", () => {
+  it("exposes commands and filesystem sub-resources", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(SANDBOX_DATA));
+
+    const sandbox = await client.sandboxes.get("sbx-test-123");
+    expect(sandbox.commands).toBeDefined();
+    expect(sandbox.filesystem).toBeDefined();
+  });
+
+  it("exposes rootfsSnapshotSources when present", async () => {
+    const dataWithSnapshots: SandboxData = {
+      ...SANDBOX_DATA,
+      rootfsSnapshotSources: [{ snapshotName: "snap1" }],
+    };
+    mockFetch.mockResolvedValueOnce(jsonResponse(dataWithSnapshots));
+
+    const sandbox = await client.sandboxes.get("sbx-test-123");
+    expect(sandbox.rootfsSnapshotSources).toEqual([
+      { snapshotName: "snap1" },
+    ]);
+  });
+});
+
+describe("NetworkSpec acronym aliases", () => {
+  it("handles allowClusterDNS and allowedEgressCIDRs round-trip", async () => {
+    const data: SandboxData = {
+      ...SANDBOX_DATA,
+      network: {
+        allowInternetEgress: true,
+        allowClusterDNS: true,
+        allowedEgressCIDRs: ["10.0.0.0/8"],
+        nameservers: ["8.8.8.8"],
+      },
+    };
+    mockFetch.mockResolvedValueOnce(jsonResponse(data));
+
+    const sandbox = await client.sandboxes.get("sbx-test-123");
+    expect(sandbox.network?.allowClusterDNS).toBe(true);
+    expect(sandbox.network?.allowedEgressCIDRs).toEqual(["10.0.0.0/8"]);
+    expect(sandbox.network?.nameservers).toEqual(["8.8.8.8"]);
+  });
+});

--- a/sdks/typescript/tests/streaming.test.ts
+++ b/sdks/typescript/tests/streaming.test.ts
@@ -242,3 +242,89 @@ describe("StreamReader with \\r\\n line endings", () => {
     expect(content).toBe("hello");
   });
 });
+
+describe("StreamReader SSE edge cases", () => {
+  it("reconnects with event id 0 (falsy but valid)", async () => {
+    const api = createMockStreamAPI();
+
+    api.openStream.mockResolvedValueOnce(
+      new Response(
+        failingSSEStream(
+          "id: 0\ndata: first\n\n",
+          new APIConnectionError("dropped"),
+        ),
+        { status: 200, headers: { "Content-Type": "text/event-stream" } },
+      ),
+    );
+    api.openStream.mockResolvedValueOnce(
+      sseResponse("id: 5\ndata: second\n\n"),
+    );
+
+    const reader = new StreamReader(api, "/stream");
+    const chunks: string[] = [];
+    for await (const chunk of reader) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual(["first", "second"]);
+    const secondCall = api.openStream.mock.calls[1]!;
+    expect(secondCall[1]).toEqual({
+      headers: { "Last-Event-ID": "0" },
+    });
+  }, 10_000);
+
+  it("flushes trailing data not terminated by blank line", async () => {
+    const api = createMockStreamAPI();
+    api.openStream.mockResolvedValueOnce(
+      sseResponse("id: 0\ndata: unterminated"),
+    );
+
+    const reader = new StreamReader(api, "/stream");
+    const content = await reader.read();
+    expect(content).toBe("unterminated");
+  });
+
+  it("throws when response has no body", async () => {
+    const api = createMockStreamAPI();
+    api.openStream.mockResolvedValueOnce(
+      new Response(null, {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    );
+
+    const reader = new StreamReader(api, "/stream");
+    await expect(reader.read()).rejects.toThrow("not readable");
+  });
+
+  it("ignores unknown SSE fields", async () => {
+    const api = createMockStreamAPI();
+    api.openStream.mockResolvedValueOnce(
+      sseResponse("event: message\nretry: 5000\ndata: hello\nid: 1\n\n"),
+    );
+
+    const reader = new StreamReader(api, "/stream");
+    const content = await reader.read();
+    expect(content).toBe("hello");
+  });
+
+  it("strips only one leading space after colon per SSE spec", async () => {
+    const api = createMockStreamAPI();
+    api.openStream.mockResolvedValueOnce(
+      sseResponse("data:  two spaces\n\n"),
+    );
+
+    const reader = new StreamReader(api, "/stream");
+    const content = await reader.read();
+    expect(content).toBe(" two spaces");
+  });
+
+  it("handles data field with no colon", async () => {
+    const api = createMockStreamAPI();
+    api.openStream.mockResolvedValueOnce(sseResponse("data\n\n"));
+
+    const reader = new StreamReader(api, "/stream");
+    const content = await reader.read();
+    expect(content).toBe("");
+  });
+});

--- a/sdks/typescript/tests/streaming.test.ts
+++ b/sdks/typescript/tests/streaming.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi } from "vitest";
+import { StreamReader, type StreamAPI } from "../src/streaming.js";
+import {
+  APIConnectionError,
+  BadGatewayError,
+  NotFoundError,
+} from "../src/errors.js";
+import { sseResponse, sseResponseChunked } from "./helpers.js";
+
+function createMockStreamAPI(): StreamAPI & {
+  openStream: ReturnType<typeof vi.fn>;
+} {
+  return {
+    openStream: vi.fn(),
+  };
+}
+
+/**
+ * Create a ReadableStream that yields one chunk of SSE data, then errors
+ * on the next read. This simulates a connection drop mid-stream.
+ */
+function failingSSEStream(
+  data: string,
+  error: Error,
+): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  let delivered = false;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (!delivered) {
+        delivered = true;
+        controller.enqueue(encoder.encode(data));
+      } else {
+        controller.error(error);
+      }
+    },
+  });
+}
+
+describe("StreamReader", () => {
+  it("yields data events from SSE stream", async () => {
+    const api = createMockStreamAPI();
+    api.openStream.mockResolvedValueOnce(
+      sseResponse("id: 0\ndata: hello\n\nid: 5\ndata: world\n\n"),
+    );
+
+    const reader = new StreamReader(api, "/stream");
+    const chunks: string[] = [];
+    for await (const chunk of reader) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual(["hello", "world"]);
+  });
+
+  it("handles multiline data events", async () => {
+    const api = createMockStreamAPI();
+    api.openStream.mockResolvedValueOnce(
+      sseResponse("data: line1\ndata: line2\ndata: line3\n\n"),
+    );
+
+    const reader = new StreamReader(api, "/stream");
+    const chunks: string[] = [];
+    for await (const chunk of reader) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual(["line1\nline2\nline3"]);
+  });
+
+  it("ignores keepalive comments", async () => {
+    const api = createMockStreamAPI();
+    api.openStream.mockResolvedValueOnce(
+      sseResponse(
+        ": keepalive\ndata: actual\n\n: another\ndata: data\n\n",
+      ),
+    );
+
+    const reader = new StreamReader(api, "/stream");
+    const chunks: string[] = [];
+    for await (const chunk of reader) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual(["actual", "data"]);
+  });
+
+  it("handles empty data events", async () => {
+    const api = createMockStreamAPI();
+    api.openStream.mockResolvedValueOnce(
+      sseResponse("id: 0\ndata: \n\n"),
+    );
+
+    const reader = new StreamReader(api, "/stream");
+    const content = await reader.read();
+    expect(content).toBe("");
+  });
+
+  it("handles chunked delivery across chunk boundaries", async () => {
+    const api = createMockStreamAPI();
+    api.openStream.mockResolvedValueOnce(
+      sseResponseChunked(["id: 0\nda", "ta: hel", "lo\n\n"]),
+    );
+
+    const reader = new StreamReader(api, "/stream");
+    const content = await reader.read();
+    expect(content).toBe("hello");
+  });
+
+  it("read() returns full concatenated content", async () => {
+    const api = createMockStreamAPI();
+    api.openStream.mockResolvedValueOnce(
+      sseResponse("data: a\n\ndata: b\n\ndata: c\n\n"),
+    );
+
+    const reader = new StreamReader(api, "/stream");
+    const content = await reader.read();
+    expect(content).toBe("abc");
+  });
+});
+
+describe("StreamReader single-use", () => {
+  it("throws on second iteration", async () => {
+    const api = createMockStreamAPI();
+    api.openStream.mockResolvedValue(sseResponse("data: x\n\n"));
+
+    const reader = new StreamReader(api, "/stream");
+
+    for await (const _ of reader) {
+      // consume
+    }
+
+    await expect(async () => {
+      for await (const _ of reader) {
+        // should not reach here
+      }
+    }).rejects.toThrow("already been consumed");
+  });
+});
+
+describe("StreamReader reconnection", () => {
+  it("reconnects when openStream fails with transient error", async () => {
+    const api = createMockStreamAPI();
+    api.openStream.mockRejectedValueOnce(
+      new APIConnectionError("connect failed"),
+    );
+    api.openStream.mockResolvedValueOnce(
+      sseResponse("id: 0\ndata: recovered\n\n"),
+    );
+
+    const reader = new StreamReader(api, "/stream");
+    const content = await reader.read();
+    expect(content).toBe("recovered");
+    expect(api.openStream).toHaveBeenCalledTimes(2);
+  }, 10_000);
+
+  it("reconnects when stream errors mid-read and sends Last-Event-ID", async () => {
+    const api = createMockStreamAPI();
+
+    // First connection: delivers data then errors during next read
+    api.openStream.mockResolvedValueOnce(
+      new Response(
+        failingSSEStream(
+          "id: 42\ndata: partial\n\n",
+          new APIConnectionError("dropped"),
+        ),
+        {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        },
+      ),
+    );
+    // Second connection: resumes from where we left off
+    api.openStream.mockResolvedValueOnce(
+      sseResponse("id: 50\ndata: rest\n\n"),
+    );
+
+    const reader = new StreamReader(api, "/stream");
+    const chunks: string[] = [];
+    for await (const chunk of reader) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual(["partial", "rest"]);
+    expect(api.openStream).toHaveBeenCalledTimes(2);
+
+    // Verify Last-Event-ID header on reconnect
+    const secondCall = api.openStream.mock.calls[1]!;
+    expect(secondCall[1]).toEqual({
+      headers: { "Last-Event-ID": "42" },
+    });
+  }, 10_000);
+
+  it("does not retry on non-transient HTTP errors", async () => {
+    const api = createMockStreamAPI();
+    api.openStream.mockRejectedValueOnce(
+      new NotFoundError(404, "not found", new Headers()),
+    );
+
+    const reader = new StreamReader(api, "/stream");
+    await expect(reader.read()).rejects.toThrow(NotFoundError);
+    expect(api.openStream).toHaveBeenCalledOnce();
+  });
+
+  it("retries on 502 errors", async () => {
+    const api = createMockStreamAPI();
+    api.openStream.mockRejectedValueOnce(
+      new BadGatewayError(502, "bad gateway", new Headers()),
+    );
+    api.openStream.mockResolvedValueOnce(sseResponse("data: ok\n\n"));
+
+    const reader = new StreamReader(api, "/stream");
+    const content = await reader.read();
+    expect(content).toBe("ok");
+    expect(api.openStream).toHaveBeenCalledTimes(2);
+  }, 10_000);
+
+  it("gives up after max reconnects", async () => {
+    const api = createMockStreamAPI();
+    // 6 attempts (1 initial + 5 reconnects)
+    for (let i = 0; i < 6; i++) {
+      api.openStream.mockRejectedValueOnce(
+        new APIConnectionError("refused"),
+      );
+    }
+
+    const reader = new StreamReader(api, "/stream");
+    await expect(reader.read()).rejects.toThrow(APIConnectionError);
+    expect(api.openStream).toHaveBeenCalledTimes(6);
+  }, 30_000);
+});
+
+describe("StreamReader with \\r\\n line endings", () => {
+  it("handles Windows-style line endings", async () => {
+    const api = createMockStreamAPI();
+    api.openStream.mockResolvedValueOnce(
+      sseResponse("data: hello\r\n\r\n"),
+    );
+
+    const reader = new StreamReader(api, "/stream");
+    const content = await reader.read();
+    expect(content).toBe("hello");
+  });
+});

--- a/sdks/typescript/tsconfig.build.json
+++ b/sdks/typescript/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["tests", "dist", "node_modules"]
+}

--- a/sdks/typescript/tsconfig.json
+++ b/sdks/typescript/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noEmit": true
+  },
+  "include": ["src", "tests"]
+}

--- a/sdks/typescript/vitest.config.ts
+++ b/sdks/typescript/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

- Add TypeScript SDK (`sdks/typescript/`) mirroring Python SDK structure with zero runtime dependencies (native `fetch`)
- Full API coverage: Isola client, Sandboxes CRUD, Commands (spawn/run with stdin/stdout/stderr SSE streaming), Filesystem (read/write)
- StreamReader with SSE parsing, auto-reconnect via `Last-Event-ID` resume, and configurable retry
- Error hierarchy matching Python SDK (`IsolaError` > `APIError` > status-specific subclasses)
- Exponential backoff with jitter and `Retry-After` header support (following Anthropic/OpenAI SDK patterns)
- 70 tests covering all modules (errors, client, sandbox, commands, filesystem, streaming)
- Makefile targets for TypeScript SDK (`test-sdk-typescript`, `sdk-typescript-typecheck`)

## Test plan

- [x] `npx tsc --noEmit` passes (strict mode, no errors)
- [x] `npx vitest run` — all 70 tests pass
- [ ] Verify SDK works against a live cluster (`tilt up` + manual test)
- [ ] Review API parity with Python SDK

https://claude.ai/code/session_012f2UHXhXAaNZwqrBHWF9Ek