### PR TITLE
Add SidecarVersion to Sandbox status for capability checks

### DIFF
--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -215,6 +215,14 @@ type SandboxStatus struct {
 	// PodIP is the IP address of the sandbox pod.
 	// +optional
 	PodIP string `json:"podIP,omitempty"`
+
+	// SidecarVersion records the isola-operator GitVersion at the time the sandbox
+	// pod was created, as a proxy for the sandbox-sidecar build shipped into the pod.
+	// Set once at pod creation and never updated afterwards, so consumers can reason
+	// about which sidecar capabilities are available for a long-running sandbox even
+	// after the operator/sidecar images have been upgraded.
+	// +optional
+	SidecarVersion string `json:"sidecarVersion,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/charts/isola/templates/crd/sandbox.isola.run_sandboxes.yaml
+++ b/charts/isola/templates/crd/sandbox.isola.run_sandboxes.yaml
@@ -329,6 +329,14 @@ spec:
               podIP:
                 description: PodIP is the IP address of the sandbox pod.
                 type: string
+              sidecarVersion:
+                description: |-
+                  SidecarVersion records the isola-operator GitVersion at the time the sandbox
+                  pod was created, as a proxy for the sandbox-sidecar build shipped into the pod.
+                  Set once at pod creation and never updated afterwards, so consumers can reason
+                  about which sidecar capabilities are available for a long-running sandbox even
+                  after the operator/sidecar images have been upgraded.
+                type: string
               terminationDeadlineAt:
                 description: |-
                   TerminationDeadlineAt is the absolute time by which the termination policy must complete.

--- a/config/crd/bases/sandbox.isola.run_sandboxes.yaml
+++ b/config/crd/bases/sandbox.isola.run_sandboxes.yaml
@@ -325,6 +325,14 @@ spec:
               podIP:
                 description: PodIP is the IP address of the sandbox pod.
                 type: string
+              sidecarVersion:
+                description: |-
+                  SidecarVersion records the isola-operator GitVersion at the time the sandbox
+                  pod was created, as a proxy for the sandbox-sidecar build shipped into the pod.
+                  Set once at pod creation and never updated afterwards, so consumers can reason
+                  about which sidecar capabilities are available for a long-running sandbox even
+                  after the operator/sidecar images have been upgraded.
+                type: string
               terminationDeadlineAt:
                 description: |-
                   TerminationDeadlineAt is the absolute time by which the termination policy must complete.

--- a/internal/operator/controller/sandbox_controller.go
+++ b/internal/operator/controller/sandbox_controller.go
@@ -41,6 +41,7 @@ import (
 	netbuilder "github.com/isola-run/isola/internal/operator/controller/network"
 	"github.com/isola-run/isola/internal/operator/controller/podutil"
 	"github.com/isola-run/isola/internal/operator/controller/snapshot"
+	internalversion "github.com/isola-run/isola/internal/version"
 	"k8s.io/client-go/tools/events"
 )
 
@@ -398,6 +399,12 @@ func (r *SandboxReconciler) CreateSandboxPod(ctx context.Context, sandbox *sandb
 	sandboxCreatedTotal.Inc()
 
 	r.Recorder.Eventf(sandbox, nil, corev1.EventTypeNormal, "PodCreated", "Created", "Sandbox Pod created")
+
+	// Capture the sidecar version at pod creation time so consumers (api-gateway)
+	// can do capability checks against long-running sandboxes whose sidecar image
+	// predates later operator upgrades. Operator and sidecar are released together,
+	// so the operator's own version stands in for the sidecar build.
+	sandbox.Status.SidecarVersion = internalversion.Get().GitVersion
 
 	if err := r.patchStatus(ctx, baseSandbox, sandbox, []metav1.Condition{
 		{

--- a/internal/operator/controller/sandbox_controller_pod_test.go
+++ b/internal/operator/controller/sandbox_controller_pod_test.go
@@ -681,5 +681,21 @@ var _ = Describe("Sandbox Controller", func() {
 			sandbox := getSandbox(ctx, sandboxName)
 			Expect(sandbox.Status.PodIP).To(Equal("10.244.0.42"))
 		})
+
+		It("should record sidecar version in sandbox status on pod creation", func() {
+			sandboxName := "sandbox-sidecar-version"
+
+			createSandbox(ctx, sandboxName)
+			defer deleteSandbox(ctx, sandboxName)
+
+			podName := sandboxName + "-pod"
+			defer deletePod(ctx, podName)
+
+			_, err := doReconcile(ctx, reconciler, sandboxName)
+			Expect(err).NotTo(HaveOccurred())
+
+			sandbox := getSandbox(ctx, sandboxName)
+			Expect(sandbox.Status.SidecarVersion).NotTo(BeEmpty())
+		})
 	})
 })


### PR DESCRIPTION
Long-running sandboxes survive operator upgrades, so the sidecar actually
running in a pod can lag the currently-deployed operator/sidecar images.
Record the operator GitVersion once at pod creation (operator and sidecar
are released together) so future api-gateway code can gate new features
on the version that shipped with each sandbox.