### PR TITLE
feat: publish isola-crds.yaml as GitHub Release asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 # Release workflow - builds and publishes container images to GitHub Container Registry
+# and creates a GitHub Release with a standalone CRD bundle asset.
 #
 # Triggered on:
 #   - Tags matching v* (e.g., v0.1.0, v1.0.0)
@@ -9,6 +10,9 @@
 #   - ghcr.io/isola-run/isola-snapshot-uploader:<tag>
 #   - ghcr.io/isola-run/api-gateway:<tag>
 #   - ghcr.io/isola-run/snapshot-mounter:<tag>
+#
+# Release assets:
+#   - isola-crds.yaml (standalone CRD bundle for kubectl apply before helm upgrade)
 
 name: Release
 
@@ -81,10 +85,29 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}
           platforms: linux/amd64,linux/arm64
 
+  create-release:
+    name: Create Release with CRD Bundle
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Generate CRD bundle
+        run: make crd-bundle
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: isola-crds.yaml
+
   update-chart-versions:
     name: Update Helm Chart appVersion
     runs-on: ubuntu-latest
-    needs: release-images
+    needs: [release-images, create-release]
     permissions:
       contents: write
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
   update-chart-versions:
     name: Update Helm Chart appVersion
     runs-on: ubuntu-latest
-    needs: [release-images, create-release]
+    needs: create-release
     permissions:
       contents: write
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,7 @@ jobs:
   create-release:
     name: Create Release with CRD Bundle
     runs-on: ubuntu-latest
+    needs: release-images
     permissions:
       contents: write
 

--- a/.gitignore
+++ b/.gitignore
@@ -217,6 +217,7 @@ coverage.html
 
 # Go
 bin/
+isola-crds.yaml
 *.exe
 *.test
 *.out

--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,18 @@ test-e2e-slow: ## Run E2E tests including slow tests
 test-e2e-verbose: ## Run E2E tests in parallel with verbose output
 	cd tests/e2e && uv run --frozen pytest -n $(E2E_WORKERS) --dist load -v $(if $(FOCUS),-k "$(FOCUS)")
 
+##@ Release
+
+CRD_BUNDLE ?= isola-crds.yaml
+
+.PHONY: crd-bundle
+crd-bundle: ## Generate concatenated CRD bundle for standalone installation
+	@: > $(CRD_BUNDLE)
+	@for f in $$(ls charts/isola/crds/*.yaml | sort); do \
+		cat "$$f" >> $(CRD_BUNDLE); \
+	done
+	@echo "Generated $(CRD_BUNDLE)"
+
 ##@ Build
 
 .PHONY: build

--- a/README.md
+++ b/README.md
@@ -241,8 +241,7 @@ For local development with Kind, `hack/setup.sh` automates the full cluster setu
 Helm does not upgrade CRDs from the chart's `crds/` directory. Before upgrading Isola, apply the CRD bundle for the target version:
 
 ```bash
-kubectl apply --server-side --force-conflicts \
-  -f https://github.com/isola-run/isola/releases/download/vX.Y.Z/isola-crds.yaml
+kubectl apply -f https://github.com/isola-run/isola/releases/download/vX.Y.Z/isola-crds.yaml
 helm upgrade isola isola/isola --namespace isola-system --version X.Y.Z
 ```
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,18 @@ export ISOLA_URL=http://localhost:8080
 
 For local development with Kind, `hack/setup.sh` automates the full cluster setup.
 
+### Upgrading
+
+Helm does not upgrade CRDs from the chart's `crds/` directory. Before upgrading Isola, apply the CRD bundle for the target version:
+
+```bash
+kubectl apply --server-side --force-conflicts \
+  -f https://github.com/isola-run/isola/releases/download/vX.Y.Z/isola-crds.yaml
+helm upgrade isola isola/isola --namespace isola-system --version X.Y.Z
+```
+
+The `isola-crds.yaml` bundle is published as a GitHub release asset for every tagged version. Always pin both the CRD bundle URL and the chart version to the same tag.
+
 ### gVisor setup
 
 Isola requires a gVisor [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) named `gvisor` in your cluster. If your cluster does not already have gVisor installed:


### PR DESCRIPTION
Add a CRD bundle release pipeline following the cert-manager pattern:

- Makefile: `crd-bundle` target concatenates charts/isola/crds/*.yaml
  into a single isola-crds.yaml for standalone CRD management
- Release workflow: new `create-release` job generates the bundle and
  uploads it as a GitHub Release asset via softprops/action-gh-release
- .gitignore: exclude the generated bundle from version control

Users managing CRDs separately can now upgrade with:

  kubectl apply --server-side --force-conflicts \
    -f https://github.com/isola-run/isola/releases/download/vX.Y.Z/isola-crds.yaml
  helm upgrade isola isola/isola --version X.Y.Z

https://claude.ai/code/session_01NZNq2qSctCR5RP1xQQVc9L