### PR TITLE
Remove snapshot-related reasons from Sandbox Ready condition

### DIFF
--- a/internal/api-gateway/proxy.go
+++ b/internal/api-gateway/proxy.go
@@ -62,21 +62,19 @@ func ConditionsToStatus(conditions []metav1.Condition) string {
 		return "running"
 	}
 
-	// TODO: remove snapshot-related reasons from Sandbox CRD — they should be
-	// encapsulated in the RootfsSnapshot CRD only.
 	// TODO benl: make them as constants and share them with routes.go openapi enum generation
 	switch ready.Reason {
 	case "PodPending", "PodCreating", "Reconciling", "NetworkPolicyApplied":
 		return "creating"
-	case "PodRunning", "RootfsSnapshottingInProgress":
+	case "PodRunning":
 		return "running"
 	case "Deleting":
 		return "shuttingDown"
 	case "PodFailed", "PodCreationFailed", "InvalidRuntime",
-		"NetworkPolicyFailed", "RootfsSnapshotFailed", "RootfsSnapshotTimeout",
+		"NetworkPolicyFailed",
 		"RootfsRestoreConfigurationError", "StartupTimeoutExceeded":
 		return "failed"
-	case "PodSucceeded", "RootfsSnapshotComplete":
+	case "PodSucceeded":
 		return "stopped"
 	default:
 		return "unknown"

--- a/internal/api-gateway/sandbox/sandbox_test.go
+++ b/internal/api-gateway/sandbox/sandbox_test.go
@@ -307,15 +307,6 @@ var _ = Describe("Sandbox Endpoints", func() {
 			Expect(apigateway.ConditionsToStatus(conditions)).To(Equal("creating"))
 		})
 
-		// Temporary: snapshot-related reasons should be removed from the Sandbox CRD
-		// and encapsulated in the RootfsSnapshot CRD only (see convert.go TODO).
-		It("maps RootfsSnapshottingInProgress to running", func() {
-			conditions := []metav1.Condition{
-				{Type: "Ready", Status: metav1.ConditionFalse, Reason: "RootfsSnapshottingInProgress"},
-			}
-			Expect(apigateway.ConditionsToStatus(conditions)).To(Equal("running"))
-		})
-
 		It("maps NetworkPolicyApplied to creating", func() {
 			conditions := []metav1.Condition{
 				{Type: "Ready", Status: metav1.ConditionFalse, Reason: "NetworkPolicyApplied"},
@@ -340,15 +331,6 @@ var _ = Describe("Sandbox Endpoints", func() {
 		It("maps PodSucceeded to stopped", func() {
 			conditions := []metav1.Condition{
 				{Type: "Ready", Status: metav1.ConditionFalse, Reason: "PodSucceeded"},
-			}
-			Expect(apigateway.ConditionsToStatus(conditions)).To(Equal("stopped"))
-		})
-
-		// Temporary: snapshot-related reasons should be removed from the Sandbox CRD
-		// and encapsulated in the RootfsSnapshot CRD only (see convert.go TODO).
-		It("maps RootfsSnapshotComplete to stopped", func() {
-			conditions := []metav1.Condition{
-				{Type: "Ready", Status: metav1.ConditionFalse, Reason: "RootfsSnapshotComplete"},
 			}
 			Expect(apigateway.ConditionsToStatus(conditions)).To(Equal("stopped"))
 		})

--- a/internal/operator/controller/sandbox_controller.go
+++ b/internal/operator/controller/sandbox_controller.go
@@ -905,7 +905,7 @@ func (r *SandboxReconciler) executeShutdownPolicy(
 		{
 			Type:               SandboxReadyCondition,
 			Status:             metav1.ConditionFalse,
-			Reason:             CondReasonRootfsSnapshottingInProgress,
+			Reason:             CondReasonDeleting,
 			Message:            "Sandbox being deleted; executing shutdown policy",
 			ObservedGeneration: sandbox.Generation,
 		},


### PR DESCRIPTION
The Sandbox CRD's Ready condition was leaking snapshot implementation details (RootfsSnapshottingInProgress, RootfsSnapshotComplete, RootfsSnapshotFailed, RootfsSnapshotTimeout). These belong on the SandboxRootfsSnapshotCondition only, which the operator already sets.