### PR TITLE
add filesystem stat endpoint

### DIFF
--- a/api/openapi/api-gateway.yaml
+++ b/api/openapi/api-gateway.yaml
@@ -265,6 +265,13 @@ components:
     FilesystemEntry:
       additionalProperties: false
       properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - https://example.com/schemas/FilesystemEntry.json
+          format: uri
+          readOnly: true
+          type: string
         gid:
           description: Owner group ID
           format: int64
@@ -1681,6 +1688,87 @@ paths:
                 $ref: "#/components/schemas/ErrorModel"
           description: Bad Gateway
       summary: List directory entries in sandbox filesystem
+      tags:
+        - sandboxes
+        - filesystem
+  /v1/sandboxes/{sandboxId}/filesystem/stat:
+    get:
+      description: Returns metadata for the file, directory, or symlink at the specified path inside the sandbox container. Symlinks are reported, not followed.
+      operationId: statSandboxFilesystemEntry
+      parameters:
+        - description: Sandbox identifier
+          in: path
+          name: sandboxId
+          required: true
+          schema:
+            description: Sandbox identifier
+            maxLength: 47
+            minLength: 1
+            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+            type: string
+        - description: Path to stat (absolute or relative to container cwd)
+          explode: false
+          in: query
+          name: path
+          required: true
+          schema:
+            description: Path to stat (absolute or relative to container cwd)
+            minLength: 1
+            type: string
+        - description: Container name. Defaults to the only container if there is one, otherwise it's required.
+          explode: false
+          in: query
+          name: container
+          schema:
+            description: Container name. Defaults to the only container if there is one, otherwise it's required.
+            maxLength: 63
+            minLength: 1
+            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FilesystemEntry"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Bad Request
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Internal Server Error
+        "502":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Bad Gateway
+      summary: Stat a path in sandbox filesystem
       tags:
         - sandboxes
         - filesystem

--- a/api/openapi/sandbox-sidecar.yaml
+++ b/api/openapi/sandbox-sidecar.yaml
@@ -131,6 +131,13 @@ components:
     FilesystemEntry:
       additionalProperties: false
       properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - https://example.com/schemas/FilesystemEntry.json
+          format: uri
+          readOnly: true
+          type: string
         gid:
           description: Owner group ID
           format: int64
@@ -751,5 +758,60 @@ paths:
                 $ref: "#/components/schemas/ErrorModel"
           description: Internal Server Error
       summary: List directory entries in the sandbox filesystem
+      tags:
+        - filesystem
+  /v1/filesystem/stat:
+    get:
+      description: Returns metadata for the file, directory, or symlink at the specified path. Symlinks are reported, not followed.
+      operationId: statFilesystemEntry
+      parameters:
+        - description: Path to stat (absolute or relative to container cwd)
+          explode: false
+          in: query
+          name: path
+          required: true
+          schema:
+            description: Path to stat (absolute or relative to container cwd)
+            minLength: 1
+            type: string
+        - description: Container name. Defaults to the only container if there is one, otherwise it's required.
+          explode: false
+          in: query
+          name: container
+          schema:
+            description: Container name. Defaults to the only container if there is one, otherwise it's required.
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FilesystemEntry"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Bad Request
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Not Found
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Internal Server Error
+      summary: Stat a path in the sandbox filesystem
       tags:
         - filesystem

--- a/internal/api-gateway/filesystem/filesystem.go
+++ b/internal/api-gateway/filesystem/filesystem.go
@@ -75,6 +75,16 @@ type FilesystemListOutput struct {
 	Body ListFilesystemEntriesResponse
 }
 
+type FilesystemStatInput struct {
+	SandboxID string `path:"sandboxId" minLength:"1" maxLength:"47" pattern:"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$" doc:"Sandbox identifier"`
+	Path      string `query:"path" required:"true" minLength:"1" doc:"Path to stat (absolute or relative to container cwd)"`
+	Container string `query:"container,omitempty" minLength:"1" maxLength:"63" pattern:"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$" doc:"Container name. Defaults to the only container if there is one, otherwise it's required."`
+}
+
+type FilesystemStatOutput struct {
+	Body FilesystemEntry
+}
+
 type Handlers struct {
 	logger           *slog.Logger
 	k8sClient        client.Client
@@ -271,6 +281,23 @@ func (h *Handlers) ListFilesystemEntries(ctx context.Context, input *FilesystemL
 	return &FilesystemListOutput{Body: ListFilesystemEntriesResponse{Entries: entries}}, nil
 }
 
+func (h *Handlers) StatFilesystemEntry(ctx context.Context, input *FilesystemStatInput) (*FilesystemStatOutput, error) {
+	resp, err := h.callSidecar(ctx, input.SandboxID, http.MethodGet, "/v1/filesystem/stat", pathParams(input.Path, input.Container), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	_ = sidecarapi.FilesystemEntry(FilesystemEntry{}) // assert field compatibility
+	var sidecarResp sidecarapi.FilesystemEntry
+	if err := json.NewDecoder(resp.Body).Decode(&sidecarResp); err != nil {
+		h.logger.Error("failed to decode sidecar response", "error", err, "id", input.SandboxID)
+		return nil, huma.Error502BadGateway("invalid sidecar response")
+	}
+
+	return &FilesystemStatOutput{Body: FilesystemEntry(sidecarResp)}, nil
+}
+
 func Register(api huma.API, h *Handlers) {
 	huma.Register(api, huma.Operation{
 		OperationID: "writeSandboxFilesystem",
@@ -322,4 +349,14 @@ func Register(api huma.API, h *Handlers) {
 		Tags:        []string{"sandboxes", "filesystem"},
 		Errors:      []int{http.StatusBadRequest, http.StatusNotFound, http.StatusConflict, http.StatusBadGateway},
 	}, h.ListFilesystemEntries)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "statSandboxFilesystemEntry",
+		Method:      http.MethodGet,
+		Path:        "/sandboxes/{sandboxId}/filesystem/stat",
+		Summary:     "Stat a path in sandbox filesystem",
+		Description: "Returns metadata for the file, directory, or symlink at the specified path inside the sandbox container. Symlinks are reported, not followed.",
+		Tags:        []string{"sandboxes", "filesystem"},
+		Errors:      []int{http.StatusBadRequest, http.StatusNotFound, http.StatusConflict, http.StatusBadGateway},
+	}, h.StatFilesystemEntry)
 }

--- a/internal/api-gateway/filesystem/filesystem_test.go
+++ b/internal/api-gateway/filesystem/filesystem_test.go
@@ -491,4 +491,45 @@ var _ = Describe("Filesystem Entry Proxy", func() {
 			Expect(resp.Code).To(Equal(http.StatusNotFound))
 		})
 	})
+
+	Describe("GET /sandboxes/{sandboxId}/filesystem/stat", func() {
+		It("proxies the stat request and decodes the entry", func() {
+			var capturedPath string
+			mockSidecar := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedPath = r.URL.Path
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"name":"link","path":"/workspace/link","type":"symlink","size":10,"permissions":"0777","uid":0,"gid":0,"modifiedTime":"2026-06-13T00:00:00Z","symlinkTarget":"/workspace/target"}`))
+			}))
+			defer mockSidecar.Close()
+
+			port := mockSidecar.Listener.Addr().(*net.TCPAddr).Port
+			api := newFilesystemTestAPI(&http.Client{}, port)
+			sbName := createRunningSandboxCR()
+
+			resp := api.Get(fmt.Sprintf("/v1/sandboxes/%s/filesystem/stat?path=/workspace/link", sbName))
+
+			Expect(resp.Code).To(Equal(http.StatusOK))
+			Expect(capturedPath).To(Equal("/v1/filesystem/stat"))
+
+			var entry FilesystemEntry
+			Expect(json.Unmarshal(resp.Body.Bytes(), &entry)).To(Succeed())
+			Expect(entry.Type).To(Equal("symlink"))
+			Expect(entry.SymlinkTarget).To(Equal("/workspace/target"))
+		})
+
+		It("forwards sidecar 404 errors", func() {
+			mockSidecar := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			}))
+			defer mockSidecar.Close()
+
+			port := mockSidecar.Listener.Addr().(*net.TCPAddr).Port
+			api := newFilesystemTestAPI(&http.Client{}, port)
+			sbName := createRunningSandboxCR()
+
+			resp := api.Get(fmt.Sprintf("/v1/sandboxes/%s/filesystem/stat?path=/no-such", sbName))
+
+			Expect(resp.Code).To(Equal(http.StatusNotFound))
+		})
+	})
 })

--- a/internal/sandbox-sidecar/filesystem/filesystem.go
+++ b/internal/sandbox-sidecar/filesystem/filesystem.go
@@ -53,6 +53,15 @@ type FilesystemListOutput struct {
 	Body sidecarapi.ListFilesystemEntriesResponse
 }
 
+type FilesystemStatInput struct {
+	Path      string `query:"path" required:"true" minLength:"1" doc:"Path to stat (absolute or relative to container cwd)"`
+	Container string `query:"container,omitempty" doc:"Container name. Defaults to the only container if there is one, otherwise it's required."`
+}
+
+type FilesystemStatOutput struct {
+	Body sidecarapi.FilesystemEntry
+}
+
 type Handlers struct {
 	logger      *slog.Logger
 	procFS      proc.ProcFS
@@ -312,6 +321,24 @@ func (h *Handlers) ListFilesystemEntries(_ context.Context, input *FilesystemLis
 	return &FilesystemListOutput{Body: sidecarapi.ListFilesystemEntriesResponse{Entries: entries}}, nil
 }
 
+func (h *Handlers) StatFilesystemEntry(_ context.Context, input *FilesystemStatInput) (*FilesystemStatOutput, error) {
+	_, resolvedPath, targetPath, err := h.resolveTarget(input.Path, input.Container)
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := os.Lstat(targetPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, huma.Error404NotFound(fmt.Sprintf("path not found: %s", input.Path))
+		}
+		h.logger.Error("failed to stat path", "error", err, "path", targetPath)
+		return nil, huma.Error500InternalServerError("failed to stat path")
+	}
+
+	return &FilesystemStatOutput{Body: entryFromInfo(filepath.Base(resolvedPath), resolvedPath, targetPath, info)}, nil
+}
+
 func Register(api huma.API, h *Handlers) {
 	huma.Register(api, huma.Operation{
 		OperationID: "postFilesystem",
@@ -363,4 +390,14 @@ func Register(api huma.API, h *Handlers) {
 		Tags:        []string{"filesystem"},
 		Errors:      []int{http.StatusBadRequest, http.StatusNotFound},
 	}, h.ListFilesystemEntries)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "statFilesystemEntry",
+		Method:      http.MethodGet,
+		Path:        "/filesystem/stat",
+		Summary:     "Stat a path in the sandbox filesystem",
+		Description: "Returns metadata for the file, directory, or symlink at the specified path. Symlinks are reported, not followed.",
+		Tags:        []string{"filesystem"},
+		Errors:      []int{http.StatusBadRequest, http.StatusNotFound},
+	}, h.StatFilesystemEntry)
 }

--- a/internal/sandbox-sidecar/filesystem/filesystem_test.go
+++ b/internal/sandbox-sidecar/filesystem/filesystem_test.go
@@ -370,6 +370,69 @@ var _ = Describe("Filesystem", func() {
 			Expect(resp.Code).To(Equal(http.StatusUnprocessableEntity))
 		})
 	})
+
+	Describe("GET /filesystem/stat", func() {
+		It("stats a regular file", func() {
+			hostPath := filepath.Join(testRootDir, "/statdir/stat-me.txt")
+			Expect(os.MkdirAll(filepath.Dir(hostPath), 0750)).To(Succeed())
+			Expect(os.WriteFile(hostPath, []byte("123"), 0600)).To(Succeed())
+			Expect(os.Chmod(hostPath, 0640)).To(Succeed()) //nolint:gosec // exact mode asserted below
+
+			resp := doGet("/v1/filesystem/stat?path=/statdir/stat-me.txt")
+
+			Expect(resp.Code).To(Equal(http.StatusOK))
+			var entry sidecarapi.FilesystemEntry
+			Expect(json.Unmarshal(resp.Body.Bytes(), &entry)).To(Succeed())
+			Expect(entry.Name).To(Equal("stat-me.txt"))
+			Expect(entry.Path).To(Equal("/statdir/stat-me.txt"))
+			Expect(entry.Type).To(Equal("file"))
+			Expect(entry.Size).To(Equal(int64(3)))
+			Expect(entry.Permissions).To(Equal("0640"))
+		})
+
+		It("stats a directory", func() {
+			Expect(os.MkdirAll(filepath.Join(testRootDir, "/statdir/sub"), 0750)).To(Succeed())
+
+			resp := doGet("/v1/filesystem/stat?path=/statdir/sub")
+
+			Expect(resp.Code).To(Equal(http.StatusOK))
+			var entry sidecarapi.FilesystemEntry
+			Expect(json.Unmarshal(resp.Body.Bytes(), &entry)).To(Succeed())
+			Expect(entry.Type).To(Equal("directory"))
+		})
+
+		It("stats a symlink without following it", func() {
+			Expect(os.MkdirAll(filepath.Join(testRootDir, "/statdir"), 0750)).To(Succeed())
+			linkPath := filepath.Join(testRootDir, "/statdir/stat-link")
+			Expect(os.Symlink("/statdir/stat-me.txt", linkPath)).To(Succeed())
+
+			resp := doGet("/v1/filesystem/stat?path=/statdir/stat-link")
+
+			Expect(resp.Code).To(Equal(http.StatusOK))
+			var entry sidecarapi.FilesystemEntry
+			Expect(json.Unmarshal(resp.Body.Bytes(), &entry)).To(Succeed())
+			Expect(entry.Type).To(Equal("symlink"))
+			Expect(entry.SymlinkTarget).To(Equal("/statdir/stat-me.txt"))
+		})
+
+		It("stats with relative path", func() {
+			hostPath := filepath.Join(testRootDir, testCwd, "relstat.txt")
+			Expect(os.WriteFile(hostPath, []byte("r"), 0600)).To(Succeed())
+
+			resp := doGet("/v1/filesystem/stat?path=relstat.txt")
+
+			Expect(resp.Code).To(Equal(http.StatusOK))
+			var entry sidecarapi.FilesystemEntry
+			Expect(json.Unmarshal(resp.Body.Bytes(), &entry)).To(Succeed())
+			Expect(entry.Path).To(Equal("/workspace/relstat.txt"))
+		})
+
+		It("returns 404 for nonexistent path", func() {
+			resp := doGet("/v1/filesystem/stat?path=/no-such-path")
+
+			Expect(resp.Code).To(Equal(http.StatusNotFound))
+		})
+	})
 })
 
 // errorMockProcFS returns errors for FindMarkedPID.

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -227,6 +227,13 @@ Parent directories are created automatically on uploads.
 # List a directory (symlinks are reported, not followed)
 for entry in sandbox.filesystem.list("/tmp"):
     print(entry.name, entry.type, entry.size, entry.permissions)
+
+# Inspect a single path
+entry = sandbox.filesystem.stat("/tmp/hello.txt")
+print(entry.modified_time, entry.uid, entry.gid)
+
+# Check existence
+sandbox.filesystem.exists("/tmp/hello.txt")  # True
 ```
 
 ## Sandbox management

--- a/sdks/python/src/isola/_filesystem.py
+++ b/sdks/python/src/isola/_filesystem.py
@@ -18,6 +18,7 @@ from typing import BinaryIO
 from urllib.parse import quote
 
 from ._client import _AsyncAPI, _SyncAPI
+from ._exceptions import NotFoundError
 from ._models import FilesystemEntry, ListFilesystemEntriesResponse
 
 
@@ -100,6 +101,50 @@ class Filesystem:
         )
         return response.entries or []
 
+    def stat(self, path: str, *, container: str | None = None) -> FilesystemEntry:
+        """Get metadata for a file, directory, or symlink in the sandbox.
+
+        Symlinks are reported, not followed.
+
+        Args:
+            path: Absolute path inside the sandbox.
+            container: Target container name. Only needed for
+                multi-container sandboxes.
+
+        Returns:
+            Entry metadata.
+
+        Raises:
+            NotFoundError: If the path does not exist.
+        """
+        params = {"path": path}
+        if container:
+            params["container"] = container
+
+        return self._api.request_model(
+            "GET",
+            f"{_filesystem_path(self._sandbox_id)}/stat",
+            FilesystemEntry,
+            params=params,
+        )
+
+    def exists(self, path: str, *, container: str | None = None) -> bool:
+        """Check whether a path exists in the sandbox.
+
+        Args:
+            path: Absolute path inside the sandbox.
+            container: Target container name. Only needed for
+                multi-container sandboxes.
+
+        Returns:
+            True if a file, directory, or symlink exists at the path.
+        """
+        try:
+            self.stat(path, container=container)
+        except NotFoundError:
+            return False
+        return True
+
 
 class AsyncFilesystem:
     """Async version of Filesystem."""
@@ -175,3 +220,47 @@ class AsyncFilesystem:
             params=params,
         )
         return response.entries or []
+
+    async def stat(self, path: str, *, container: str | None = None) -> FilesystemEntry:
+        """Get metadata for a file, directory, or symlink in the sandbox.
+
+        Symlinks are reported, not followed.
+
+        Args:
+            path: Absolute path inside the sandbox.
+            container: Target container name. Only needed for
+                multi-container sandboxes.
+
+        Returns:
+            Entry metadata.
+
+        Raises:
+            NotFoundError: If the path does not exist.
+        """
+        params = {"path": path}
+        if container:
+            params["container"] = container
+
+        return await self._api.request_model(
+            "GET",
+            f"{_filesystem_path(self._sandbox_id)}/stat",
+            FilesystemEntry,
+            params=params,
+        )
+
+    async def exists(self, path: str, *, container: str | None = None) -> bool:
+        """Check whether a path exists in the sandbox.
+
+        Args:
+            path: Absolute path inside the sandbox.
+            container: Target container name. Only needed for
+                multi-container sandboxes.
+
+        Returns:
+            True if a file, directory, or symlink exists at the path.
+        """
+        try:
+            await self.stat(path, container=container)
+        except NotFoundError:
+            return False
+        return True

--- a/sdks/python/tests/test_filesystem.py
+++ b/sdks/python/tests/test_filesystem.py
@@ -401,3 +401,38 @@ def test_filesystem_list_empty(sandbox_response_copy: dict[str, object]) -> None
         entries = sandbox.filesystem.list("/empty")
 
     assert entries == []
+
+
+@respx.mock
+def test_filesystem_stat(sandbox_response_copy: dict[str, object]) -> None:
+    respx.get("http://localhost:8080/v1/sandboxes/sandbox-123").mock(
+        return_value=httpx.Response(200, json=sandbox_response_copy)
+    )
+    stat_route = respx.get("http://localhost:8080/v1/sandboxes/sandbox-123/filesystem/stat").mock(
+        return_value=httpx.Response(200, json=_SYMLINK_JSON)
+    )
+
+    with Isola(url="http://localhost:8080") as client:
+        sandbox = client.sandboxes.get("sandbox-123")
+        entry = sandbox.filesystem.stat("/workspace/link")
+
+    assert stat_route.calls[0].request.url.params["path"] == "/workspace/link"
+    assert entry.type == FilesystemEntryType.SYMLINK
+    assert entry.symlink_target == "/workspace/file.txt"
+
+
+@respx.mock
+def test_filesystem_exists(sandbox_response_copy: dict[str, object]) -> None:
+    respx.get("http://localhost:8080/v1/sandboxes/sandbox-123").mock(
+        return_value=httpx.Response(200, json=sandbox_response_copy)
+    )
+    stat_route = respx.get("http://localhost:8080/v1/sandboxes/sandbox-123/filesystem/stat")
+    stat_route.side_effect = [
+        httpx.Response(200, json=_ENTRY_JSON),
+        httpx.Response(404, json={"title": "Not Found", "status": 404, "detail": "path not found"}),
+    ]
+
+    with Isola(url="http://localhost:8080") as client:
+        sandbox = client.sandboxes.get("sandbox-123")
+        assert sandbox.filesystem.exists("/workspace/file.txt") is True
+        assert sandbox.filesystem.exists("/workspace/missing.txt") is False

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -255,6 +255,13 @@ Parent directories are created automatically on uploads. Streaming bodies (`Read
 for (const entry of await sandbox.filesystem.list("/tmp")) {
   console.log(entry.name, entry.type, entry.size, entry.permissions);
 }
+
+// Inspect a single path
+const entry = await sandbox.filesystem.stat("/tmp/hello.txt");
+console.log(entry.modifiedTime, entry.uid, entry.gid);
+
+// Check existence
+await sandbox.filesystem.exists("/tmp/hello.txt"); // true
 ```
 
 ## Sandbox management

--- a/sdks/typescript/src/filesystem.ts
+++ b/sdks/typescript/src/filesystem.ts
@@ -15,9 +15,10 @@
 // Mirrors sdks/python/src/isola/_filesystem.py:AsyncFilesystem.
 
 import type { RequestOptions } from "./client";
+import { NotFoundError } from "./errors";
 import type { HttpClient } from "./internal/http";
-import { filesystemEntriesPath, filesystemPath } from "./internal/url";
-import { type FilesystemEntry, ListFilesystemEntriesResponse } from "./models";
+import { filesystemEntriesPath, filesystemPath, filesystemStatPath } from "./internal/url";
+import { FilesystemEntry, ListFilesystemEntriesResponse } from "./models";
 
 /** Options for most {@link Filesystem} operations. */
 export interface FileOptions {
@@ -147,5 +148,54 @@ export class Filesystem {
       ListFilesystemEntriesResponse.fromWire,
     );
     return response.entries;
+  }
+
+  /**
+   * Get metadata for a file, directory, or symlink in the sandbox.
+   *
+   * Symlinks are reported, not followed.
+   *
+   * @param path - Absolute path inside the sandbox.
+   * @param opts - File options (e.g. `container` for multi-container
+   * sandboxes).
+   * @returns Entry metadata.
+   * @throws {NotFoundError} If the path does not exist.
+   * @throws {APIError} If the API returns a non-2xx response.
+   * @throws {APIConnectionError} If the request cannot reach the API.
+   */
+  async stat(path: string, opts: FileOptions = {}, req: RequestOptions = {}): Promise<FilesystemEntry> {
+    const params: Record<string, string> = { path };
+    if (opts.container) params.container = opts.container;
+
+    return this._api.requestModel(
+      {
+        method: "GET",
+        path: filesystemStatPath(this._sandboxId),
+        params,
+        ...(req.signal ? { signal: req.signal } : {}),
+      },
+      FilesystemEntry.fromWire,
+    );
+  }
+
+  /**
+   * Check whether a path exists in the sandbox.
+   *
+   * @param path - Absolute path inside the sandbox.
+   * @param opts - File options (e.g. `container` for multi-container
+   * sandboxes).
+   * @returns `true` if a file, directory, or symlink exists at the
+   * path.
+   * @throws {APIError} If the API returns a non-2xx response.
+   * @throws {APIConnectionError} If the request cannot reach the API.
+   */
+  async exists(path: string, opts: FileOptions = {}, req: RequestOptions = {}): Promise<boolean> {
+    try {
+      await this.stat(path, opts, req);
+    } catch (err) {
+      if (err instanceof NotFoundError) return false;
+      throw err;
+    }
+    return true;
   }
 }

--- a/sdks/typescript/src/internal/url.ts
+++ b/sdks/typescript/src/internal/url.ts
@@ -98,6 +98,10 @@ export function filesystemEntriesPath(sandboxId: string): string {
   return `${filesystemPath(sandboxId)}/entries`;
 }
 
+export function filesystemStatPath(sandboxId: string): string {
+  return `${filesystemPath(sandboxId)}/stat`;
+}
+
 // Builds a URL with optional query string. Drops undefined/null values.
 // Uses quoteQueryComponent so spaces become `+` and !'()* are percent-encoded,
 // matching Python httpx's QueryParams.__str__ wire output.

--- a/sdks/typescript/tests/filesystem.test.ts
+++ b/sdks/typescript/tests/filesystem.test.ts
@@ -361,7 +361,76 @@ describe("Filesystem.list", () => {
   });
 });
 
+describe("Filesystem.stat/exists", () => {
+  it("stat() parses a symlink entry", async () => {
+    const stub = makeStubFetch(jsonResponse(sandboxResponseFixture()), jsonResponse(SYMLINK_JSON));
+    const client = new Isola({ url: URL_BASE, fetch: stub.fetch, requestTimeoutMs: null });
+    const sandbox = await client.sandboxes.get("sandbox-123");
+    const entry = await sandbox.filesystem.stat("/workspace/link", { container: "worker" });
+
+    const statCall = stub.calls[1]!;
+    expect(statCall.url.startsWith(`${URL_BASE}/v1/sandboxes/sandbox-123/filesystem/stat`)).toBe(true);
+    expect(getSearchParam(statCall.url, "path")).toBe("/workspace/link");
+    expect(getSearchParam(statCall.url, "container")).toBe("worker");
+
+    expect(entry.type).toBe("symlink");
+    expect(entry.symlinkTarget).toBe("/workspace/file.txt");
+  });
+
+  it("exists() returns true when stat succeeds", async () => {
+    const stub = makeStubFetch(jsonResponse(sandboxResponseFixture()), jsonResponse(ENTRY_JSON));
+    const client = new Isola({ url: URL_BASE, fetch: stub.fetch, requestTimeoutMs: null });
+    const sandbox = await client.sandboxes.get("sandbox-123");
+
+    await expect(sandbox.filesystem.exists("/workspace/file.txt")).resolves.toBe(true);
+  });
+
+  it("exists() returns false on 404", async () => {
+    const stub = makeStubFetch(
+      jsonResponse(sandboxResponseFixture()),
+      jsonResponse({ detail: "path not found" }, { status: 404 }),
+    );
+    const client = new Isola({ url: URL_BASE, fetch: stub.fetch, requestTimeoutMs: null });
+    const sandbox = await client.sandboxes.get("sandbox-123");
+
+    await expect(sandbox.filesystem.exists("/workspace/missing.txt")).resolves.toBe(false);
+  });
+
+  it("exists() rethrows non-404 errors", async () => {
+    const stub = makeStubFetch(
+      jsonResponse(sandboxResponseFixture()),
+      ...Array.from({ length: 1 + MAX_RETRIES }, () => jsonResponse({ detail: "boom" }, { status: 500 })),
+    );
+    const client = new Isola({ url: URL_BASE, fetch: stub.fetch, requestTimeoutMs: null });
+    const sandbox = await client.sandboxes.get("sandbox-123");
+
+    await expect(sandbox.filesystem.exists("/workspace/file.txt")).rejects.toBeInstanceOf(InternalError);
+  });
+});
+
 describe("FilesystemEntry wire decoding", () => {
+  it("rejects a missing name", async () => {
+    const stub = makeStubFetch(
+      jsonResponse(sandboxResponseFixture()),
+      jsonResponse({ ...ENTRY_JSON, name: undefined }),
+    );
+    const client = new Isola({ url: URL_BASE, fetch: stub.fetch, requestTimeoutMs: null });
+    const sandbox = await client.sandboxes.get("sandbox-123");
+
+    await expect(sandbox.filesystem.stat("/workspace/file.txt")).rejects.toThrow(/invalid response payload/);
+  });
+
+  it("rejects a missing path", async () => {
+    const stub = makeStubFetch(
+      jsonResponse(sandboxResponseFixture()),
+      jsonResponse({ ...ENTRY_JSON, path: undefined }),
+    );
+    const client = new Isola({ url: URL_BASE, fetch: stub.fetch, requestTimeoutMs: null });
+    const sandbox = await client.sandboxes.get("sandbox-123");
+
+    await expect(sandbox.filesystem.stat("/workspace/file.txt")).rejects.toThrow(/invalid response payload/);
+  });
+
   it("rejects a non-array entries field", async () => {
     const stub = makeStubFetch(jsonResponse(sandboxResponseFixture()), jsonResponse({ entries: "nope" }));
     const client = new Isola({ url: URL_BASE, fetch: stub.fetch, requestTimeoutMs: null });


### PR DESCRIPTION
PR 2 of 5 from the `fs_ops` split. **Base: `fs-list`** — review this diff against `fs-list`.

Adds the **stat** operation (`GET .../filesystem/stat`) end to end: sidecar handler, gateway proxy, OpenAPI, Python/TypeScript SDKs, and tests. Symlinks are reported, not followed.

Also adds the SDK-only `exists()` helper (built on `stat`, returns `false` on `NotFoundError`) and the `FilesystemEntry` wire-decoding error tests, which exercise the shared decoder introduced in PR 1.

Stack: list → **stat** → delete → mkdir → move.