### PR TITLE
add zizmor GitHub Actions security audit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,12 @@
       directory: "/"
       schedule:
         interval: "weekly"
+      cooldown:
+        default-days: 7
 
     - package-ecosystem: "github-actions"
       directory: "/"
       schedule:
         interval: "weekly"
+      cooldown:
+        default-days: 7

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code
         id: claude

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6

--- a/.github/workflows/python-sdk.yml
+++ b/.github/workflows/python-sdk.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
@@ -109,6 +111,9 @@ jobs:
 
     steps:
       - name: Checkout
+        # zizmor: ignore[artipacked] credentials are intentionally persisted
+        # so the subsequent "Commit and push" step can push the chart version
+        # bump back to main under github-actions[bot].
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -28,3 +30,27 @@ jobs:
 
       - name: Run govulncheck
         run: govulncheck ./...
+
+  zizmor:
+    name: Workflow Security Audit
+    runs-on: ubuntu-latest
+    permissions:
+      # security-events: write is required for uploading SARIF to the Security tab.
+      # contents: read is needed so actions/checkout can clone on private repos; harmless on public.
+      security-events: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          # Scope to workflow/action/dependabot definitions. isola has none outside .github/.
+          inputs: ./.github/
+          # Pin the zizmor CLI version independently of the action version, matching
+          # the project's tool-pinning policy. Keep in sync with hack/setup.sh.
+          version: 1.24.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ Tool versions are pinned and must be kept in sync across locations:
 | Go | `Makefile` (`GO_VERSION`), `go.mod` | Dockerfile `FROM golang:` tags |
 | golangci-lint | `hack/setup.sh` | `.github/workflows/lint.yml` |
 | govulncheck | `hack/setup.sh` | - |
+| zizmor | `hack/setup.sh` (`ZIZMOR_VERSION`) | `.github/workflows/security.yml` (`version:` input on zizmor-action) |
 | lefthook | `hack/setup.sh` | - |
 | setup-envtest | `hack/setup.sh` | `.github/workflows/test.yml` |
 | envtest K8s | `Makefile` | k8s.io/api in go.mod |

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,10 @@ lint-fix: ## Run golangci-lint --fix
 vulncheck: ## Run govulncheck
 	govulncheck ./...
 
+.PHONY: vulncheck-workflows
+vulncheck-workflows: ## Run zizmor on GitHub Actions workflows
+	zizmor ./.github/
+
 .PHONY: tidy
 tidy: ## Run go mod tidy
 	go mod tidy
@@ -102,7 +106,7 @@ check-manifests: manifests ## Verify generated manifests are up-to-date
 	fi
 
 .PHONY: check-all
-check-all: vet lint vulncheck check-openapi check-manifests sdk-python-check-all ## Run all checks (read-only, CI-safe)
+check-all: vet lint vulncheck vulncheck-workflows check-openapi check-manifests sdk-python-check-all ## Run all checks (read-only, CI-safe)
 
 .PHONY: fix-all
 fix-all: fmt lint-fix sdk-python-fix-all ## Fix all auto-fixable issues

--- a/hack/setup.sh
+++ b/hack/setup.sh
@@ -28,6 +28,7 @@ SETUP_ENVTEST_VERSION="release-0.23"
 CONTROLLER_GEN_VERSION="v0.20.0"
 LEFTHOOK_VERSION="v2.0.15"
 GVISOR_VERSION="20260302"
+ZIZMOR_VERSION="1.24.1"
 
 GVISOR_URL="https://storage.googleapis.com/gvisor/releases/release/${GVISOR_VERSION}"
 
@@ -135,6 +136,12 @@ if check_optional_tool "govulncheck" "Install: go install golang.org/x/vuln/cmd/
     installed_version=$(govulncheck -version 2>&1 | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "unknown")
     if [ "$installed_version" != "$GOVULNCHECK_VERSION" ]; then
         echo "    [WARN] Version mismatch: installed $installed_version, expected $GOVULNCHECK_VERSION"
+    fi
+fi
+if check_optional_tool "zizmor" "Install: uv tool install zizmor==${ZIZMOR_VERSION}  (or: cargo install --locked zizmor@${ZIZMOR_VERSION})"; then
+    installed_version=$(zizmor --version 2>/dev/null | awk '{print $2}' || echo "unknown")
+    if [ "$installed_version" != "$ZIZMOR_VERSION" ]; then
+        echo "    [WARN] Version mismatch: installed $installed_version, expected $ZIZMOR_VERSION"
     fi
 fi
 check_optional_tool "lefthook" "Install: go install github.com/evilmartians/lefthook/v2@${LEFTHOOK_VERSION}" && HAS_LEFTHOOK=1

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,17 @@
+# zizmor configuration — https://docs.zizmor.sh/configuration/
+#
+# Any suppression added here MUST include a comment explaining why the finding
+# is either a false positive or intentional. Prefer inline `# zizmor: ignore[...]`
+# comments in workflow files when placement allows; fall back to this file when
+# it does not (e.g. when the finding points at a `uses:` line where the version
+# pin comment already occupies the trailing YAML comment slot).
+
+rules:
+  cache-poisoning:
+    ignore:
+      # e2e.yml is a test-only workflow: docker/build-push-action uses
+      # `load: true` (not `push: true`) and no release artifacts are published
+      # here. Releases go through .github/workflows/release.yml, which does not
+      # enable action caching. The astral-sh/setup-uv cache only affects pytest
+      # execution inside this test job.
+      - e2e.yml


### PR DESCRIPTION
Integrates zizmor (https://docs.zizmor.sh) as a second job in security.yml
alongside govulncheck. Runs on push to main and PRs, uploads SARIF to the
Security tab via GitHub Advanced Security, and covers the 35+ audits zizmor
ships with (template injection, credential persistence, excessive permissions,
impostor commits, stale action refs, etc.).

Address findings surfaced in default persona:
  - dependabot-cooldown: add 7-day cooldown to both ecosystems (zizmor --fix)
  - artipacked: add persist-credentials: false to every checkout that does
    not push; the release.yml update-chart-versions checkout keeps credentials
    and carries an inline zizmor ignore comment explaining why
  - cache-poisoning: suppressed for e2e.yml in zizmor.yml with rationale
    (this workflow builds with load: true, not push: true, and never publishes
    release artifacts)

Pin zizmor CLI to 1.24.1 and the zizmor-action to v0.5.3 by SHA, matching the
project's tool-pinning policy. Mirror the pin locally via hack/setup.sh and
a new `make vulncheck-workflows` target added to `make check-all`.