### PR TITLE
Rename isola dependency to isola-run

### DIFF
--- a/tests/e2e/pyproject.toml
+++ b/tests/e2e/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "End-to-end tests for the Isola sandbox platform"
 requires-python = ">=3.10"
 dependencies = [
-    "isola",
+    "isola-run",
     "prometheus-client>=0.20",
     "pytest>=8.0",
     "pytest-asyncio>=0.24",
@@ -13,7 +13,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-isola = { path = "../../sdks/python", editable = true }
+isola-run = { path = "../../sdks/python", editable = true }
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/tests/e2e/uv.lock
+++ b/tests/e2e/uv.lock
@@ -138,7 +138,30 @@ wheels = [
 ]
 
 [[package]]
-name = "isola"
+name = "isola-e2e-tests"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "isola-run" },
+    { name = "prometheus-client" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "isola-run", editable = "../../sdks/python" },
+    { name = "prometheus-client", specifier = ">=0.20" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
+    { name = "pytest-timeout", specifier = ">=2.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
+]
+
+[[package]]
+name = "isola-run"
 version = "0.1.0"
 source = { editable = "../../sdks/python" }
 dependencies = [
@@ -159,29 +182,6 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
 ]
 provides-extras = ["dev"]
-
-[[package]]
-name = "isola-e2e-tests"
-version = "0.1.0"
-source = { virtual = "." }
-dependencies = [
-    { name = "isola" },
-    { name = "prometheus-client" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-timeout" },
-    { name = "pytest-xdist" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "isola", editable = "../../sdks/python" },
-    { name = "prometheus-client", specifier = ">=0.20" },
-    { name = "pytest", specifier = ">=8.0" },
-    { name = "pytest-asyncio", specifier = ">=0.24" },
-    { name = "pytest-timeout", specifier = ">=2.0" },
-    { name = "pytest-xdist", specifier = ">=3.8.0" },
-]
 
 [[package]]
 name = "packaging"


### PR DESCRIPTION
## Summary
Updated the e2e test project dependencies to use the renamed `isola-run` package instead of `isola`.

## Changes
- Updated the package dependency in `dependencies` list from `isola` to `isola-run`
- Updated the local path source configuration in `[tool.uv.sources]` to reference `isola-run` instead of `isola`

## Details
This change reflects a package rename in the Python SDK. The e2e tests now correctly reference the renamed package while maintaining the same local editable installation from `../../sdks/python`.

https://claude.ai/code/session_01LDTveVXDfYKaN8ujiS4xbK