### PR TITLE
ci: consolidate dependabot GitHub Actions bumps (#243-#247)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,7 +33,7 @@ jobs:
 
       # Build all images in parallel with caching
       - name: Build isola-operator image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: .
           file: cmd/operator/Dockerfile
@@ -43,7 +43,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=operator
 
       - name: Build sandbox-sidecar image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: .
           file: cmd/sandbox-sidecar/Dockerfile
@@ -53,7 +53,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=sidecar
 
       - name: Build isola-snapshot-uploader image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: .
           file: cmd/snapshot-uploader/Dockerfile
@@ -63,7 +63,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=uploader
 
       - name: Build api-gateway image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: .
           file: cmd/api-gateway/Dockerfile
@@ -73,7 +73,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=api
 
       - name: Build snapshot-mounter image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: cmd/snapshot-mounter
           file: cmd/snapshot-mounter/Dockerfile
@@ -83,7 +83,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=snapshot-mounter
 
       - name: Create Kind cluster
-        uses: helm/kind-action@0b5c88445f37b7e12a2ce1ecca7805b9046a74db # v1
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
         with:
           cluster_name: ${{ env.KIND_CLUSTER_NAME }}
           config: hack/kind-config.yaml
@@ -145,7 +145,7 @@ jobs:
           kind load docker-image ${{ env.SNAPSHOT_MOUNTER_IMAGE }}:ci --name ${{ env.KIND_CLUSTER_NAME }}
 
       - name: Set up Helm
-        uses: azure/setup-helm@f0accbfd55e3332a28f721b8202b1016cecf90d5 # v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
 
       - name: Deploy LocalStack
         run: |
@@ -201,7 +201,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Run E2E tests
         working-directory: tests/e2e
@@ -210,7 +210,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: test-results
           path: tests/e2e/test-results.xml
@@ -257,7 +257,7 @@ jobs:
 
       - name: Upload failure artifacts
         if: failure()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: e2e-failure-logs-${{ github.run_id }}
           path: |

--- a/.github/workflows/python-sdk.yml
+++ b/.github/workflows/python-sdk.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Sync dependencies
         run: uv sync --frozen --extra dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
             type=sha,prefix=
 
       - name: Build and push
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: ${{ matrix.image.context || '.' }}
           file: ${{ matrix.image.dockerfile }}


### PR DESCRIPTION
## Summary

Consolidates the five open dependabot PRs into a single PR so they can be merged together.

- #247 Bump docker/build-push-action (v7.0.0 -> v7.1.0)
- #246 Bump astral-sh/setup-uv
- #245 Bump azure/setup-helm
- #244 Bump actions/upload-artifact (v7.0.0 -> v7.0.1)
- #243 Bump helm/kind-action

Each SHA and ref matches the corresponding dependabot PR exactly; no other changes.

## Test plan

- [ ] E2E workflow runs green on this PR
- [ ] After merge, close #243, #244, #245, #246, #247