### PR TITLE
ci: stop pushing to main from release workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,116 @@
+# Prepare Release workflow - opens a PR that bumps the Helm chart version for a release.
+#
+# This workflow is run manually via the "Run workflow" button. It never pushes
+# directly to main - it opens a pull request that must be reviewed and merged.
+# After the PR is merged, tag the merge commit locally (vX.Y.Z) and push the
+# tag to trigger .github/workflows/release.yml.
+#
+# Why the chart bump must happen before tagging:
+#   charts/isola/templates/_helpers.tpl defaults each image tag to
+#   Chart.AppVersion, so the chart committed at the tagged SHA must already
+#   reference the images the tag will build.
+
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version without v prefix (e.g. 0.2.0, 1.0.0-rc.1)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    name: Open release prep PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]]; then
+            echo "::error::version must be semver without 'v' prefix (e.g. 0.2.0, 1.0.0-rc.1), got: '$VERSION'"
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: main
+
+      - name: Bump chart version and appVersion
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          sed -i "s/^version:.*/version: ${VERSION}/" charts/isola/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: \"${VERSION}\"/" charts/isola/Chart.yaml
+          echo "--- charts/isola/Chart.yaml (head) ---"
+          head -10 charts/isola/Chart.yaml
+
+      - name: Create branch, commit, and open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          BRANCH="release/v${VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git diff --quiet -- charts/isola/Chart.yaml; then
+            echo "::error::charts/isola/Chart.yaml is already at version ${VERSION} - nothing to do"
+            exit 1
+          fi
+
+          git checkout -b "$BRANCH"
+          git add charts/isola/Chart.yaml
+          git commit -m "chore: prepare release v${VERSION}"
+          # Force is safe: branch name is deterministic per version, any
+          # pre-existing branch is a prior run of this same prep.
+          git push -u origin "$BRANCH" --force
+
+          # Reuse an existing PR for the same branch if present, otherwise create one.
+          existing=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            echo "Updated existing PR #$existing"
+            gh pr view "$existing" --json url --jq '.url'
+            exit 0
+          fi
+
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore: prepare release v${VERSION}" \
+            --body "$(cat <<EOF
+          Prepares release **v${VERSION}** by bumping the Helm chart version and appVersion.
+
+          ## After merging
+
+          Tag the merge commit on \`main\` and push the tag:
+
+          \`\`\`
+          git checkout main
+          git pull
+          git tag -a v${VERSION} -m "Release v${VERSION}"
+          git push origin v${VERSION}
+          \`\`\`
+
+          Pushing the tag triggers \`.github/workflows/release.yml\`, which
+          builds and publishes the container images under this version.
+
+          ## Note on CI
+
+          Pull requests opened by \`GITHUB_TOKEN\` do not trigger other
+          workflows. If you want lint/test/codegen to run on this PR, push an
+          empty commit to the branch (or close and reopen the PR):
+
+          \`\`\`
+          git fetch origin ${BRANCH} && git checkout ${BRANCH}
+          git commit --allow-empty -m "ci: trigger checks" && git push
+          \`\`\`
+          EOF
+          )"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,17 @@
 #   - ghcr.io/isola-run/isola-snapshot-uploader:<tag>
 #   - ghcr.io/isola-run/api-gateway:<tag>
 #   - ghcr.io/isola-run/snapshot-mounter:<tag>
+#
+# This workflow is intentionally build-only. It does not write back to the
+# repository. The Helm chart's appVersion must be bumped in a PR *before* the
+# tag is created (see .github/workflows/prepare-release.yml). Release flow:
+#   1. Run the "Prepare Release" workflow with the target version.
+#   2. Review and merge the PR it opens.
+#   3. Tag the merge commit locally and push the tag:
+#        git checkout main && git pull
+#        git tag -a vX.Y.Z -m "Release vX.Y.Z"
+#        git push origin vX.Y.Z
+#   4. This workflow then builds and publishes the images.
 
 name: Release
 
@@ -80,31 +91,3 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.image.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}
           platforms: linux/amd64,linux/arm64
-
-  update-chart-versions:
-    name: Update Helm Chart appVersion
-    runs-on: ubuntu-latest
-    needs: release-images
-    permissions:
-      contents: write
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: main
-
-      - name: Update Chart.yaml appVersion
-        run: |
-          VERSION=${GITHUB_REF_NAME#v}  # Strip 'v' prefix
-
-          # Update isola Chart.yaml (unified chart)
-          sed -i "s/^appVersion:.*/appVersion: \"${VERSION}\"/" charts/isola/Chart.yaml
-
-      - name: Commit and push
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add charts/*/Chart.yaml
-          git diff --staged --quiet || git commit -m "chore: update appVersion to ${GITHUB_REF_NAME#v}"
-          git push


### PR DESCRIPTION
The release workflow pushed directly to main after every tag to bump
charts/isola/Chart.yaml appVersion. CI writing to a protected branch is
an anti-pattern and a footgun - any bug in the sed, ref, or matrix means
the write lands unreviewed on main.

Move to the CNCF-typical release pattern:

- release.yml becomes build-only on tag push. No writeback.
- prepare-release.yml is a new workflow_dispatch workflow that bumps
  Chart.yaml version and appVersion on a release/vX.Y.Z branch and opens
  a PR to main. A human reviews and merges it; a human tags the merge
  commit; pushing the tag triggers release.yml to build images.

The chart bump must happen before tagging because the Helm chart defaults
each image tag to Chart.AppVersion, so the chart committed at the tagged
SHA must already reference the images the tag will build.