### PR TITLE
add Prometheus metrics to api-gateway

### DIFF
--- a/charts/isola/templates/api-gateway/servicemonitor.yaml
+++ b/charts/isola/templates/api-gateway/servicemonitor.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.apiGateway.enabled .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "isola.apiGateway.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "isola.apiGateway.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "isola.apiGateway.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: /metrics
+{{- end }}

--- a/cmd/api-gateway/main.go
+++ b/cmd/api-gateway/main.go
@@ -46,6 +46,7 @@ import (
 	"github.com/isola-run/isola/internal/api-gateway/command"
 	"github.com/isola-run/isola/internal/api-gateway/filesystem"
 	"github.com/isola-run/isola/internal/api-gateway/health"
+	"github.com/isola-run/isola/internal/api-gateway/metrics"
 	"github.com/isola-run/isola/internal/api-gateway/rootfssnapshot"
 	"github.com/isola-run/isola/internal/api-gateway/sandbox"
 	"github.com/isola-run/isola/internal/api-gateway/version"
@@ -169,6 +170,9 @@ func main() {
 	}
 
 	r := chi.NewRouter()
+	// Install metrics first so the histogram observes the total server-side latency,
+	// including httplog and the chi.Recoverer (installed by httplog) layers beneath it.
+	r.Use(metrics.Middleware)
 	// httplog.RequestLogger automatically includes chi's RequestID and Recoverer middleware
 	r.Use(httplog.RequestLogger(&httplog.Logger{
 		Logger: logger,
@@ -178,6 +182,7 @@ func main() {
 			Concise:  true,
 		},
 	}))
+	r.Handle("/metrics", metrics.Handler())
 
 	logger.Info("starting api-gateway", "version", internalversion.Get())
 

--- a/internal/api-gateway/metrics/metrics.go
+++ b/internal/api-gateway/metrics/metrics.go
@@ -1,0 +1,107 @@
+// Copyright The Isola Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package metrics provides Prometheus instrumentation for the api-gateway HTTP server.
+//
+// Metrics are registered on prometheus.DefaultRegisterer; expose them via Handler.
+// Wire the HTTP middleware into a chi router via Middleware so the route pattern
+// label stays bounded (raw URLs would explode cardinality on path params).
+package metrics
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	chimw "github.com/go-chi/chi/v5/middleware"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// unknownRoute labels requests that do not match any registered route (e.g. 404s)
+// so a malicious probe across random URLs does not blow up label cardinality.
+const unknownRoute = "unknown"
+
+// latencyBuckets extends prometheus.DefBuckets with longer-tail buckets for
+// long-poll endpoints (gateway allows waitSeconds up to 25) and SSE streams.
+var latencyBuckets = append(append([]float64{}, prometheus.DefBuckets...), 15, 30, 60)
+
+var (
+	httpRequestsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "isola",
+		Subsystem: "apigateway",
+		Name:      "http_requests_total",
+		Help:      "Total HTTP requests processed, partitioned by method, matched route pattern, and response status code.",
+	}, []string{"method", "path", "code"})
+
+	httpRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "isola",
+		Subsystem: "apigateway",
+		Name:      "http_request_duration_seconds",
+		Help:      "HTTP request latency in seconds, partitioned by method, matched route pattern, and response status code.",
+		Buckets:   latencyBuckets,
+	}, []string{"method", "path", "code"})
+
+	httpRequestsInFlight = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "isola",
+		Subsystem: "apigateway",
+		Name:      "http_requests_in_flight",
+		Help:      "Current number of HTTP requests being served.",
+	})
+)
+
+// Middleware instruments HTTP requests with Prometheus metrics.
+//
+// It must be installed on a chi router: the matched route pattern is read from
+// chi.RouteContext AFTER next.ServeHTTP returns, because chi only populates it
+// during routing (see https://github.com/go-chi/chi/issues/270).
+//
+// Register before other middleware (i.e. call r.Use(metrics.Middleware) first)
+// so the observed duration covers the full server-side processing time.
+func Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		ww := chimw.NewWrapResponseWriter(w, r.ProtoMajor)
+
+		httpRequestsInFlight.Inc()
+		defer httpRequestsInFlight.Dec()
+
+		next.ServeHTTP(ww, r)
+
+		path := unknownRoute
+		if rctx := chi.RouteContext(r.Context()); rctx != nil {
+			if p := rctx.RoutePattern(); p != "" {
+				path = p
+			}
+		}
+
+		status := ww.Status()
+		if status == 0 {
+			// Handler returned without WriteHeader or Write: net/http emits 200.
+			status = http.StatusOK
+		}
+		code := strconv.Itoa(status)
+
+		httpRequestsTotal.WithLabelValues(r.Method, path, code).Inc()
+		httpRequestDuration.WithLabelValues(r.Method, path, code).Observe(time.Since(start).Seconds())
+	})
+}
+
+// Handler returns the HTTP handler that exposes metrics for Prometheus scraping.
+// Mount it at /metrics on the chi router.
+func Handler() http.Handler {
+	return promhttp.Handler()
+}

--- a/internal/api-gateway/metrics/metrics_test.go
+++ b/internal/api-gateway/metrics/metrics_test.go
@@ -1,0 +1,174 @@
+// Copyright The Isola Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestMiddleware_CollapsesPathParamsToRoutePattern(t *testing.T) {
+	r := chi.NewRouter()
+	r.Use(Middleware)
+	r.Get("/v1/sandboxes/{id}", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	before := testutil.ToFloat64(httpRequestsTotal.WithLabelValues("GET", "/v1/sandboxes/{id}", "200"))
+
+	for _, id := range []string{"abc", "def", "xyz"} {
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/v1/sandboxes/"+id, nil))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("unexpected status: %d", rr.Code)
+		}
+	}
+
+	if got, want := testutil.ToFloat64(httpRequestsTotal.WithLabelValues("GET", "/v1/sandboxes/{id}", "200")), before+3; got != want {
+		t.Errorf("counter = %v, want %v (distinct path params must collapse onto the route pattern)", got, want)
+	}
+}
+
+func TestMiddleware_RecordsErrorStatusCode(t *testing.T) {
+	r := chi.NewRouter()
+	r.Use(Middleware)
+	r.Get("/fail", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "bad", http.StatusBadRequest)
+	})
+
+	before := testutil.ToFloat64(httpRequestsTotal.WithLabelValues("GET", "/fail", "400"))
+
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/fail", nil))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("unexpected status: %d", rr.Code)
+	}
+
+	if got, want := testutil.ToFloat64(httpRequestsTotal.WithLabelValues("GET", "/fail", "400")), before+1; got != want {
+		t.Errorf("counter = %v, want %v", got, want)
+	}
+}
+
+func TestMiddleware_TreatsNoWriteAs200(t *testing.T) {
+	r := chi.NewRouter()
+	r.Use(Middleware)
+	// Handler returns without calling WriteHeader or Write; net/http writes an implicit 200.
+	r.Get("/ok-implicit", func(http.ResponseWriter, *http.Request) {})
+
+	before := testutil.ToFloat64(httpRequestsTotal.WithLabelValues("GET", "/ok-implicit", "200"))
+
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/ok-implicit", nil))
+
+	if got, want := testutil.ToFloat64(httpRequestsTotal.WithLabelValues("GET", "/ok-implicit", "200")), before+1; got != want {
+		t.Errorf("counter = %v, want %v", got, want)
+	}
+}
+
+func TestMiddleware_UnmatchedRouteSharesUnknownLabel(t *testing.T) {
+	r := chi.NewRouter()
+	r.Use(Middleware)
+	r.Get("/known", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	before := testutil.ToFloat64(httpRequestsTotal.WithLabelValues("GET", unknownRoute, "404"))
+
+	for _, path := range []string{"/nope/1", "/nope/2", "/different/path"} {
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, path, nil))
+		if rr.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d for %s", rr.Code, path)
+		}
+	}
+
+	if got, want := testutil.ToFloat64(httpRequestsTotal.WithLabelValues("GET", unknownRoute, "404")), before+3; got != want {
+		t.Errorf("counter = %v, want %v (unmatched routes must share the 'unknown' label to bound cardinality)", got, want)
+	}
+}
+
+func TestMiddleware_InFlightReturnsToBaselineAfterRequest(t *testing.T) {
+	r := chi.NewRouter()
+	r.Use(Middleware)
+	r.Get("/inflight", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	before := testutil.ToFloat64(httpRequestsInFlight)
+
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/inflight", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d", rr.Code)
+	}
+
+	if got := testutil.ToFloat64(httpRequestsInFlight); got != before {
+		t.Errorf("in-flight gauge = %v, want %v (should return to baseline after request completes)", got, before)
+	}
+}
+
+func TestMiddleware_ObservesDuration(t *testing.T) {
+	r := chi.NewRouter()
+	r.Use(Middleware)
+	r.Get("/dur", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	before := testutil.CollectAndCount(httpRequestDuration)
+
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/dur", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d", rr.Code)
+	}
+
+	if got := testutil.CollectAndCount(httpRequestDuration); got < before {
+		t.Errorf("duration histogram series count decreased: before=%d after=%d", before, got)
+	}
+}
+
+func TestHandler_ExposesRegisteredMetrics(t *testing.T) {
+	r := chi.NewRouter()
+	r.Use(Middleware)
+	r.Handle("/metrics", Handler())
+	r.Get("/hit", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Observe at least one request so the vec collectors have a series to scrape.
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/hit", nil))
+
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d", rr.Code)
+	}
+
+	body := rr.Body.String()
+	for _, want := range []string{
+		"isola_apigateway_http_requests_total",
+		"isola_apigateway_http_request_duration_seconds",
+		"isola_apigateway_http_requests_in_flight",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("/metrics output missing %q", want)
+		}
+	}
+}


### PR DESCRIPTION
Instruments HTTP requests with three metrics, using chi's route pattern as the
low-cardinality path label (raw URL would explode on path params):
- isola_apigateway_http_requests_total{method,path,code}
- isola_apigateway_http_request_duration_seconds{method,path,code}
- isola_apigateway_http_requests_in_flight

Latency histogram extends prometheus.DefBuckets with 15/30/60s buckets for
the long-poll (waitSeconds up to 25) and SSE streaming endpoints.

Metrics are registered on prometheus.DefaultRegisterer (the api-gateway does
not run controller-runtime's metrics server) and exposed at /metrics via
promhttp.Handler. A ServiceMonitor is added under the existing
serviceMonitor.enabled flag.

The middleware reads chi.RouteContext AFTER next.ServeHTTP so the matched
route pattern is populated, and falls back to an "unknown" sentinel for
unmatched routes to keep the label set bounded.