### PR TITLE
Update license copyright year to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -176,7 +176,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2025 The Isola Authors
+   Copyright 2026 The Isola Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
The copyright year should reflect the year of first publication (when the
repo was made public), not the year of the first commit.

https://claude.ai/code/session_01UDU5F1UoFKLMnRQDdx5V1j