### PR TITLE
fix: rewind BinaryIO streams before retry in Python SDK

### DIFF
--- a/sdks/python/src/isola/_client.py
+++ b/sdks/python/src/isola/_client.py
@@ -38,9 +38,12 @@ ModelT = TypeVar("ModelT", bound=BaseModel)
 
 def _make_rewind(content: bytes | BinaryIO | None) -> Callable[[], bool] | None:
     """If *content* is a seekable stream, return a closure that rewinds it."""
-    if not (hasattr(content, "seekable") and content.seekable()):
+    try:
+        if not (hasattr(content, "seekable") and content.seekable()):
+            return None
+        pos = content.tell()
+    except (ValueError, OSError):
         return None
-    pos = content.tell()
 
     def rewind() -> bool:
         try:

--- a/sdks/python/src/isola/_client.py
+++ b/sdks/python/src/isola/_client.py
@@ -42,6 +42,17 @@ def _stream_position(content: bytes | BinaryIO | None) -> int | None:
     return None
 
 
+def _try_rewind(content: bytes | BinaryIO | None, pos: int | None) -> bool:
+    """Rewind stream to *pos* before a retry. No-op (returns True) for bytes/None."""
+    if pos is None:
+        return True
+    try:
+        content.seek(pos)  # type: ignore[union-attr]
+        return True
+    except OSError:
+        return False
+
+
 class _SyncAPI:
     def __init__(self, base_url: str) -> None:
         self.base_url = _normalize_base_url(base_url)
@@ -63,8 +74,8 @@ class _SyncAPI:
     ) -> httpx.Response:
         url = f"{self.base_url}{path}"
         rewind_to = _stream_position(content)
-        # Non-seekable streams cannot be retried (body would be empty).
-        can_retry = rewind_to is not None or not hasattr(content, "read")
+        is_stream = hasattr(content, "read")
+        can_retry = not is_stream or rewind_to is not None
 
         for attempt in range(1 + MAX_RETRIES):
             try:
@@ -78,9 +89,7 @@ class _SyncAPI:
                     timeout=timeout,
                 )
             except httpx.RequestError as exc:
-                if can_retry and attempt < MAX_RETRIES:
-                    if rewind_to is not None:
-                        content.seek(rewind_to)
+                if can_retry and attempt < MAX_RETRIES and _try_rewind(content, rewind_to):
                     time.sleep(RETRY_DELAY)
                     continue
                 raise connection_error_from_request(exc, method=method, path=path) from exc
@@ -90,9 +99,7 @@ class _SyncAPI:
             if response.status_code >= 400:
                 body = response.read()
                 api_err = error_from_http(response.status_code, response.reason_phrase, body, method=method, path=path)
-                if is_transient(api_err) and can_retry and attempt < MAX_RETRIES:
-                    if rewind_to is not None:
-                        content.seek(rewind_to)
+                if is_transient(api_err) and can_retry and attempt < MAX_RETRIES and _try_rewind(content, rewind_to):
                     time.sleep(RETRY_DELAY)
                     continue
                 raise api_err
@@ -184,7 +191,8 @@ class _AsyncAPI:
     ) -> httpx.Response:
         url = f"{self.base_url}{path}"
         rewind_to = _stream_position(content)
-        can_retry = rewind_to is not None or not hasattr(content, "read")
+        is_stream = hasattr(content, "read")
+        can_retry = not is_stream or rewind_to is not None
 
         for attempt in range(1 + MAX_RETRIES):
             try:
@@ -198,9 +206,7 @@ class _AsyncAPI:
                     timeout=timeout,
                 )
             except httpx.RequestError as exc:
-                if can_retry and attempt < MAX_RETRIES:
-                    if rewind_to is not None:
-                        content.seek(rewind_to)
+                if can_retry and attempt < MAX_RETRIES and _try_rewind(content, rewind_to):
                     await asyncio.sleep(RETRY_DELAY)
                     continue
                 raise connection_error_from_request(exc, method=method, path=path) from exc
@@ -210,9 +216,7 @@ class _AsyncAPI:
             if response.status_code >= 400:
                 body = await response.aread()
                 api_err = error_from_http(response.status_code, response.reason_phrase, body, method=method, path=path)
-                if is_transient(api_err) and can_retry and attempt < MAX_RETRIES:
-                    if rewind_to is not None:
-                        content.seek(rewind_to)
+                if is_transient(api_err) and can_retry and attempt < MAX_RETRIES and _try_rewind(content, rewind_to):
                     await asyncio.sleep(RETRY_DELAY)
                     continue
                 raise api_err

--- a/sdks/python/src/isola/_client.py
+++ b/sdks/python/src/isola/_client.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import asyncio
 import os
 import time
-from collections.abc import Callable
 from contextlib import AbstractAsyncContextManager, AbstractContextManager
 from typing import Any, BinaryIO, TypeVar
 
@@ -36,23 +35,14 @@ RETRY_DELAY = 1.0
 ModelT = TypeVar("ModelT", bound=BaseModel)
 
 
-def _make_rewind(content: bytes | BinaryIO | None) -> Callable[[], bool] | None:
-    """If *content* is a seekable stream, return a closure that rewinds it."""
+def _stream_pos(content: bytes | BinaryIO | None) -> int | None:
+    """Return the current position of a seekable stream, or None."""
     try:
-        if not (hasattr(content, "seekable") and content.seekable()):
-            return None
-        pos = content.tell()
+        if hasattr(content, "seekable") and content.seekable():
+            return content.tell()
     except (ValueError, OSError):
-        return None
-
-    def rewind() -> bool:
-        try:
-            content.seek(pos)
-            return True
-        except OSError:
-            return False
-
-    return rewind
+        pass
+    return None
 
 
 class _SyncAPI:
@@ -75,8 +65,8 @@ class _SyncAPI:
         timeout: httpx.Timeout | float | None = DEFAULT_TIMEOUT,
     ) -> httpx.Response:
         url = f"{self.base_url}{path}"
-        rewind = _make_rewind(content)
-        can_retry = rewind is not None or content is None or isinstance(content, bytes)
+        pos = _stream_pos(content)
+        can_retry = pos is not None or content is None or isinstance(content, bytes)
 
         for attempt in range(1 + MAX_RETRIES):
             try:
@@ -90,7 +80,9 @@ class _SyncAPI:
                     timeout=timeout,
                 )
             except httpx.RequestError as exc:
-                if can_retry and attempt < MAX_RETRIES and (rewind is None or rewind()):
+                if can_retry and attempt < MAX_RETRIES:
+                    if pos is not None:
+                        content.seek(pos)  # type: ignore[union-attr]
                     time.sleep(RETRY_DELAY)
                     continue
                 raise connection_error_from_request(exc, method=method, path=path) from exc
@@ -100,7 +92,9 @@ class _SyncAPI:
             if response.status_code >= 400:
                 body = response.read()
                 api_err = error_from_http(response.status_code, response.reason_phrase, body, method=method, path=path)
-                if is_transient(api_err) and can_retry and attempt < MAX_RETRIES and (rewind is None or rewind()):
+                if is_transient(api_err) and can_retry and attempt < MAX_RETRIES:
+                    if pos is not None:
+                        content.seek(pos)  # type: ignore[union-attr]
                     time.sleep(RETRY_DELAY)
                     continue
                 raise api_err
@@ -191,8 +185,8 @@ class _AsyncAPI:
         timeout: httpx.Timeout | float | None = DEFAULT_TIMEOUT,
     ) -> httpx.Response:
         url = f"{self.base_url}{path}"
-        rewind = _make_rewind(content)
-        can_retry = rewind is not None or content is None or isinstance(content, bytes)
+        pos = _stream_pos(content)
+        can_retry = pos is not None or content is None or isinstance(content, bytes)
 
         for attempt in range(1 + MAX_RETRIES):
             try:
@@ -206,7 +200,9 @@ class _AsyncAPI:
                     timeout=timeout,
                 )
             except httpx.RequestError as exc:
-                if can_retry and attempt < MAX_RETRIES and (rewind is None or rewind()):
+                if can_retry and attempt < MAX_RETRIES:
+                    if pos is not None:
+                        content.seek(pos)  # type: ignore[union-attr]
                     await asyncio.sleep(RETRY_DELAY)
                     continue
                 raise connection_error_from_request(exc, method=method, path=path) from exc
@@ -216,7 +212,9 @@ class _AsyncAPI:
             if response.status_code >= 400:
                 body = await response.aread()
                 api_err = error_from_http(response.status_code, response.reason_phrase, body, method=method, path=path)
-                if is_transient(api_err) and can_retry and attempt < MAX_RETRIES and (rewind is None or rewind()):
+                if is_transient(api_err) and can_retry and attempt < MAX_RETRIES:
+                    if pos is not None:
+                        content.seek(pos)  # type: ignore[union-attr]
                     await asyncio.sleep(RETRY_DELAY)
                     continue
                 raise api_err

--- a/sdks/python/src/isola/_client.py
+++ b/sdks/python/src/isola/_client.py
@@ -35,13 +35,10 @@ RETRY_DELAY = 1.0
 ModelT = TypeVar("ModelT", bound=BaseModel)
 
 
-def _rewind_pos(content: bytes | BinaryIO | None) -> tuple[BinaryIO, int] | None:
-    """If content is a seekable stream, return (stream, position); otherwise None."""
-    if hasattr(content, "seek") and hasattr(content, "tell"):
-        try:
-            return content, content.tell()
-        except Exception:
-            pass
+def _stream_position(content: bytes | BinaryIO | None) -> int | None:
+    """If content is a seekable stream, return its current position; otherwise None."""
+    if hasattr(content, "seekable") and content.seekable():
+        return content.tell()
     return None
 
 
@@ -65,9 +62,9 @@ class _SyncAPI:
         timeout: httpx.Timeout | float | None = DEFAULT_TIMEOUT,
     ) -> httpx.Response:
         url = f"{self.base_url}{path}"
-        rewind = _rewind_pos(content)
+        rewind_to = _stream_position(content)
         # Non-seekable streams cannot be retried (body would be empty).
-        can_retry = not hasattr(content, "read") or rewind is not None
+        can_retry = rewind_to is not None or not hasattr(content, "read")
 
         for attempt in range(1 + MAX_RETRIES):
             try:
@@ -82,8 +79,8 @@ class _SyncAPI:
                 )
             except httpx.RequestError as exc:
                 if can_retry and attempt < MAX_RETRIES:
-                    if rewind is not None:
-                        rewind[0].seek(rewind[1])
+                    if rewind_to is not None:
+                        content.seek(rewind_to)
                     time.sleep(RETRY_DELAY)
                     continue
                 raise connection_error_from_request(exc, method=method, path=path) from exc
@@ -94,8 +91,8 @@ class _SyncAPI:
                 body = response.read()
                 api_err = error_from_http(response.status_code, response.reason_phrase, body, method=method, path=path)
                 if is_transient(api_err) and can_retry and attempt < MAX_RETRIES:
-                    if rewind is not None:
-                        rewind[0].seek(rewind[1])
+                    if rewind_to is not None:
+                        content.seek(rewind_to)
                     time.sleep(RETRY_DELAY)
                     continue
                 raise api_err
@@ -186,8 +183,8 @@ class _AsyncAPI:
         timeout: httpx.Timeout | float | None = DEFAULT_TIMEOUT,
     ) -> httpx.Response:
         url = f"{self.base_url}{path}"
-        rewind = _rewind_pos(content)
-        can_retry = not hasattr(content, "read") or rewind is not None
+        rewind_to = _stream_position(content)
+        can_retry = rewind_to is not None or not hasattr(content, "read")
 
         for attempt in range(1 + MAX_RETRIES):
             try:
@@ -202,8 +199,8 @@ class _AsyncAPI:
                 )
             except httpx.RequestError as exc:
                 if can_retry and attempt < MAX_RETRIES:
-                    if rewind is not None:
-                        rewind[0].seek(rewind[1])
+                    if rewind_to is not None:
+                        content.seek(rewind_to)
                     await asyncio.sleep(RETRY_DELAY)
                     continue
                 raise connection_error_from_request(exc, method=method, path=path) from exc
@@ -214,8 +211,8 @@ class _AsyncAPI:
                 body = await response.aread()
                 api_err = error_from_http(response.status_code, response.reason_phrase, body, method=method, path=path)
                 if is_transient(api_err) and can_retry and attempt < MAX_RETRIES:
-                    if rewind is not None:
-                        rewind[0].seek(rewind[1])
+                    if rewind_to is not None:
+                        content.seek(rewind_to)
                     await asyncio.sleep(RETRY_DELAY)
                     continue
                 raise api_err

--- a/sdks/python/src/isola/_client.py
+++ b/sdks/python/src/isola/_client.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import asyncio
+import io
 import os
 import time
 from contextlib import AbstractAsyncContextManager, AbstractContextManager
@@ -37,11 +38,12 @@ ModelT = TypeVar("ModelT", bound=BaseModel)
 
 def _stream_pos(content: bytes | BinaryIO | None) -> int | None:
     """Return the current position of a seekable stream, or None."""
-    try:
-        if hasattr(content, "seekable") and content.seekable():
-            return content.tell()
-    except (ValueError, OSError):
-        pass
+    if isinstance(content, io.IOBase):
+        try:
+            if content.seekable():
+                return content.tell()
+        except ValueError:  # closed file
+            pass
     return None
 
 

--- a/sdks/python/src/isola/_client.py
+++ b/sdks/python/src/isola/_client.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import os
 import time
+from collections.abc import Callable
 from contextlib import AbstractAsyncContextManager, AbstractContextManager
 from typing import Any, BinaryIO, TypeVar
 
@@ -35,22 +36,20 @@ RETRY_DELAY = 1.0
 ModelT = TypeVar("ModelT", bound=BaseModel)
 
 
-def _stream_position(content: bytes | BinaryIO | None) -> int | None:
-    """If content is a seekable stream, return its current position; otherwise None."""
-    if hasattr(content, "seekable") and content.seekable():
-        return content.tell()
-    return None
+def _make_rewind(content: bytes | BinaryIO | None) -> Callable[[], bool] | None:
+    """If *content* is a seekable stream, return a closure that rewinds it."""
+    if not (hasattr(content, "seekable") and content.seekable()):
+        return None
+    pos = content.tell()
 
+    def rewind() -> bool:
+        try:
+            content.seek(pos)
+            return True
+        except OSError:
+            return False
 
-def _try_rewind(content: bytes | BinaryIO | None, pos: int | None) -> bool:
-    """Rewind stream to *pos* before a retry. No-op (returns True) for bytes/None."""
-    if pos is None:
-        return True
-    try:
-        content.seek(pos)  # type: ignore[union-attr]
-        return True
-    except OSError:
-        return False
+    return rewind
 
 
 class _SyncAPI:
@@ -73,9 +72,8 @@ class _SyncAPI:
         timeout: httpx.Timeout | float | None = DEFAULT_TIMEOUT,
     ) -> httpx.Response:
         url = f"{self.base_url}{path}"
-        rewind_to = _stream_position(content)
-        is_stream = hasattr(content, "read")
-        can_retry = not is_stream or rewind_to is not None
+        rewind = _make_rewind(content)
+        can_retry = rewind is not None or not hasattr(content, "read")
 
         for attempt in range(1 + MAX_RETRIES):
             try:
@@ -89,7 +87,7 @@ class _SyncAPI:
                     timeout=timeout,
                 )
             except httpx.RequestError as exc:
-                if can_retry and attempt < MAX_RETRIES and _try_rewind(content, rewind_to):
+                if can_retry and attempt < MAX_RETRIES and (rewind is None or rewind()):
                     time.sleep(RETRY_DELAY)
                     continue
                 raise connection_error_from_request(exc, method=method, path=path) from exc
@@ -99,7 +97,7 @@ class _SyncAPI:
             if response.status_code >= 400:
                 body = response.read()
                 api_err = error_from_http(response.status_code, response.reason_phrase, body, method=method, path=path)
-                if is_transient(api_err) and can_retry and attempt < MAX_RETRIES and _try_rewind(content, rewind_to):
+                if is_transient(api_err) and can_retry and attempt < MAX_RETRIES and (rewind is None or rewind()):
                     time.sleep(RETRY_DELAY)
                     continue
                 raise api_err
@@ -190,9 +188,8 @@ class _AsyncAPI:
         timeout: httpx.Timeout | float | None = DEFAULT_TIMEOUT,
     ) -> httpx.Response:
         url = f"{self.base_url}{path}"
-        rewind_to = _stream_position(content)
-        is_stream = hasattr(content, "read")
-        can_retry = not is_stream or rewind_to is not None
+        rewind = _make_rewind(content)
+        can_retry = rewind is not None or not hasattr(content, "read")
 
         for attempt in range(1 + MAX_RETRIES):
             try:
@@ -206,7 +203,7 @@ class _AsyncAPI:
                     timeout=timeout,
                 )
             except httpx.RequestError as exc:
-                if can_retry and attempt < MAX_RETRIES and _try_rewind(content, rewind_to):
+                if can_retry and attempt < MAX_RETRIES and (rewind is None or rewind()):
                     await asyncio.sleep(RETRY_DELAY)
                     continue
                 raise connection_error_from_request(exc, method=method, path=path) from exc
@@ -216,7 +213,7 @@ class _AsyncAPI:
             if response.status_code >= 400:
                 body = await response.aread()
                 api_err = error_from_http(response.status_code, response.reason_phrase, body, method=method, path=path)
-                if is_transient(api_err) and can_retry and attempt < MAX_RETRIES and _try_rewind(content, rewind_to):
+                if is_transient(api_err) and can_retry and attempt < MAX_RETRIES and (rewind is None or rewind()):
                     await asyncio.sleep(RETRY_DELAY)
                     continue
                 raise api_err

--- a/sdks/python/src/isola/_client.py
+++ b/sdks/python/src/isola/_client.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import asyncio
-import io
 import os
 import time
 from contextlib import AbstractAsyncContextManager, AbstractContextManager
@@ -38,8 +37,8 @@ ModelT = TypeVar("ModelT", bound=BaseModel)
 
 def _stream_pos(content: bytes | BinaryIO | None) -> int | None:
     """Return the current position of a seekable stream, or None."""
-    if isinstance(content, io.IOBase) and content.seekable():
-        return content.tell()
+    if hasattr(content, "seekable") and content.seekable():  # type: ignore[union-attr]
+        return content.tell()  # type: ignore[union-attr]
     return None
 
 

--- a/sdks/python/src/isola/_client.py
+++ b/sdks/python/src/isola/_client.py
@@ -35,11 +35,11 @@ RETRY_DELAY = 1.0
 ModelT = TypeVar("ModelT", bound=BaseModel)
 
 
-def _can_rewind(content: bytes | BinaryIO | None) -> int | None:
-    """If content is a seekable stream, return its current position; otherwise None."""
+def _rewind_pos(content: bytes | BinaryIO | None) -> tuple[BinaryIO, int] | None:
+    """If content is a seekable stream, return (stream, position); otherwise None."""
     if hasattr(content, "seek") and hasattr(content, "tell"):
         try:
-            return content.tell()
+            return content, content.tell()
         except Exception:
             pass
     return None
@@ -65,12 +65,9 @@ class _SyncAPI:
         timeout: httpx.Timeout | float | None = DEFAULT_TIMEOUT,
     ) -> httpx.Response:
         url = f"{self.base_url}{path}"
-        rewind_pos = _can_rewind(content)
-        # Streams that are not seekable cannot be retried — the body would be
-        # empty on the second attempt.  Only allow retries when content is
-        # bytes/None (always safe) or a seekable stream we can rewind.
-        is_stream = hasattr(content, "read")
-        can_retry = not is_stream or rewind_pos is not None
+        rewind = _rewind_pos(content)
+        # Non-seekable streams cannot be retried (body would be empty).
+        can_retry = not hasattr(content, "read") or rewind is not None
 
         for attempt in range(1 + MAX_RETRIES):
             try:
@@ -85,8 +82,8 @@ class _SyncAPI:
                 )
             except httpx.RequestError as exc:
                 if can_retry and attempt < MAX_RETRIES:
-                    if rewind_pos is not None:
-                        content.seek(rewind_pos)  # type: ignore[union-attr]
+                    if rewind is not None:
+                        rewind[0].seek(rewind[1])
                     time.sleep(RETRY_DELAY)
                     continue
                 raise connection_error_from_request(exc, method=method, path=path) from exc
@@ -97,8 +94,8 @@ class _SyncAPI:
                 body = response.read()
                 api_err = error_from_http(response.status_code, response.reason_phrase, body, method=method, path=path)
                 if is_transient(api_err) and can_retry and attempt < MAX_RETRIES:
-                    if rewind_pos is not None:
-                        content.seek(rewind_pos)  # type: ignore[union-attr]
+                    if rewind is not None:
+                        rewind[0].seek(rewind[1])
                     time.sleep(RETRY_DELAY)
                     continue
                 raise api_err
@@ -189,9 +186,8 @@ class _AsyncAPI:
         timeout: httpx.Timeout | float | None = DEFAULT_TIMEOUT,
     ) -> httpx.Response:
         url = f"{self.base_url}{path}"
-        rewind_pos = _can_rewind(content)
-        is_stream = hasattr(content, "read")
-        can_retry = not is_stream or rewind_pos is not None
+        rewind = _rewind_pos(content)
+        can_retry = not hasattr(content, "read") or rewind is not None
 
         for attempt in range(1 + MAX_RETRIES):
             try:
@@ -206,8 +202,8 @@ class _AsyncAPI:
                 )
             except httpx.RequestError as exc:
                 if can_retry and attempt < MAX_RETRIES:
-                    if rewind_pos is not None:
-                        content.seek(rewind_pos)  # type: ignore[union-attr]
+                    if rewind is not None:
+                        rewind[0].seek(rewind[1])
                     await asyncio.sleep(RETRY_DELAY)
                     continue
                 raise connection_error_from_request(exc, method=method, path=path) from exc
@@ -218,8 +214,8 @@ class _AsyncAPI:
                 body = await response.aread()
                 api_err = error_from_http(response.status_code, response.reason_phrase, body, method=method, path=path)
                 if is_transient(api_err) and can_retry and attempt < MAX_RETRIES:
-                    if rewind_pos is not None:
-                        content.seek(rewind_pos)  # type: ignore[union-attr]
+                    if rewind is not None:
+                        rewind[0].seek(rewind[1])
                     await asyncio.sleep(RETRY_DELAY)
                     continue
                 raise api_err

--- a/sdks/python/src/isola/_client.py
+++ b/sdks/python/src/isola/_client.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import asyncio
-import io
 import os
 import time
 from contextlib import AbstractAsyncContextManager, AbstractContextManager
@@ -34,6 +33,16 @@ MAX_RETRIES = 5
 RETRY_DELAY = 1.0
 
 ModelT = TypeVar("ModelT", bound=BaseModel)
+
+
+def _can_rewind(content: bytes | BinaryIO | None) -> int | None:
+    """If content is a seekable stream, return its current position; otherwise None."""
+    if hasattr(content, "seek") and hasattr(content, "tell"):
+        try:
+            return content.tell()
+        except Exception:
+            pass
+    return None
 
 
 class _SyncAPI:
@@ -56,7 +65,12 @@ class _SyncAPI:
         timeout: httpx.Timeout | float | None = DEFAULT_TIMEOUT,
     ) -> httpx.Response:
         url = f"{self.base_url}{path}"
-        initial_pos = _stream_initial_position(content)
+        rewind_pos = _can_rewind(content)
+        # Streams that are not seekable cannot be retried — the body would be
+        # empty on the second attempt.  Only allow retries when content is
+        # bytes/None (always safe) or a seekable stream we can rewind.
+        is_stream = hasattr(content, "read")
+        can_retry = not is_stream or rewind_pos is not None
 
         for attempt in range(1 + MAX_RETRIES):
             try:
@@ -70,7 +84,9 @@ class _SyncAPI:
                     timeout=timeout,
                 )
             except httpx.RequestError as exc:
-                if attempt < MAX_RETRIES and _try_rewind(content, initial_pos):
+                if can_retry and attempt < MAX_RETRIES:
+                    if rewind_pos is not None:
+                        content.seek(rewind_pos)  # type: ignore[union-attr]
                     time.sleep(RETRY_DELAY)
                     continue
                 raise connection_error_from_request(exc, method=method, path=path) from exc
@@ -80,7 +96,9 @@ class _SyncAPI:
             if response.status_code >= 400:
                 body = response.read()
                 api_err = error_from_http(response.status_code, response.reason_phrase, body, method=method, path=path)
-                if is_transient(api_err) and attempt < MAX_RETRIES and _try_rewind(content, initial_pos):
+                if is_transient(api_err) and can_retry and attempt < MAX_RETRIES:
+                    if rewind_pos is not None:
+                        content.seek(rewind_pos)  # type: ignore[union-attr]
                     time.sleep(RETRY_DELAY)
                     continue
                 raise api_err
@@ -171,7 +189,9 @@ class _AsyncAPI:
         timeout: httpx.Timeout | float | None = DEFAULT_TIMEOUT,
     ) -> httpx.Response:
         url = f"{self.base_url}{path}"
-        initial_pos = _stream_initial_position(content)
+        rewind_pos = _can_rewind(content)
+        is_stream = hasattr(content, "read")
+        can_retry = not is_stream or rewind_pos is not None
 
         for attempt in range(1 + MAX_RETRIES):
             try:
@@ -185,7 +205,9 @@ class _AsyncAPI:
                     timeout=timeout,
                 )
             except httpx.RequestError as exc:
-                if attempt < MAX_RETRIES and _try_rewind(content, initial_pos):
+                if can_retry and attempt < MAX_RETRIES:
+                    if rewind_pos is not None:
+                        content.seek(rewind_pos)  # type: ignore[union-attr]
                     await asyncio.sleep(RETRY_DELAY)
                     continue
                 raise connection_error_from_request(exc, method=method, path=path) from exc
@@ -195,7 +217,9 @@ class _AsyncAPI:
             if response.status_code >= 400:
                 body = await response.aread()
                 api_err = error_from_http(response.status_code, response.reason_phrase, body, method=method, path=path)
-                if is_transient(api_err) and attempt < MAX_RETRIES and _try_rewind(content, initial_pos):
+                if is_transient(api_err) and can_retry and attempt < MAX_RETRIES:
+                    if rewind_pos is not None:
+                        content.seek(rewind_pos)  # type: ignore[union-attr]
                     await asyncio.sleep(RETRY_DELAY)
                     continue
                 raise api_err
@@ -264,44 +288,6 @@ class _AsyncAPI:
             headers=headers,
             timeout=timeout,
         )
-
-
-_NOT_SEEKABLE = -1
-
-
-def _stream_initial_position(content: bytes | BinaryIO | None) -> int | None:
-    """Record the initial stream position so we can rewind on retry.
-
-    Returns None for non-stream content (bytes/None), the stream position
-    for seekable streams, or _NOT_SEEKABLE for streams that cannot be rewound.
-    """
-    if content is None or isinstance(content, bytes):
-        return None
-    if hasattr(content, "tell"):
-        try:
-            return content.tell()
-        except (OSError, io.UnsupportedOperation):
-            pass
-    return _NOT_SEEKABLE
-
-
-def _try_rewind(content: bytes | BinaryIO | None, initial_pos: int | None) -> bool:
-    """Rewind a stream to its initial position before retrying.
-
-    Returns True if the content can be safely retried (bytes, None, or
-    a seekable stream that was successfully rewound). Returns False if
-    the stream is not seekable — the caller must not retry because the
-    body would be empty or incomplete.
-    """
-    if initial_pos is None:
-        return True
-    if initial_pos == _NOT_SEEKABLE:
-        return False
-    try:
-        content.seek(initial_pos)  # type: ignore[union-attr]
-        return True
-    except (OSError, io.UnsupportedOperation):
-        return False
 
 
 def _normalize_base_url(base_url: str) -> str:

--- a/sdks/python/src/isola/_client.py
+++ b/sdks/python/src/isola/_client.py
@@ -38,12 +38,8 @@ ModelT = TypeVar("ModelT", bound=BaseModel)
 
 def _stream_pos(content: bytes | BinaryIO | None) -> int | None:
     """Return the current position of a seekable stream, or None."""
-    if isinstance(content, io.IOBase):
-        try:
-            if content.seekable():
-                return content.tell()
-        except ValueError:  # closed file
-            pass
+    if isinstance(content, io.IOBase) and content.seekable():
+        return content.tell()
     return None
 
 

--- a/sdks/python/src/isola/_client.py
+++ b/sdks/python/src/isola/_client.py
@@ -76,7 +76,7 @@ class _SyncAPI:
     ) -> httpx.Response:
         url = f"{self.base_url}{path}"
         rewind = _make_rewind(content)
-        can_retry = rewind is not None or not hasattr(content, "read")
+        can_retry = rewind is not None or content is None or isinstance(content, bytes)
 
         for attempt in range(1 + MAX_RETRIES):
             try:
@@ -192,7 +192,7 @@ class _AsyncAPI:
     ) -> httpx.Response:
         url = f"{self.base_url}{path}"
         rewind = _make_rewind(content)
-        can_retry = rewind is not None or not hasattr(content, "read")
+        can_retry = rewind is not None or content is None or isinstance(content, bytes)
 
         for attempt in range(1 + MAX_RETRIES):
             try:

--- a/sdks/python/src/isola/_client.py
+++ b/sdks/python/src/isola/_client.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import asyncio
+import io
 import os
 import time
 from contextlib import AbstractAsyncContextManager, AbstractContextManager
@@ -55,6 +56,7 @@ class _SyncAPI:
         timeout: httpx.Timeout | float | None = DEFAULT_TIMEOUT,
     ) -> httpx.Response:
         url = f"{self.base_url}{path}"
+        initial_pos = _stream_initial_position(content)
 
         for attempt in range(1 + MAX_RETRIES):
             try:
@@ -68,7 +70,7 @@ class _SyncAPI:
                     timeout=timeout,
                 )
             except httpx.RequestError as exc:
-                if attempt < MAX_RETRIES:
+                if attempt < MAX_RETRIES and _try_rewind(content, initial_pos):
                     time.sleep(RETRY_DELAY)
                     continue
                 raise connection_error_from_request(exc, method=method, path=path) from exc
@@ -78,7 +80,7 @@ class _SyncAPI:
             if response.status_code >= 400:
                 body = response.read()
                 api_err = error_from_http(response.status_code, response.reason_phrase, body, method=method, path=path)
-                if is_transient(api_err) and attempt < MAX_RETRIES:
+                if is_transient(api_err) and attempt < MAX_RETRIES and _try_rewind(content, initial_pos):
                     time.sleep(RETRY_DELAY)
                     continue
                 raise api_err
@@ -169,6 +171,7 @@ class _AsyncAPI:
         timeout: httpx.Timeout | float | None = DEFAULT_TIMEOUT,
     ) -> httpx.Response:
         url = f"{self.base_url}{path}"
+        initial_pos = _stream_initial_position(content)
 
         for attempt in range(1 + MAX_RETRIES):
             try:
@@ -182,7 +185,7 @@ class _AsyncAPI:
                     timeout=timeout,
                 )
             except httpx.RequestError as exc:
-                if attempt < MAX_RETRIES:
+                if attempt < MAX_RETRIES and _try_rewind(content, initial_pos):
                     await asyncio.sleep(RETRY_DELAY)
                     continue
                 raise connection_error_from_request(exc, method=method, path=path) from exc
@@ -192,7 +195,7 @@ class _AsyncAPI:
             if response.status_code >= 400:
                 body = await response.aread()
                 api_err = error_from_http(response.status_code, response.reason_phrase, body, method=method, path=path)
-                if is_transient(api_err) and attempt < MAX_RETRIES:
+                if is_transient(api_err) and attempt < MAX_RETRIES and _try_rewind(content, initial_pos):
                     await asyncio.sleep(RETRY_DELAY)
                     continue
                 raise api_err
@@ -261,6 +264,44 @@ class _AsyncAPI:
             headers=headers,
             timeout=timeout,
         )
+
+
+_NOT_SEEKABLE = -1
+
+
+def _stream_initial_position(content: bytes | BinaryIO | None) -> int | None:
+    """Record the initial stream position so we can rewind on retry.
+
+    Returns None for non-stream content (bytes/None), the stream position
+    for seekable streams, or _NOT_SEEKABLE for streams that cannot be rewound.
+    """
+    if content is None or isinstance(content, bytes):
+        return None
+    if hasattr(content, "tell"):
+        try:
+            return content.tell()
+        except (OSError, io.UnsupportedOperation):
+            pass
+    return _NOT_SEEKABLE
+
+
+def _try_rewind(content: bytes | BinaryIO | None, initial_pos: int | None) -> bool:
+    """Rewind a stream to its initial position before retrying.
+
+    Returns True if the content can be safely retried (bytes, None, or
+    a seekable stream that was successfully rewound). Returns False if
+    the stream is not seekable — the caller must not retry because the
+    body would be empty or incomplete.
+    """
+    if initial_pos is None:
+        return True
+    if initial_pos == _NOT_SEEKABLE:
+        return False
+    try:
+        content.seek(initial_pos)  # type: ignore[union-attr]
+        return True
+    except (OSError, io.UnsupportedOperation):
+        return False
 
 
 def _normalize_base_url(base_url: str) -> str:

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -445,6 +445,32 @@ def test_retries_rewind_seekable_stream_on_transient_error(monkeypatch: pytest.M
 
 
 @respx.mock
+def test_retries_rewind_seekable_stream_on_connection_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("isola._client.time.sleep", lambda _: None)
+    payload = b"file content here"
+    bodies_received: list[bytes] = []
+
+    def capture_body(request: httpx.Request) -> httpx.Response:
+        bodies_received.append(request.content)
+        return httpx.Response(200, json={"sandboxes": []})
+
+    route = respx.get("http://localhost:8080/v1/sandboxes")
+    route.mock(
+        side_effect=[
+            httpx.ConnectError("connect failed"),
+            capture_body,
+        ]
+    )
+
+    stream = io.BytesIO(payload)
+    with Isola(base_url="http://localhost:8080") as client:
+        client._api.request("GET", "/v1/sandboxes", content=stream)
+
+    assert len(bodies_received) == 1
+    assert bodies_received[0] == payload
+
+
+@respx.mock
 def test_no_retry_for_non_seekable_stream_on_connection_error(monkeypatch: pytest.MonkeyPatch) -> None:
     """Non-seekable streams cannot be retried — the body would be empty."""
     monkeypatch.setattr("isola._client.time.sleep", lambda _: None)

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import io
+import os
 from unittest.mock import patch
 
 import httpx
@@ -33,7 +34,7 @@ from isola import (
     NotFoundError,
     ValidationError,
 )
-from isola._client import _NOT_SEEKABLE, MAX_RETRIES, _stream_initial_position, _try_rewind
+from isola._client import MAX_RETRIES
 
 
 @respx.mock
@@ -417,71 +418,11 @@ async def test_async_close_is_idempotent() -> None:
     assert client._api._client.is_closed
 
 
-# --- Stream rewind helpers ---
-
-
-def test_stream_initial_position_returns_none_for_bytes() -> None:
-    assert _stream_initial_position(b"hello") is None
-    assert _stream_initial_position(None) is None
-
-
-def test_stream_initial_position_returns_tell_for_seekable() -> None:
-    stream = io.BytesIO(b"hello")
-    stream.read(2)
-    assert _stream_initial_position(stream) == 2
-
-
-def test_try_rewind_returns_true_for_bytes() -> None:
-    assert _try_rewind(b"hello", None) is True
-    assert _try_rewind(None, None) is True
-
-
-def test_try_rewind_seeks_stream_to_initial_position() -> None:
-    stream = io.BytesIO(b"hello world")
-    stream.read(5)
-    initial = stream.tell()
-    stream.read()  # consume the rest
-    assert _try_rewind(stream, initial) is True
-    assert stream.tell() == initial
-
-
-def test_try_rewind_returns_false_for_non_seekable() -> None:
-    class NonSeekable(io.RawIOBase):
-        def read(self, _n: int = -1) -> bytes:
-            return b""
-
-        def seek(self, _offset: int, _whence: int = 0) -> int:
-            raise OSError("not seekable")
-
-    stream = NonSeekable()
-    assert _try_rewind(stream, 0) is False
-
-
-def test_try_rewind_returns_false_for_not_seekable_sentinel() -> None:
-    assert _try_rewind(io.BytesIO(b"x"), _NOT_SEEKABLE) is False
-
-
-def test_stream_initial_position_returns_not_seekable_when_tell_raises() -> None:
-    class TellRaises(io.RawIOBase):
-        def tell(self) -> int:
-            raise io.UnsupportedOperation("tell")
-
-    assert _stream_initial_position(TellRaises()) == _NOT_SEEKABLE
-
-
-def test_stream_initial_position_returns_not_seekable_for_stream_without_tell() -> None:
-    class NoTell:
-        def read(self, _n: int = -1) -> bytes:
-            return b""
-
-    assert _stream_initial_position(NoTell()) == _NOT_SEEKABLE  # type: ignore[arg-type]
-
-
-# --- Stream rewind retry integration tests ---
+# --- Stream rewind on retry ---
 
 
 @respx.mock
-def test_retries_rewind_stream_on_transient_error(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_retries_rewind_seekable_stream_on_transient_error(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("isola._client.time.sleep", lambda _: None)
     payload = b"file content here"
     bodies_received: list[bytes] = []
@@ -504,77 +445,19 @@ def test_retries_rewind_stream_on_transient_error(monkeypatch: pytest.MonkeyPatc
 
 
 @respx.mock
-def test_no_retry_for_non_seekable_stream_on_transient_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("isola._client.time.sleep", lambda _: None)
-
-    class NonSeekableStream(io.RawIOBase):
-        def __init__(self, data: bytes) -> None:
-            self._data = data
-            self._pos = 0
-
-        def read(self, n: int = -1) -> bytes:
-            if n == -1:
-                result = self._data[self._pos :]
-                self._pos = len(self._data)
-            else:
-                result = self._data[self._pos : self._pos + n]
-                self._pos += len(result)
-            return result
-
-        def readinto(self, _b: bytearray | memoryview) -> int:
-            data = self.read(len(_b))
-            n = len(data)
-            _b[:n] = data
-            return n
-
-        def readable(self) -> bool:
-            return True
-
-        def seekable(self) -> bool:
-            return False
-
-        def seek(self, _offset: int, _whence: int = 0) -> int:
-            raise OSError("not seekable")
-
-        def tell(self) -> int:
-            return self._pos
-
-    respx.get("http://localhost:8080/v1/sandboxes").mock(
-        return_value=httpx.Response(502, json={"detail": "bad gateway"})
-    )
-
-    stream = NonSeekableStream(b"data")
-    with Isola(base_url="http://localhost:8080") as client, pytest.raises(BadGatewayError):
-        client._api.request("GET", "/v1/sandboxes", content=stream)
-
-
-@respx.mock
 def test_no_retry_for_non_seekable_stream_on_connection_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-seekable streams cannot be retried — the body would be empty."""
     monkeypatch.setattr("isola._client.time.sleep", lambda _: None)
-
-    class NonSeekableStream(io.RawIOBase):
-        def read(self, _n: int = -1) -> bytes:
-            return b""
-
-        def readinto(self, _b: bytearray | memoryview) -> int:
-            return 0
-
-        def readable(self) -> bool:
-            return True
-
-        def seekable(self) -> bool:
-            return False
-
-        def seek(self, _offset: int, _whence: int = 0) -> int:
-            raise OSError("not seekable")
-
-        def tell(self) -> int:
-            return 0
 
     route = respx.get("http://localhost:8080/v1/sandboxes")
     route.mock(side_effect=httpx.ConnectError("connect failed"))
 
-    stream = NonSeekableStream()
+    # A pipe-like object: has read() but no seek()/tell()
+    r, w = os.pipe()
+    os.write(w, b"data")
+    os.close(w)
+    stream = os.fdopen(r, "rb")
+
     with Isola(base_url="http://localhost:8080") as client, pytest.raises(APIConnectionError):
         client._api.request("GET", "/v1/sandboxes", content=stream)
 

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import io
 from unittest.mock import patch
 
 import httpx
@@ -32,7 +33,7 @@ from isola import (
     NotFoundError,
     ValidationError,
 )
-from isola._client import MAX_RETRIES
+from isola._client import _NOT_SEEKABLE, MAX_RETRIES, _stream_initial_position, _try_rewind
 
 
 @respx.mock
@@ -414,3 +415,167 @@ async def test_async_close_is_idempotent() -> None:
     await client.close()
     await client.close()
     assert client._api._client.is_closed
+
+
+# --- Stream rewind helpers ---
+
+
+def test_stream_initial_position_returns_none_for_bytes() -> None:
+    assert _stream_initial_position(b"hello") is None
+    assert _stream_initial_position(None) is None
+
+
+def test_stream_initial_position_returns_tell_for_seekable() -> None:
+    stream = io.BytesIO(b"hello")
+    stream.read(2)
+    assert _stream_initial_position(stream) == 2
+
+
+def test_try_rewind_returns_true_for_bytes() -> None:
+    assert _try_rewind(b"hello", None) is True
+    assert _try_rewind(None, None) is True
+
+
+def test_try_rewind_seeks_stream_to_initial_position() -> None:
+    stream = io.BytesIO(b"hello world")
+    stream.read(5)
+    initial = stream.tell()
+    stream.read()  # consume the rest
+    assert _try_rewind(stream, initial) is True
+    assert stream.tell() == initial
+
+
+def test_try_rewind_returns_false_for_non_seekable() -> None:
+    class NonSeekable(io.RawIOBase):
+        def read(self, _n: int = -1) -> bytes:
+            return b""
+
+        def seek(self, _offset: int, _whence: int = 0) -> int:
+            raise OSError("not seekable")
+
+    stream = NonSeekable()
+    assert _try_rewind(stream, 0) is False
+
+
+def test_try_rewind_returns_false_for_not_seekable_sentinel() -> None:
+    assert _try_rewind(io.BytesIO(b"x"), _NOT_SEEKABLE) is False
+
+
+def test_stream_initial_position_returns_not_seekable_when_tell_raises() -> None:
+    class TellRaises(io.RawIOBase):
+        def tell(self) -> int:
+            raise io.UnsupportedOperation("tell")
+
+    assert _stream_initial_position(TellRaises()) == _NOT_SEEKABLE
+
+
+def test_stream_initial_position_returns_not_seekable_for_stream_without_tell() -> None:
+    class NoTell:
+        def read(self, _n: int = -1) -> bytes:
+            return b""
+
+    assert _stream_initial_position(NoTell()) == _NOT_SEEKABLE  # type: ignore[arg-type]
+
+
+# --- Stream rewind retry integration tests ---
+
+
+@respx.mock
+def test_retries_rewind_stream_on_transient_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("isola._client.time.sleep", lambda _: None)
+    payload = b"file content here"
+    bodies_received: list[bytes] = []
+
+    def capture_body(request: httpx.Request) -> httpx.Response:
+        bodies_received.append(request.content)
+        if len(bodies_received) == 1:
+            return httpx.Response(502, json={"detail": "bad gateway"})
+        return httpx.Response(200, json={"sandboxes": []})
+
+    respx.get("http://localhost:8080/v1/sandboxes").mock(side_effect=capture_body)
+
+    stream = io.BytesIO(payload)
+    with Isola(base_url="http://localhost:8080") as client:
+        client._api.request("GET", "/v1/sandboxes", content=stream)
+
+    assert len(bodies_received) == 2
+    assert bodies_received[0] == payload
+    assert bodies_received[1] == payload
+
+
+@respx.mock
+def test_no_retry_for_non_seekable_stream_on_transient_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("isola._client.time.sleep", lambda _: None)
+
+    class NonSeekableStream(io.RawIOBase):
+        def __init__(self, data: bytes) -> None:
+            self._data = data
+            self._pos = 0
+
+        def read(self, n: int = -1) -> bytes:
+            if n == -1:
+                result = self._data[self._pos :]
+                self._pos = len(self._data)
+            else:
+                result = self._data[self._pos : self._pos + n]
+                self._pos += len(result)
+            return result
+
+        def readinto(self, _b: bytearray | memoryview) -> int:
+            data = self.read(len(_b))
+            n = len(data)
+            _b[:n] = data
+            return n
+
+        def readable(self) -> bool:
+            return True
+
+        def seekable(self) -> bool:
+            return False
+
+        def seek(self, _offset: int, _whence: int = 0) -> int:
+            raise OSError("not seekable")
+
+        def tell(self) -> int:
+            return self._pos
+
+    respx.get("http://localhost:8080/v1/sandboxes").mock(
+        return_value=httpx.Response(502, json={"detail": "bad gateway"})
+    )
+
+    stream = NonSeekableStream(b"data")
+    with Isola(base_url="http://localhost:8080") as client, pytest.raises(BadGatewayError):
+        client._api.request("GET", "/v1/sandboxes", content=stream)
+
+
+@respx.mock
+def test_no_retry_for_non_seekable_stream_on_connection_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("isola._client.time.sleep", lambda _: None)
+
+    class NonSeekableStream(io.RawIOBase):
+        def read(self, _n: int = -1) -> bytes:
+            return b""
+
+        def readinto(self, _b: bytearray | memoryview) -> int:
+            return 0
+
+        def readable(self) -> bool:
+            return True
+
+        def seekable(self) -> bool:
+            return False
+
+        def seek(self, _offset: int, _whence: int = 0) -> int:
+            raise OSError("not seekable")
+
+        def tell(self) -> int:
+            return 0
+
+    route = respx.get("http://localhost:8080/v1/sandboxes")
+    route.mock(side_effect=httpx.ConnectError("connect failed"))
+
+    stream = NonSeekableStream()
+    with Isola(base_url="http://localhost:8080") as client, pytest.raises(APIConnectionError):
+        client._api.request("GET", "/v1/sandboxes", content=stream)
+
+    assert route.call_count == 1

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -449,18 +449,17 @@ def test_retries_rewind_seekable_stream_on_connection_error(monkeypatch: pytest.
     monkeypatch.setattr("isola._client.time.sleep", lambda _: None)
     payload = b"file content here"
     bodies_received: list[bytes] = []
+    call_count = 0
 
-    def capture_body(request: httpx.Request) -> httpx.Response:
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise httpx.ConnectError("connect failed")
         bodies_received.append(request.content)
         return httpx.Response(200, json={"sandboxes": []})
 
-    route = respx.get("http://localhost:8080/v1/sandboxes")
-    route.mock(
-        side_effect=[
-            httpx.ConnectError("connect failed"),
-            capture_body,
-        ]
-    )
+    respx.get("http://localhost:8080/v1/sandboxes").mock(side_effect=handler)
 
     stream = io.BytesIO(payload)
     with Isola(base_url="http://localhost:8080") as client:

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -478,13 +478,15 @@ def test_no_retry_for_non_seekable_stream_on_connection_error(monkeypatch: pytes
     route = respx.get("http://localhost:8080/v1/sandboxes")
     route.mock(side_effect=httpx.ConnectError("connect failed"))
 
-    # A pipe-like object: has read() but no seek()/tell()
+    # A pipe-like object: has read() but is not seekable
     r, w = os.pipe()
     os.write(w, b"data")
     os.close(w)
-    stream = os.fdopen(r, "rb")
-
-    with Isola(base_url="http://localhost:8080") as client, pytest.raises(APIConnectionError):
+    with (
+        os.fdopen(r, "rb") as stream,
+        Isola(base_url="http://localhost:8080") as client,
+        pytest.raises(APIConnectionError),
+    ):
         client._api.request("GET", "/v1/sandboxes", content=stream)
 
     assert route.call_count == 1


### PR DESCRIPTION
When a BinaryIO stream was passed as request content and a transient error
triggered a retry, the stream position was left at EOF — causing the retry
to send an empty body. Following botocore's pattern, record the initial
stream position before the retry loop and seek back before each retry.
Non-seekable streams are not retried to avoid silent data loss.

https://claude.ai/code/session_01SwuRbMGJtnYkkYTLCjEZqj