### PR TITLE
add filesystem delete endpoint

### DIFF
--- a/api/openapi/api-gateway.yaml
+++ b/api/openapi/api-gateway.yaml
@@ -1444,6 +1444,89 @@ paths:
         - sandboxes
         - commands
   /v1/sandboxes/{sandboxId}/filesystem:
+    delete:
+      description: Deletes the file, empty directory, or symlink at the specified path in the sandbox container. Set recursive=true to delete a directory and its contents.
+      operationId: deleteSandboxFilesystemEntry
+      parameters:
+        - description: Sandbox identifier
+          in: path
+          name: sandboxId
+          required: true
+          schema:
+            description: Sandbox identifier
+            maxLength: 47
+            minLength: 1
+            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+            type: string
+        - description: Path to delete (absolute or relative to container cwd)
+          explode: false
+          in: query
+          name: path
+          required: true
+          schema:
+            description: Path to delete (absolute or relative to container cwd)
+            minLength: 1
+            type: string
+        - description: Delete directories and their contents recursively
+          explode: false
+          in: query
+          name: recursive
+          schema:
+            description: Delete directories and their contents recursively
+            type: boolean
+        - description: Container name. Defaults to the only container if there is one, otherwise it's required.
+          explode: false
+          in: query
+          name: container
+          schema:
+            description: Container name. Defaults to the only container if there is one, otherwise it's required.
+            maxLength: 63
+            minLength: 1
+            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+            type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Bad Request
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Internal Server Error
+        "502":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Bad Gateway
+      summary: Delete a file or directory from sandbox filesystem
+      tags:
+        - sandboxes
+        - filesystem
     get:
       description: Streams a file download from the specified path in the sandbox container
       operationId: readSandboxFilesystem

--- a/api/openapi/sandbox-sidecar.yaml
+++ b/api/openapi/sandbox-sidecar.yaml
@@ -591,6 +591,63 @@ paths:
       tags:
         - commands
   /v1/filesystem:
+    delete:
+      description: Deletes the file, empty directory, or symlink at the specified path. Set recursive=true to delete a directory and its contents.
+      operationId: deleteFilesystemEntry
+      parameters:
+        - description: Path to delete (absolute or relative to container cwd)
+          explode: false
+          in: query
+          name: path
+          required: true
+          schema:
+            description: Path to delete (absolute or relative to container cwd)
+            minLength: 1
+            type: string
+        - description: Delete directories and their contents recursively
+          explode: false
+          in: query
+          name: recursive
+          schema:
+            description: Delete directories and their contents recursively
+            type: boolean
+        - description: Container name. Defaults to the only container if there is one, otherwise it's required.
+          explode: false
+          in: query
+          name: container
+          schema:
+            description: Container name. Defaults to the only container if there is one, otherwise it's required.
+            type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Bad Request
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Not Found
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Internal Server Error
+      summary: Delete a file or directory from the sandbox filesystem
+      tags:
+        - filesystem
     get:
       description: Reads a file from the specified path in the sandbox container
       operationId: getFilesystem

--- a/internal/api-gateway/filesystem/filesystem.go
+++ b/internal/api-gateway/filesystem/filesystem.go
@@ -85,6 +85,13 @@ type FilesystemStatOutput struct {
 	Body FilesystemEntry
 }
 
+type FilesystemDeleteInput struct {
+	SandboxID string `path:"sandboxId" minLength:"1" maxLength:"47" pattern:"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$" doc:"Sandbox identifier"`
+	Path      string `query:"path" required:"true" minLength:"1" doc:"Path to delete (absolute or relative to container cwd)"`
+	Recursive bool   `query:"recursive,omitempty" doc:"Delete directories and their contents recursively"`
+	Container string `query:"container,omitempty" minLength:"1" maxLength:"63" pattern:"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$" doc:"Container name. Defaults to the only container if there is one, otherwise it's required."`
+}
+
 type Handlers struct {
 	logger           *slog.Logger
 	k8sClient        client.Client
@@ -298,6 +305,21 @@ func (h *Handlers) StatFilesystemEntry(ctx context.Context, input *FilesystemSta
 	return &FilesystemStatOutput{Body: FilesystemEntry(sidecarResp)}, nil
 }
 
+func (h *Handlers) DeleteFilesystemEntry(ctx context.Context, input *FilesystemDeleteInput) (*struct{}, error) {
+	params := pathParams(input.Path, input.Container)
+	if input.Recursive {
+		params.Set("recursive", "true")
+	}
+
+	resp, err := h.callSidecar(ctx, input.SandboxID, http.MethodDelete, "/v1/filesystem", params, nil)
+	if err != nil {
+		return nil, err
+	}
+	_ = resp.Body.Close()
+
+	return nil, nil
+}
+
 func Register(api huma.API, h *Handlers) {
 	huma.Register(api, huma.Operation{
 		OperationID: "writeSandboxFilesystem",
@@ -359,4 +381,15 @@ func Register(api huma.API, h *Handlers) {
 		Tags:        []string{"sandboxes", "filesystem"},
 		Errors:      []int{http.StatusBadRequest, http.StatusNotFound, http.StatusConflict, http.StatusBadGateway},
 	}, h.StatFilesystemEntry)
+
+	huma.Register(api, huma.Operation{
+		OperationID:   "deleteSandboxFilesystemEntry",
+		Method:        http.MethodDelete,
+		Path:          "/sandboxes/{sandboxId}/filesystem",
+		Summary:       "Delete a file or directory from sandbox filesystem",
+		Description:   "Deletes the file, empty directory, or symlink at the specified path in the sandbox container. Set recursive=true to delete a directory and its contents.",
+		Tags:          []string{"sandboxes", "filesystem"},
+		DefaultStatus: http.StatusNoContent,
+		Errors:        []int{http.StatusBadRequest, http.StatusNotFound, http.StatusConflict, http.StatusBadGateway},
+	}, h.DeleteFilesystemEntry)
 }

--- a/internal/api-gateway/filesystem/filesystem_test.go
+++ b/internal/api-gateway/filesystem/filesystem_test.go
@@ -532,4 +532,53 @@ var _ = Describe("Filesystem Entry Proxy", func() {
 			Expect(resp.Code).To(Equal(http.StatusNotFound))
 		})
 	})
+
+	Describe("DELETE /sandboxes/{sandboxId}/filesystem", func() {
+		It("proxies delete with recursive param", func() {
+			var capturedMethod, capturedRecursive string
+			mockSidecar := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedMethod = r.Method
+				capturedRecursive = r.URL.Query().Get("recursive")
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer mockSidecar.Close()
+
+			port := mockSidecar.Listener.Addr().(*net.TCPAddr).Port
+			api := newFilesystemTestAPI(&http.Client{}, port)
+			sbName := createRunningSandboxCR()
+
+			resp := api.Delete(fmt.Sprintf("/v1/sandboxes/%s/filesystem?path=/workspace/dir&recursive=true", sbName))
+
+			Expect(resp.Code).To(Equal(http.StatusNoContent))
+			Expect(capturedMethod).To(Equal(http.MethodDelete))
+			Expect(capturedRecursive).To(Equal("true"))
+		})
+
+		It("omits recursive param when not set", func() {
+			var hasRecursive bool
+			mockSidecar := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				hasRecursive = r.URL.Query().Has("recursive")
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer mockSidecar.Close()
+
+			port := mockSidecar.Listener.Addr().(*net.TCPAddr).Port
+			api := newFilesystemTestAPI(&http.Client{}, port)
+			sbName := createRunningSandboxCR()
+
+			resp := api.Delete(fmt.Sprintf("/v1/sandboxes/%s/filesystem?path=/workspace/f.txt", sbName))
+
+			Expect(resp.Code).To(Equal(http.StatusNoContent))
+			Expect(hasRecursive).To(BeFalse())
+		})
+
+		It("returns 409 when sandbox is not ready", func() {
+			api := newFilesystemTestAPI(&http.Client{}, 0)
+			sbName := createSandboxCR()
+
+			resp := api.Delete(fmt.Sprintf("/v1/sandboxes/%s/filesystem?path=/workspace/f.txt", sbName))
+
+			Expect(resp.Code).To(Equal(http.StatusConflict))
+		})
+	})
 })

--- a/internal/sandbox-sidecar/filesystem/filesystem.go
+++ b/internal/sandbox-sidecar/filesystem/filesystem.go
@@ -62,6 +62,12 @@ type FilesystemStatOutput struct {
 	Body sidecarapi.FilesystemEntry
 }
 
+type FilesystemDeleteInput struct {
+	Path      string `query:"path" required:"true" minLength:"1" doc:"Path to delete (absolute or relative to container cwd)"`
+	Recursive bool   `query:"recursive,omitempty" doc:"Delete directories and their contents recursively"`
+	Container string `query:"container,omitempty" doc:"Container name. Defaults to the only container if there is one, otherwise it's required."`
+}
+
 type Handlers struct {
 	logger      *slog.Logger
 	procFS      proc.ProcFS
@@ -339,6 +345,42 @@ func (h *Handlers) StatFilesystemEntry(_ context.Context, input *FilesystemStatI
 	return &FilesystemStatOutput{Body: entryFromInfo(filepath.Base(resolvedPath), resolvedPath, targetPath, info)}, nil
 }
 
+func (h *Handlers) DeleteFilesystemEntry(_ context.Context, input *FilesystemDeleteInput) (*struct{}, error) {
+	_, resolvedPath, targetPath, err := h.resolveTarget(input.Path, input.Container)
+	if err != nil {
+		return nil, err
+	}
+
+	if resolvedPath == "/" {
+		return nil, huma.Error400BadRequest("refusing to delete filesystem root")
+	}
+
+	// Lstat (not Stat) so dangling symlinks are deletable.
+	if _, err := os.Lstat(targetPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil, huma.Error404NotFound(fmt.Sprintf("path not found: %s", input.Path))
+		}
+		h.logger.Error("failed to stat path", "error", err, "path", targetPath)
+		return nil, huma.Error500InternalServerError("failed to stat path")
+	}
+
+	var rmErr error
+	if input.Recursive {
+		rmErr = os.RemoveAll(targetPath)
+	} else {
+		rmErr = os.Remove(targetPath)
+	}
+	if rmErr != nil {
+		if errors.Is(rmErr, syscall.ENOTEMPTY) || errors.Is(rmErr, syscall.EEXIST) {
+			return nil, huma.Error400BadRequest(fmt.Sprintf("directory not empty (use recursive=true): %s", input.Path))
+		}
+		h.logger.Error("failed to delete path", "error", rmErr, "path", targetPath)
+		return nil, huma.Error500InternalServerError("failed to delete path")
+	}
+
+	return nil, nil
+}
+
 func Register(api huma.API, h *Handlers) {
 	huma.Register(api, huma.Operation{
 		OperationID: "postFilesystem",
@@ -400,4 +442,15 @@ func Register(api huma.API, h *Handlers) {
 		Tags:        []string{"filesystem"},
 		Errors:      []int{http.StatusBadRequest, http.StatusNotFound},
 	}, h.StatFilesystemEntry)
+
+	huma.Register(api, huma.Operation{
+		OperationID:   "deleteFilesystemEntry",
+		Method:        http.MethodDelete,
+		Path:          "/filesystem",
+		Summary:       "Delete a file or directory from the sandbox filesystem",
+		Description:   "Deletes the file, empty directory, or symlink at the specified path. Set recursive=true to delete a directory and its contents.",
+		Tags:          []string{"filesystem"},
+		DefaultStatus: http.StatusNoContent,
+		Errors:        []int{http.StatusBadRequest, http.StatusNotFound},
+	}, h.DeleteFilesystemEntry)
 }

--- a/internal/sandbox-sidecar/filesystem/filesystem_test.go
+++ b/internal/sandbox-sidecar/filesystem/filesystem_test.go
@@ -433,6 +433,77 @@ var _ = Describe("Filesystem", func() {
 			Expect(resp.Code).To(Equal(http.StatusNotFound))
 		})
 	})
+
+	Describe("DELETE /filesystem", func() {
+		It("deletes a file", func() {
+			hostPath := filepath.Join(testRootDir, "/deldir/del-me.txt")
+			Expect(os.MkdirAll(filepath.Dir(hostPath), 0750)).To(Succeed())
+			Expect(os.WriteFile(hostPath, []byte("x"), 0600)).To(Succeed())
+
+			resp := doDelete("/v1/filesystem?path=/deldir/del-me.txt")
+
+			Expect(resp.Code).To(Equal(http.StatusNoContent))
+			_, err := os.Lstat(hostPath)
+			Expect(os.IsNotExist(err)).To(BeTrue())
+		})
+
+		It("deletes an empty directory", func() {
+			hostPath := filepath.Join(testRootDir, "/deldir/empty-sub")
+			Expect(os.MkdirAll(hostPath, 0750)).To(Succeed())
+
+			resp := doDelete("/v1/filesystem?path=/deldir/empty-sub")
+
+			Expect(resp.Code).To(Equal(http.StatusNoContent))
+			_, err := os.Lstat(hostPath)
+			Expect(os.IsNotExist(err)).To(BeTrue())
+		})
+
+		It("returns 400 for non-empty directory without recursive", func() {
+			hostPath := filepath.Join(testRootDir, "/deldir/full-sub")
+			Expect(os.MkdirAll(hostPath, 0750)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(hostPath, "f.txt"), []byte("x"), 0600)).To(Succeed())
+
+			resp := doDelete("/v1/filesystem?path=/deldir/full-sub")
+
+			Expect(resp.Code).To(Equal(http.StatusBadRequest))
+		})
+
+		It("deletes a non-empty directory with recursive=true", func() {
+			hostPath := filepath.Join(testRootDir, "/deldir/rec-sub")
+			Expect(os.MkdirAll(filepath.Join(hostPath, "nested"), 0750)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(hostPath, "nested/f.txt"), []byte("x"), 0600)).To(Succeed())
+
+			resp := doDelete("/v1/filesystem?path=/deldir/rec-sub&recursive=true")
+
+			Expect(resp.Code).To(Equal(http.StatusNoContent))
+			_, err := os.Lstat(hostPath)
+			Expect(os.IsNotExist(err)).To(BeTrue())
+		})
+
+		It("deletes a dangling symlink", func() {
+			Expect(os.MkdirAll(filepath.Join(testRootDir, "/deldir"), 0750)).To(Succeed())
+			linkPath := filepath.Join(testRootDir, "/deldir/dangling")
+			Expect(os.Symlink("/nonexistent/target", linkPath)).To(Succeed())
+
+			resp := doDelete("/v1/filesystem?path=/deldir/dangling")
+
+			Expect(resp.Code).To(Equal(http.StatusNoContent))
+			_, err := os.Lstat(linkPath)
+			Expect(os.IsNotExist(err)).To(BeTrue())
+		})
+
+		It("returns 404 for nonexistent path", func() {
+			resp := doDelete("/v1/filesystem?path=/no-such-path")
+
+			Expect(resp.Code).To(Equal(http.StatusNotFound))
+		})
+
+		It("refuses to delete the filesystem root", func() {
+			resp := doDelete("/v1/filesystem?path=/")
+
+			Expect(resp.Code).To(Equal(http.StatusBadRequest))
+		})
+	})
 })
 
 // errorMockProcFS returns errors for FindMarkedPID.

--- a/internal/sandbox-sidecar/filesystem/suite_test.go
+++ b/internal/sandbox-sidecar/filesystem/suite_test.go
@@ -117,3 +117,7 @@ func doPost(path string, body []byte) *httptest.ResponseRecorder {
 func doGet(path string) *httptest.ResponseRecorder {
 	return testAPI.Get(path)
 }
+
+func doDelete(path string) *httptest.ResponseRecorder {
+	return testAPI.Delete(path)
+}

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -234,6 +234,10 @@ print(entry.modified_time, entry.uid, entry.gid)
 
 # Check existence
 sandbox.filesystem.exists("/tmp/hello.txt")  # True
+
+# Delete a file, or a directory tree with recursive=True
+sandbox.filesystem.delete("/tmp/data.bin")
+sandbox.filesystem.delete("/tmp/output", recursive=True)
 ```
 
 ## Sandbox management

--- a/sdks/python/src/isola/_filesystem.py
+++ b/sdks/python/src/isola/_filesystem.py
@@ -145,6 +145,27 @@ class Filesystem:
             return False
         return True
 
+    def delete(self, path: str, *, recursive: bool = False, container: str | None = None) -> None:
+        """Delete a file, empty directory, or symlink from the sandbox.
+
+        Args:
+            path: Absolute path inside the sandbox.
+            recursive: Delete directories and their contents
+                recursively. Required to delete a non-empty directory.
+            container: Target container name. Only needed for
+                multi-container sandboxes.
+
+        Raises:
+            NotFoundError: If the path does not exist.
+        """
+        params = {"path": path}
+        if recursive:
+            params["recursive"] = "true"
+        if container:
+            params["container"] = container
+
+        self._api.request_no_content("DELETE", _filesystem_path(self._sandbox_id), params=params)
+
 
 class AsyncFilesystem:
     """Async version of Filesystem."""
@@ -264,3 +285,24 @@ class AsyncFilesystem:
         except NotFoundError:
             return False
         return True
+
+    async def delete(self, path: str, *, recursive: bool = False, container: str | None = None) -> None:
+        """Delete a file, empty directory, or symlink from the sandbox.
+
+        Args:
+            path: Absolute path inside the sandbox.
+            recursive: Delete directories and their contents
+                recursively. Required to delete a non-empty directory.
+            container: Target container name. Only needed for
+                multi-container sandboxes.
+
+        Raises:
+            NotFoundError: If the path does not exist.
+        """
+        params = {"path": path}
+        if recursive:
+            params["recursive"] = "true"
+        if container:
+            params["container"] = container
+
+        await self._api.request_no_content("DELETE", _filesystem_path(self._sandbox_id), params=params)

--- a/sdks/python/tests/test_filesystem.py
+++ b/sdks/python/tests/test_filesystem.py
@@ -436,3 +436,37 @@ def test_filesystem_exists(sandbox_response_copy: dict[str, object]) -> None:
         sandbox = client.sandboxes.get("sandbox-123")
         assert sandbox.filesystem.exists("/workspace/file.txt") is True
         assert sandbox.filesystem.exists("/workspace/missing.txt") is False
+
+
+@respx.mock
+def test_filesystem_delete(sandbox_response_copy: dict[str, object]) -> None:
+    respx.get("http://localhost:8080/v1/sandboxes/sandbox-123").mock(
+        return_value=httpx.Response(200, json=sandbox_response_copy)
+    )
+    delete_route = respx.delete("http://localhost:8080/v1/sandboxes/sandbox-123/filesystem").mock(
+        return_value=httpx.Response(204)
+    )
+
+    with Isola(url="http://localhost:8080") as client:
+        sandbox = client.sandboxes.get("sandbox-123")
+        sandbox.filesystem.delete("/workspace/file.txt")
+        sandbox.filesystem.delete("/workspace/dir", recursive=True)
+
+    assert delete_route.calls[0].request.url.params["path"] == "/workspace/file.txt"
+    assert "recursive" not in delete_route.calls[0].request.url.params
+    assert delete_route.calls[1].request.url.params["recursive"] == "true"
+
+
+@respx.mock
+def test_filesystem_delete_not_found(sandbox_response_copy: dict[str, object]) -> None:
+    respx.get("http://localhost:8080/v1/sandboxes/sandbox-123").mock(
+        return_value=httpx.Response(200, json=sandbox_response_copy)
+    )
+    respx.delete("http://localhost:8080/v1/sandboxes/sandbox-123/filesystem").mock(
+        return_value=httpx.Response(404, json={"title": "Not Found", "status": 404, "detail": "path not found"})
+    )
+
+    with Isola(url="http://localhost:8080") as client:
+        sandbox = client.sandboxes.get("sandbox-123")
+        with pytest.raises(NotFoundError):
+            sandbox.filesystem.delete("/workspace/missing.txt")

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -262,6 +262,10 @@ console.log(entry.modifiedTime, entry.uid, entry.gid);
 
 // Check existence
 await sandbox.filesystem.exists("/tmp/hello.txt"); // true
+
+// Delete a file, or a directory tree with recursive: true
+await sandbox.filesystem.delete("/tmp/data.bin");
+await sandbox.filesystem.delete("/tmp/output", { recursive: true });
 ```
 
 ## Sandbox management

--- a/sdks/typescript/src/filesystem.ts
+++ b/sdks/typescript/src/filesystem.ts
@@ -28,6 +28,15 @@ export interface FileOptions {
   container?: string;
 }
 
+/** Options for {@link Filesystem.delete}. */
+export interface DeleteFileOptions extends FileOptions {
+  /**
+   * Delete directories and their contents recursively. Required to
+   * delete a non-empty directory.
+   */
+  recursive?: boolean;
+}
+
 /**
  * Body types accepted by {@link Filesystem.write}.
  *
@@ -197,5 +206,28 @@ export class Filesystem {
       throw err;
     }
     return true;
+  }
+
+  /**
+   * Delete a file, empty directory, or symlink from the sandbox.
+   *
+   * @param path - Absolute path inside the sandbox.
+   * @param opts - Delete options. Set `recursive: true` to delete a
+   * directory and its contents.
+   * @throws {NotFoundError} If the path does not exist.
+   * @throws {APIError} If the API returns a non-2xx response.
+   * @throws {APIConnectionError} If the request cannot reach the API.
+   */
+  async delete(path: string, opts: DeleteFileOptions = {}, req: RequestOptions = {}): Promise<void> {
+    const params: Record<string, string> = { path };
+    if (opts.recursive) params.recursive = "true";
+    if (opts.container) params.container = opts.container;
+
+    await this._api.requestNoContent({
+      method: "DELETE",
+      path: filesystemPath(this._sandboxId),
+      params,
+      ...(req.signal ? { signal: req.signal } : {}),
+    });
   }
 }

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -30,7 +30,7 @@ export {
   NotFoundError,
   ValidationError,
 } from "./errors";
-export type { FileOptions, UploadBody } from "./filesystem";
+export type { DeleteFileOptions, FileOptions, UploadBody } from "./filesystem";
 export { Filesystem } from "./filesystem";
 export type {
   CommandResult,

--- a/sdks/typescript/tests/filesystem.test.ts
+++ b/sdks/typescript/tests/filesystem.test.ts
@@ -408,6 +408,37 @@ describe("Filesystem.stat/exists", () => {
   });
 });
 
+describe("Filesystem.delete", () => {
+  it("sends DELETE with recursive param when set", async () => {
+    const stub = makeStubFetch(jsonResponse(sandboxResponseFixture()), emptyResponse(204), emptyResponse(204));
+    const client = new Isola({ url: URL_BASE, fetch: stub.fetch, requestTimeoutMs: null });
+    const sandbox = await client.sandboxes.get("sandbox-123");
+    await sandbox.filesystem.delete("/workspace/file.txt", { container: "worker" });
+    await sandbox.filesystem.delete("/workspace/dir", { recursive: true });
+
+    const plainCall = stub.calls[1]!;
+    expect(plainCall.method).toBe("DELETE");
+    expect(plainCall.url.startsWith(`${URL_BASE}/v1/sandboxes/sandbox-123/filesystem`)).toBe(true);
+    expect(getSearchParam(plainCall.url, "path")).toBe("/workspace/file.txt");
+    expect(getSearchParam(plainCall.url, "container")).toBe("worker");
+    expect(getSearchParam(plainCall.url, "recursive")).toBeNull();
+
+    const recursiveCall = stub.calls[2]!;
+    expect(getSearchParam(recursiveCall.url, "recursive")).toBe("true");
+  });
+
+  it("raises NotFoundError on 404", async () => {
+    const stub = makeStubFetch(
+      jsonResponse(sandboxResponseFixture()),
+      jsonResponse({ detail: "path not found" }, { status: 404 }),
+    );
+    const client = new Isola({ url: URL_BASE, fetch: stub.fetch, requestTimeoutMs: null });
+    const sandbox = await client.sandboxes.get("sandbox-123");
+
+    await expect(sandbox.filesystem.delete("/workspace/missing.txt")).rejects.toBeInstanceOf(NotFoundError);
+  });
+});
+
 describe("FilesystemEntry wire decoding", () => {
   it("rejects a missing name", async () => {
     const stub = makeStubFetch(


### PR DESCRIPTION
PR 3 of 5 from the `fs_ops` split. **Base: `fs-stat`** — review this diff against `fs-stat`.

Adds the **delete** operation (`DELETE .../filesystem`) end to end: sidecar handler, gateway proxy, OpenAPI, Python/TypeScript SDKs, and tests. `recursive=true` removes a directory and its contents; dangling symlinks are removable; deleting the filesystem root is refused.

Stack: list → stat → **delete** → mkdir → move.