### PR TITLE
operator: trim reconciler log noise, warn on DNS override

### DIFF
--- a/internal/operator/controller/sandbox_controller.go
+++ b/internal/operator/controller/sandbox_controller.go
@@ -267,8 +267,6 @@ func (r *SandboxReconciler) patchStatus(ctx context.Context, baseSandbox *sandbo
 
 func (r *SandboxReconciler) CreateSandboxPod(ctx context.Context, sandbox *sandboxv1alpha1.Sandbox, baseSandbox *sandboxv1alpha1.Sandbox) error {
 	log := logf.FromContext(ctx)
-	// todo benl reduce verbose logging
-	log.Info("Creating Pod")
 
 	// Apply pod template labels first, then override with our labels.
 	// This prevents templates from overriding app.kubernetes.io/* etc.
@@ -365,7 +363,7 @@ func (r *SandboxReconciler) CreateSandboxPod(ctx context.Context, sandbox *sandb
 		}
 	}
 
-	configureDNS(sandboxPod, sandbox.Spec.Network)
+	configureDNS(ctx, sandboxPod, sandbox.Spec.Network)
 
 	markContainers(sandboxPod)
 
@@ -434,7 +432,7 @@ func (r *SandboxReconciler) CreateSandboxPod(ctx context.Context, sandbox *sandb
 	return nil
 }
 
-func configureDNS(sandboxPod *corev1.Pod, network *sandboxv1alpha1.Network) {
+func configureDNS(ctx context.Context, sandboxPod *corev1.Pod, network *sandboxv1alpha1.Network) {
 	allowClusterDNS := network != nil && network.AllowClusterDNS != nil && *network.AllowClusterDNS
 
 	if allowClusterDNS {
@@ -442,8 +440,11 @@ func configureDNS(sandboxPod *corev1.Pod, network *sandboxv1alpha1.Network) {
 		if len(network.Nameservers) > 0 {
 			if sandboxPod.Spec.DNSConfig == nil {
 				sandboxPod.Spec.DNSConfig = &corev1.PodDNSConfig{}
+			} else if len(sandboxPod.Spec.DNSConfig.Nameservers) > 0 {
+				logf.FromContext(ctx).Info("overriding pod template DNSConfig.Nameservers with Sandbox network.nameservers",
+					"templateNameservers", sandboxPod.Spec.DNSConfig.Nameservers,
+					"networkNameservers", network.Nameservers)
 			}
-			// todo benl: log warn if pod spec has nameservers already?
 			sandboxPod.Spec.DNSConfig.Nameservers = network.Nameservers
 		}
 	} else {

--- a/internal/operator/controller/sandbox_controller_network_test.go
+++ b/internal/operator/controller/sandbox_controller_network_test.go
@@ -15,6 +15,7 @@
 package controller
 
 import (
+	"context"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -471,7 +472,7 @@ var _ = Describe("configureDNS function", func() {
 			},
 		}
 
-		configureDNS(pod, nil)
+		configureDNS(context.Background(), pod, nil)
 		Expect(pod.Spec.DNSPolicy).To(Equal(corev1.DNSNone))
 		Expect(pod.Spec.DNSConfig.Nameservers).To(Equal([]string{"127.0.0.1"}))
 	})
@@ -489,7 +490,7 @@ var _ = Describe("configureDNS function", func() {
 			AllowClusterDNS: ptr.To(true),
 		}
 
-		configureDNS(pod, network)
+		configureDNS(context.Background(), pod, network)
 		Expect(pod.Spec.DNSPolicy).To(Equal(corev1.DNSClusterFirst))
 	})
 
@@ -506,7 +507,7 @@ var _ = Describe("configureDNS function", func() {
 			Nameservers: []string{"8.8.8.8", "1.1.1.1"},
 		}
 
-		configureDNS(pod, network)
+		configureDNS(context.Background(), pod, network)
 		Expect(pod.Spec.DNSPolicy).To(Equal(corev1.DNSNone))
 		Expect(pod.Spec.DNSConfig.Nameservers).To(Equal([]string{"8.8.8.8", "1.1.1.1"}))
 	})
@@ -524,7 +525,7 @@ var _ = Describe("configureDNS function", func() {
 			AllowedEgressCIDRs: []string{"203.0.113.0/24"},
 		}
 
-		configureDNS(pod, network)
+		configureDNS(context.Background(), pod, network)
 		Expect(pod.Spec.DNSPolicy).To(Equal(corev1.DNSNone))
 		Expect(pod.Spec.DNSConfig.Nameservers).To(Equal([]string{"8.8.8.8", "1.1.1.1"}))
 		Expect(pod.Spec.DNSConfig.Options).To(HaveLen(1))
@@ -544,7 +545,7 @@ var _ = Describe("configureDNS function", func() {
 			AllowInternetEgress: ptr.To(true),
 		}
 
-		configureDNS(pod, network)
+		configureDNS(context.Background(), pod, network)
 		Expect(pod.Spec.DNSPolicy).To(Equal(corev1.DNSNone))
 		Expect(pod.Spec.DNSConfig.Nameservers).To(Equal([]string{"8.8.8.8", "1.1.1.1"}))
 		Expect(pod.Spec.DNSConfig.Options).To(HaveLen(1))
@@ -565,7 +566,29 @@ var _ = Describe("configureDNS function", func() {
 			Nameservers:     []string{"8.8.8.8"},
 		}
 
-		configureDNS(pod, network)
+		configureDNS(context.Background(), pod, network)
+		Expect(pod.Spec.DNSPolicy).To(Equal(corev1.DNSClusterFirst))
+		Expect(pod.Spec.DNSConfig.Nameservers).To(Equal([]string{"8.8.8.8"}))
+	})
+
+	It("should override pod template nameservers with network.nameservers when allowClusterDNS is true", func() {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "test", Image: "busybox"},
+				},
+				DNSConfig: &corev1.PodDNSConfig{
+					Nameservers: []string{"9.9.9.9"},
+				},
+			},
+		}
+
+		network := &sandboxv1alpha1.Network{
+			AllowClusterDNS: ptr.To(true),
+			Nameservers:     []string{"8.8.8.8"},
+		}
+
+		configureDNS(context.Background(), pod, network)
 		Expect(pod.Spec.DNSPolicy).To(Equal(corev1.DNSClusterFirst))
 		Expect(pod.Spec.DNSConfig.Nameservers).To(Equal([]string{"8.8.8.8"}))
 	})


### PR DESCRIPTION
Drop the "Creating Pod" info log in CreateSandboxPod — the existing
"Reconciling Sandbox" / "Sandbox found" / "Pod created" sequence is
enough, and the error paths already log failures.

When Sandbox network.nameservers replaces nameservers that the user's
pod template had set, log a one-line info noting the override instead
of silently overwriting.