### PR TITLE
use kmeta-style ChildName helper for operator child resource names

### DIFF
--- a/internal/operator/controller/podutil/childname.go
+++ b/internal/operator/controller/podutil/childname.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Adapted from https://github.com/knative/pkg/blob/main/kmeta/names.go
+//
+// Modifications from the upstream version:
+//   - makeValidName is invoked on every return path, defending against
+//     trailing non-alphanumeric characters in the parent (knative/pkg#2659)
+//     even when the suffix would otherwise mask them.
+
+package podutil
+
+import (
+	"crypto/md5" // #nosec G401 -- used for name uniqueness, not security
+	"encoding/hex"
+	"fmt"
+	"regexp"
+)
+
+const (
+	// longest is the maximum length of a DNS-1123 label, which is the
+	// strictest name limit applied by Kubernetes (Services, the job-name
+	// label, etc.). Capping at this size keeps generated names usable
+	// everywhere a parent name might be referenced.
+	longest = 63
+	md5Len  = 32
+	// head is how much of the parent we can keep before the MD5 hex hash
+	// fills the remainder of the budget.
+	head = longest - md5Len
+)
+
+var isAlphanumeric = regexp.MustCompile("^[a-zA-Z0-9]$")
+
+// ChildName generates a name for a child resource derived from `parent` plus
+// `suffix`. When the simple concatenation would exceed Kubernetes' 63-char
+// DNS-1123 label limit, the parent is truncated and the MD5 hex of the
+// original parent is spliced in so distinct long parents still yield distinct
+// child names.
+//
+// For short parents (the common case in this operator, where parents are
+// 22-char nanoid sandbox / snapshot IDs) the result is the unmodified
+// `parent + suffix` concatenation.
+func ChildName(parent, suffix string) string {
+	n := parent
+	if len(parent) > (longest - len(suffix)) {
+		// Suffix alone is so long that there's no room to keep parent prefix
+		// plus a full hash; hash the (parent+suffix) pair, keep as much
+		// parent prefix as fits, then append as much suffix as still fits.
+		if head-len(suffix) <= 0 {
+			h := md5.Sum([]byte(parent + suffix)) // #nosec G401
+			if head < len(parent) {
+				parent = parent[:head]
+			}
+			ret := parent + hex.EncodeToString(h[:])
+			if d := longest - len(ret); d > 0 {
+				ret += suffix[:d]
+			}
+			return makeValidName(ret)
+		}
+		n = fmt.Sprintf("%s%x", parent[:head-len(suffix)], md5.Sum([]byte(parent))) // #nosec G401
+	}
+	return makeValidName(n + suffix)
+}
+
+// makeValidName strips trailing characters that aren't allowed at the end of
+// a DNS-1123 name (which must end in [a-z0-9]).
+func makeValidName(n string) string {
+	for len(n) > 0 && !isAlphanumeric.MatchString(n[len(n)-1:]) {
+		n = n[:len(n)-1]
+	}
+	return n
+}

--- a/internal/operator/controller/podutil/childname_test.go
+++ b/internal/operator/controller/podutil/childname_test.go
@@ -1,0 +1,120 @@
+// Copyright The Isola Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podutil
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+// dns1123Subdomain matches a single DNS-1123 label (which all our generated
+// names must be valid as, since labels are the strictest constraint).
+var dns1123Label = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+
+func TestChildName_ShortParent_PlainConcat(t *testing.T) {
+	g := NewWithT(t)
+
+	// 22-char nanoid (matches sandboxIDLength in api-gateway/sandbox).
+	parent := "abc1234567890123456789"
+	g.Expect(parent).To(HaveLen(22))
+
+	// Golden: short parents must produce the same name as the previous
+	// plain-concatenation implementation, so existing sandboxes keep the
+	// same child resource names.
+	g.Expect(ChildName(parent, "-pod")).To(Equal(parent + "-pod"))
+	g.Expect(ChildName(parent, "-custom-netpol")).To(Equal(parent + "-custom-netpol"))
+	g.Expect(ChildName(parent, "-termination")).To(Equal(parent + "-termination"))
+	g.Expect(ChildName(parent, "-job")).To(Equal(parent + "-job"))
+}
+
+func TestChildName_AtBoundary_PlainConcat(t *testing.T) {
+	g := NewWithT(t)
+
+	// parent length + suffix length == 63: still plain concat.
+	parent := strings.Repeat("a", 59)
+	got := ChildName(parent, "-pod")
+	g.Expect(got).To(HaveLen(63))
+	g.Expect(got).To(Equal(parent + "-pod"))
+}
+
+func TestChildName_OverBoundary_HashesParent(t *testing.T) {
+	g := NewWithT(t)
+
+	parent := strings.Repeat("a", 60) // 60 + 4 = 64 > 63: triggers hash branch.
+	got := ChildName(parent, "-pod")
+
+	g.Expect(len(got)).To(BeNumerically("<=", 63))
+	g.Expect(got).To(HaveSuffix("-pod"))
+	g.Expect(dns1123Label.MatchString(got)).To(BeTrue(), "result %q is not a valid DNS-1123 label", got)
+	// Should not just be a naive truncation of the parent.
+	g.Expect(got).NotTo(Equal(parent[:59] + "-pod"))
+}
+
+func TestChildName_DistinctLongParents_ProduceDistinctNames(t *testing.T) {
+	g := NewWithT(t)
+
+	// Two parents that share the first many characters; without a hash a
+	// naive truncation would collide.
+	a := strings.Repeat("a", 60) + "-one"
+	b := strings.Repeat("a", 60) + "-two"
+
+	g.Expect(ChildName(a, "-pod")).NotTo(Equal(ChildName(b, "-pod")))
+}
+
+func TestChildName_LongSuffix_HashesPair(t *testing.T) {
+	g := NewWithT(t)
+
+	// Suffix longer than head (31): exercises the second branch.
+	parent := strings.Repeat("a", 50)
+	suffix := "-" + strings.Repeat("b", 40)
+
+	got := ChildName(parent, suffix)
+	g.Expect(len(got)).To(BeNumerically("<=", 63))
+	g.Expect(dns1123Label.MatchString(got)).To(BeTrue(), "result %q is not a valid DNS-1123 label", got)
+}
+
+func TestChildName_TrailingNonAlnumStripped(t *testing.T) {
+	g := NewWithT(t)
+
+	// makeValidName must trim a trailing non-alphanumeric character. We
+	// can't easily produce one through ChildName itself with our usual
+	// suffixes, so test the helper directly.
+	g.Expect(makeValidName("foo.")).To(Equal("foo"))
+	g.Expect(makeValidName("foo-")).To(Equal("foo"))
+	g.Expect(makeValidName("foo.-.")).To(Equal("foo"))
+	g.Expect(makeValidName("foo")).To(Equal("foo"))
+	g.Expect(makeValidName("")).To(Equal(""))
+}
+
+func TestChildName_AllHelpersBoundedAt63(t *testing.T) {
+	g := NewWithT(t)
+
+	// Pathologically long parent (would never come from our APIs today,
+	// but verifies the invariant that derived names always fit).
+	parent := strings.Repeat("x", 200)
+
+	for _, name := range []string{
+		GetSandboxPodName(parent),
+		GetCustomNetworkPolicyName(parent),
+		GetTerminationSnapshotName(parent),
+		GetSnapshotJobName(parent),
+	} {
+		g.Expect(len(name)).To(BeNumerically("<=", 63), "name %q exceeds 63 chars", name)
+		g.Expect(dns1123Label.MatchString(name)).To(BeTrue(), "name %q is not a valid DNS-1123 label", name)
+	}
+}

--- a/internal/operator/controller/podutil/podutil.go
+++ b/internal/operator/controller/podutil/podutil.go
@@ -57,19 +57,19 @@ func IsPodTerminated(pod *corev1.Pod) bool {
 }
 
 func GetSandboxPodName(sandboxName string) string {
-	return sandboxName + "-pod"
+	return ChildName(sandboxName, "-pod")
 }
 
 func GetCustomNetworkPolicyName(sandboxName string) string {
-	return sandboxName + "-custom-netpol"
+	return ChildName(sandboxName, "-custom-netpol")
 }
 
 func GetTerminationSnapshotName(sandboxName string) string {
-	return sandboxName + "-termination"
+	return ChildName(sandboxName, "-termination")
 }
 
 func GetSnapshotJobName(snapshotName string) string {
-	return snapshotName + "-job"
+	return ChildName(snapshotName, "-job")
 }
 
 // ExtractContainerID gets the container ID for a named container.


### PR DESCRIPTION
The operator derives child resource names (Pod, NetworkPolicy,
RootfsSnapshot, Job) by concatenating a parent name with a fixed
suffix. That is safe today because sandbox/snapshot IDs are a
fixed 22-char nanoid, but the invariant is implicit and any future
change that lengthens parent names would silently produce names
exceeding Kubernetes' 63-char DNS-1123 label limit.

Adopt Knative's kmeta.ChildName algorithm: short parents continue
to produce `<parent>-<suffix>` verbatim (so existing sandboxes
keep identical child resource names), while long parents get
truncated and spliced with an MD5 hex of the original parent,
capping output at 63 chars and preserving uniqueness.

The file is adapted from knative.dev/pkg/kmeta under Apache-2.0
rather than taken as a module dependency, which would pull in the
full knative/pkg tree for 30 lines of code (Tekton and OpenShift
vendor it for the same reason). makeValidName is applied on every
return path as a defense against knative/pkg#2659.