### PR TITLE
add filesystem mkdir endpoint

### DIFF
--- a/api/openapi/api-gateway.yaml
+++ b/api/openapi/api-gateway.yaml
@@ -1693,6 +1693,83 @@ paths:
       tags:
         - sandboxes
         - filesystem
+  /v1/sandboxes/{sandboxId}/filesystem/directories:
+    post:
+      description: Creates a directory at the specified path in the sandbox container, including missing parent directories. Idempotent if the directory already exists.
+      operationId: createSandboxFilesystemDirectory
+      parameters:
+        - description: Sandbox identifier
+          in: path
+          name: sandboxId
+          required: true
+          schema:
+            description: Sandbox identifier
+            maxLength: 47
+            minLength: 1
+            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+            type: string
+        - description: Directory path to create (absolute or relative to container cwd)
+          explode: false
+          in: query
+          name: path
+          required: true
+          schema:
+            description: Directory path to create (absolute or relative to container cwd)
+            minLength: 1
+            type: string
+        - description: Container name. Defaults to the only container if there is one, otherwise it's required.
+          explode: false
+          in: query
+          name: container
+          schema:
+            description: Container name. Defaults to the only container if there is one, otherwise it's required.
+            maxLength: 63
+            minLength: 1
+            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+            type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Bad Request
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Internal Server Error
+        "502":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Bad Gateway
+      summary: Create a directory in sandbox filesystem
+      tags:
+        - sandboxes
+        - filesystem
   /v1/sandboxes/{sandboxId}/filesystem/entries:
     get:
       description: Returns metadata for each entry in the specified directory inside the sandbox container. Symlinks are reported, not followed.

--- a/api/openapi/sandbox-sidecar.yaml
+++ b/api/openapi/sandbox-sidecar.yaml
@@ -762,6 +762,57 @@ paths:
       summary: Write a file to the sandbox filesystem
       tags:
         - filesystem
+  /v1/filesystem/directories:
+    post:
+      description: Creates a directory at the specified path, including missing parent directories. Idempotent if the directory already exists.
+      operationId: createFilesystemDirectory
+      parameters:
+        - description: Directory path to create (absolute or relative to container cwd)
+          explode: false
+          in: query
+          name: path
+          required: true
+          schema:
+            description: Directory path to create (absolute or relative to container cwd)
+            minLength: 1
+            type: string
+        - description: Container name. Defaults to the only container if there is one, otherwise it's required.
+          explode: false
+          in: query
+          name: container
+          schema:
+            description: Container name. Defaults to the only container if there is one, otherwise it's required.
+            type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Bad Request
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Internal Server Error
+      summary: Create a directory in the sandbox filesystem
+      tags:
+        - filesystem
   /v1/filesystem/entries:
     get:
       description: Returns metadata for each entry in the specified directory. Symlinks are reported, not followed.

--- a/internal/api-gateway/filesystem/filesystem.go
+++ b/internal/api-gateway/filesystem/filesystem.go
@@ -92,6 +92,12 @@ type FilesystemDeleteInput struct {
 	Container string `query:"container,omitempty" minLength:"1" maxLength:"63" pattern:"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$" doc:"Container name. Defaults to the only container if there is one, otherwise it's required."`
 }
 
+type FilesystemMkdirInput struct {
+	SandboxID string `path:"sandboxId" minLength:"1" maxLength:"47" pattern:"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$" doc:"Sandbox identifier"`
+	Path      string `query:"path" required:"true" minLength:"1" doc:"Directory path to create (absolute or relative to container cwd)"`
+	Container string `query:"container,omitempty" minLength:"1" maxLength:"63" pattern:"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$" doc:"Container name. Defaults to the only container if there is one, otherwise it's required."`
+}
+
 type Handlers struct {
 	logger           *slog.Logger
 	k8sClient        client.Client
@@ -320,6 +326,16 @@ func (h *Handlers) DeleteFilesystemEntry(ctx context.Context, input *FilesystemD
 	return nil, nil
 }
 
+func (h *Handlers) CreateFilesystemDirectory(ctx context.Context, input *FilesystemMkdirInput) (*struct{}, error) {
+	resp, err := h.callSidecar(ctx, input.SandboxID, http.MethodPost, "/v1/filesystem/directories", pathParams(input.Path, input.Container), nil)
+	if err != nil {
+		return nil, err
+	}
+	_ = resp.Body.Close()
+
+	return nil, nil
+}
+
 func Register(api huma.API, h *Handlers) {
 	huma.Register(api, huma.Operation{
 		OperationID: "writeSandboxFilesystem",
@@ -392,4 +408,15 @@ func Register(api huma.API, h *Handlers) {
 		DefaultStatus: http.StatusNoContent,
 		Errors:        []int{http.StatusBadRequest, http.StatusNotFound, http.StatusConflict, http.StatusBadGateway},
 	}, h.DeleteFilesystemEntry)
+
+	huma.Register(api, huma.Operation{
+		OperationID:   "createSandboxFilesystemDirectory",
+		Method:        http.MethodPost,
+		Path:          "/sandboxes/{sandboxId}/filesystem/directories",
+		Summary:       "Create a directory in sandbox filesystem",
+		Description:   "Creates a directory at the specified path in the sandbox container, including missing parent directories. Idempotent if the directory already exists.",
+		Tags:          []string{"sandboxes", "filesystem"},
+		DefaultStatus: http.StatusNoContent,
+		Errors:        []int{http.StatusBadRequest, http.StatusNotFound, http.StatusConflict, http.StatusBadGateway},
+	}, h.CreateFilesystemDirectory)
 }

--- a/internal/api-gateway/filesystem/filesystem_test.go
+++ b/internal/api-gateway/filesystem/filesystem_test.go
@@ -581,4 +581,43 @@ var _ = Describe("Filesystem Entry Proxy", func() {
 			Expect(resp.Code).To(Equal(http.StatusConflict))
 		})
 	})
+
+	Describe("POST /sandboxes/{sandboxId}/filesystem/directories", func() {
+		It("proxies the mkdir request", func() {
+			var capturedPath, capturedQueryPath string
+			mockSidecar := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedPath = r.URL.Path
+				capturedQueryPath = r.URL.Query().Get("path")
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer mockSidecar.Close()
+
+			port := mockSidecar.Listener.Addr().(*net.TCPAddr).Port
+			api := newFilesystemTestAPI(&http.Client{}, port)
+			sbName := createRunningSandboxCR()
+
+			resp := api.Post(fmt.Sprintf("/v1/sandboxes/%s/filesystem/directories?path=/workspace/newdir", sbName))
+
+			Expect(resp.Code).To(Equal(http.StatusNoContent))
+			Expect(capturedPath).To(Equal("/v1/filesystem/directories"))
+			Expect(capturedQueryPath).To(Equal("/workspace/newdir"))
+		})
+
+		It("forwards sidecar 409 errors", func() {
+			mockSidecar := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusConflict)
+				_ = json.NewEncoder(w).Encode(map[string]string{"detail": "path exists and is not a directory"})
+			}))
+			defer mockSidecar.Close()
+
+			port := mockSidecar.Listener.Addr().(*net.TCPAddr).Port
+			api := newFilesystemTestAPI(&http.Client{}, port)
+			sbName := createRunningSandboxCR()
+
+			resp := api.Post(fmt.Sprintf("/v1/sandboxes/%s/filesystem/directories?path=/workspace/taken", sbName))
+
+			Expect(resp.Code).To(Equal(http.StatusConflict))
+		})
+	})
 })

--- a/internal/sandbox-sidecar/filesystem/filesystem.go
+++ b/internal/sandbox-sidecar/filesystem/filesystem.go
@@ -68,6 +68,11 @@ type FilesystemDeleteInput struct {
 	Container string `query:"container,omitempty" doc:"Container name. Defaults to the only container if there is one, otherwise it's required."`
 }
 
+type FilesystemMkdirInput struct {
+	Path      string `query:"path" required:"true" minLength:"1" doc:"Directory path to create (absolute or relative to container cwd)"`
+	Container string `query:"container,omitempty" doc:"Container name. Defaults to the only container if there is one, otherwise it's required."`
+}
+
 type Handlers struct {
 	logger      *slog.Logger
 	procFS      proc.ProcFS
@@ -381,6 +386,36 @@ func (h *Handlers) DeleteFilesystemEntry(_ context.Context, input *FilesystemDel
 	return nil, nil
 }
 
+func (h *Handlers) CreateFilesystemDirectory(_ context.Context, input *FilesystemMkdirInput) (*struct{}, error) {
+	pid, _, targetPath, err := h.resolveTarget(input.Path, input.Container)
+	if err != nil {
+		return nil, err
+	}
+
+	uid, gid, err := h.procFS.GetUIDGID(pid)
+	if err != nil {
+		h.logger.Error("failed to get container uid/gid", "error", err, "pid", pid)
+		return nil, huma.Error500InternalServerError("failed to get container uid/gid")
+	}
+
+	if info, err := os.Lstat(targetPath); err == nil {
+		if info.IsDir() {
+			return nil, nil // already exists; mkdir is idempotent
+		}
+		return nil, huma.Error409Conflict(fmt.Sprintf("path exists and is not a directory: %s", input.Path))
+	}
+
+	if err := mkdirAllChown(targetPath, uid, gid); err != nil {
+		h.logger.Error("failed to create directory", "error", err, "path", targetPath)
+		if errors.Is(err, errNotADirectory) || errors.Is(err, syscall.ENOTDIR) {
+			return nil, huma.Error409Conflict("a parent path component exists and is not a directory")
+		}
+		return nil, huma.Error500InternalServerError("failed to create directory")
+	}
+
+	return nil, nil
+}
+
 func Register(api huma.API, h *Handlers) {
 	huma.Register(api, huma.Operation{
 		OperationID: "postFilesystem",
@@ -453,4 +488,15 @@ func Register(api huma.API, h *Handlers) {
 		DefaultStatus: http.StatusNoContent,
 		Errors:        []int{http.StatusBadRequest, http.StatusNotFound},
 	}, h.DeleteFilesystemEntry)
+
+	huma.Register(api, huma.Operation{
+		OperationID:   "createFilesystemDirectory",
+		Method:        http.MethodPost,
+		Path:          "/filesystem/directories",
+		Summary:       "Create a directory in the sandbox filesystem",
+		Description:   "Creates a directory at the specified path, including missing parent directories. Idempotent if the directory already exists.",
+		Tags:          []string{"filesystem"},
+		DefaultStatus: http.StatusNoContent,
+		Errors:        []int{http.StatusBadRequest, http.StatusConflict},
+	}, h.CreateFilesystemDirectory)
 }

--- a/internal/sandbox-sidecar/filesystem/filesystem_test.go
+++ b/internal/sandbox-sidecar/filesystem/filesystem_test.go
@@ -504,6 +504,54 @@ var _ = Describe("Filesystem", func() {
 			Expect(resp.Code).To(Equal(http.StatusBadRequest))
 		})
 	})
+
+	Describe("POST /filesystem/directories", func() {
+		It("creates nested directories", func() {
+			resp := doPostNoBody("/v1/filesystem/directories?path=/mkdir/deeply/nested")
+
+			Expect(resp.Code).To(Equal(http.StatusNoContent))
+			info, err := os.Stat(filepath.Join(testRootDir, "/mkdir/deeply/nested"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(info.IsDir()).To(BeTrue())
+		})
+
+		It("is idempotent for existing directory", func() {
+			Expect(os.MkdirAll(filepath.Join(testRootDir, "/mkdir/existing"), 0750)).To(Succeed())
+
+			resp := doPostNoBody("/v1/filesystem/directories?path=/mkdir/existing")
+
+			Expect(resp.Code).To(Equal(http.StatusNoContent))
+		})
+
+		It("creates directory with relative path", func() {
+			resp := doPostNoBody("/v1/filesystem/directories?path=relmkdir")
+
+			Expect(resp.Code).To(Equal(http.StatusNoContent))
+			info, err := os.Stat(filepath.Join(testRootDir, testCwd, "relmkdir"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(info.IsDir()).To(BeTrue())
+		})
+
+		It("returns 409 when path exists as a file", func() {
+			hostPath := filepath.Join(testRootDir, "/mkdir/taken.txt")
+			Expect(os.MkdirAll(filepath.Dir(hostPath), 0750)).To(Succeed())
+			Expect(os.WriteFile(hostPath, []byte("x"), 0600)).To(Succeed())
+
+			resp := doPostNoBody("/v1/filesystem/directories?path=/mkdir/taken.txt")
+
+			Expect(resp.Code).To(Equal(http.StatusConflict))
+		})
+
+		It("returns 409 when a parent component is a file", func() {
+			hostPath := filepath.Join(testRootDir, "/mkdir/blocker.txt")
+			Expect(os.MkdirAll(filepath.Dir(hostPath), 0750)).To(Succeed())
+			Expect(os.WriteFile(hostPath, []byte("x"), 0600)).To(Succeed())
+
+			resp := doPostNoBody("/v1/filesystem/directories?path=/mkdir/blocker.txt/sub")
+
+			Expect(resp.Code).To(Equal(http.StatusConflict))
+		})
+	})
 })
 
 // errorMockProcFS returns errors for FindMarkedPID.

--- a/internal/sandbox-sidecar/filesystem/suite_test.go
+++ b/internal/sandbox-sidecar/filesystem/suite_test.go
@@ -121,3 +121,7 @@ func doGet(path string) *httptest.ResponseRecorder {
 func doDelete(path string) *httptest.ResponseRecorder {
 	return testAPI.Delete(path)
 }
+
+func doPostNoBody(path string) *httptest.ResponseRecorder {
+	return testAPI.Post(path)
+}

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -235,6 +235,9 @@ print(entry.modified_time, entry.uid, entry.gid)
 # Check existence
 sandbox.filesystem.exists("/tmp/hello.txt")  # True
 
+# Create a directory (parents included, idempotent)
+sandbox.filesystem.mkdir("/tmp/output/reports")
+
 # Delete a file, or a directory tree with recursive=True
 sandbox.filesystem.delete("/tmp/data.bin")
 sandbox.filesystem.delete("/tmp/output", recursive=True)

--- a/sdks/python/src/isola/_filesystem.py
+++ b/sdks/python/src/isola/_filesystem.py
@@ -166,6 +166,27 @@ class Filesystem:
 
         self._api.request_no_content("DELETE", _filesystem_path(self._sandbox_id), params=params)
 
+    def mkdir(self, path: str, *, container: str | None = None) -> None:
+        """Create a directory in the sandbox.
+
+        Missing parent directories are created automatically. Succeeds
+        without error if the directory already exists.
+
+        Args:
+            path: Absolute path inside the sandbox.
+            container: Target container name. Only needed for
+                multi-container sandboxes.
+        """
+        params = {"path": path}
+        if container:
+            params["container"] = container
+
+        self._api.request_no_content(
+            "POST",
+            f"{_filesystem_path(self._sandbox_id)}/directories",
+            params=params,
+        )
+
 
 class AsyncFilesystem:
     """Async version of Filesystem."""
@@ -306,3 +327,24 @@ class AsyncFilesystem:
             params["container"] = container
 
         await self._api.request_no_content("DELETE", _filesystem_path(self._sandbox_id), params=params)
+
+    async def mkdir(self, path: str, *, container: str | None = None) -> None:
+        """Create a directory in the sandbox.
+
+        Missing parent directories are created automatically. Succeeds
+        without error if the directory already exists.
+
+        Args:
+            path: Absolute path inside the sandbox.
+            container: Target container name. Only needed for
+                multi-container sandboxes.
+        """
+        params = {"path": path}
+        if container:
+            params["container"] = container
+
+        await self._api.request_no_content(
+            "POST",
+            f"{_filesystem_path(self._sandbox_id)}/directories",
+            params=params,
+        )

--- a/sdks/python/tests/test_filesystem.py
+++ b/sdks/python/tests/test_filesystem.py
@@ -470,3 +470,20 @@ def test_filesystem_delete_not_found(sandbox_response_copy: dict[str, object]) -
         sandbox = client.sandboxes.get("sandbox-123")
         with pytest.raises(NotFoundError):
             sandbox.filesystem.delete("/workspace/missing.txt")
+
+
+@respx.mock
+def test_filesystem_mkdir(sandbox_response_copy: dict[str, object]) -> None:
+    respx.get("http://localhost:8080/v1/sandboxes/sandbox-123").mock(
+        return_value=httpx.Response(200, json=sandbox_response_copy)
+    )
+    mkdir_route = respx.post("http://localhost:8080/v1/sandboxes/sandbox-123/filesystem/directories").mock(
+        return_value=httpx.Response(204)
+    )
+
+    with Isola(url="http://localhost:8080") as client:
+        sandbox = client.sandboxes.get("sandbox-123")
+        sandbox.filesystem.mkdir("/workspace/new/dir", container="worker")
+
+    assert mkdir_route.calls[0].request.url.params["path"] == "/workspace/new/dir"
+    assert mkdir_route.calls[0].request.url.params["container"] == "worker"

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -263,6 +263,9 @@ console.log(entry.modifiedTime, entry.uid, entry.gid);
 // Check existence
 await sandbox.filesystem.exists("/tmp/hello.txt"); // true
 
+// Create a directory (parents included, idempotent)
+await sandbox.filesystem.mkdir("/tmp/output/reports");
+
 // Delete a file, or a directory tree with recursive: true
 await sandbox.filesystem.delete("/tmp/data.bin");
 await sandbox.filesystem.delete("/tmp/output", { recursive: true });

--- a/sdks/typescript/src/filesystem.ts
+++ b/sdks/typescript/src/filesystem.ts
@@ -17,7 +17,7 @@
 import type { RequestOptions } from "./client";
 import { NotFoundError } from "./errors";
 import type { HttpClient } from "./internal/http";
-import { filesystemEntriesPath, filesystemPath, filesystemStatPath } from "./internal/url";
+import { filesystemDirectoriesPath, filesystemEntriesPath, filesystemPath, filesystemStatPath } from "./internal/url";
 import { FilesystemEntry, ListFilesystemEntriesResponse } from "./models";
 
 /** Options for most {@link Filesystem} operations. */
@@ -226,6 +226,30 @@ export class Filesystem {
     await this._api.requestNoContent({
       method: "DELETE",
       path: filesystemPath(this._sandboxId),
+      params,
+      ...(req.signal ? { signal: req.signal } : {}),
+    });
+  }
+
+  /**
+   * Create a directory in the sandbox.
+   *
+   * Missing parent directories are created automatically. Succeeds
+   * without error if the directory already exists.
+   *
+   * @param path - Absolute path inside the sandbox.
+   * @param opts - File options (e.g. `container` for multi-container
+   * sandboxes).
+   * @throws {APIError} If the API returns a non-2xx response.
+   * @throws {APIConnectionError} If the request cannot reach the API.
+   */
+  async mkdir(path: string, opts: FileOptions = {}, req: RequestOptions = {}): Promise<void> {
+    const params: Record<string, string> = { path };
+    if (opts.container) params.container = opts.container;
+
+    await this._api.requestNoContent({
+      method: "POST",
+      path: filesystemDirectoriesPath(this._sandboxId),
       params,
       ...(req.signal ? { signal: req.signal } : {}),
     });

--- a/sdks/typescript/src/internal/url.ts
+++ b/sdks/typescript/src/internal/url.ts
@@ -102,6 +102,10 @@ export function filesystemStatPath(sandboxId: string): string {
   return `${filesystemPath(sandboxId)}/stat`;
 }
 
+export function filesystemDirectoriesPath(sandboxId: string): string {
+  return `${filesystemPath(sandboxId)}/directories`;
+}
+
 // Builds a URL with optional query string. Drops undefined/null values.
 // Uses quoteQueryComponent so spaces become `+` and !'()* are percent-encoded,
 // matching Python httpx's QueryParams.__str__ wire output.

--- a/sdks/typescript/tests/filesystem.test.ts
+++ b/sdks/typescript/tests/filesystem.test.ts
@@ -439,6 +439,30 @@ describe("Filesystem.delete", () => {
   });
 });
 
+describe("Filesystem.mkdir", () => {
+  it("posts to the directories endpoint", async () => {
+    const stub = makeStubFetch(jsonResponse(sandboxResponseFixture()), emptyResponse(204));
+    const client = new Isola({ url: URL_BASE, fetch: stub.fetch, requestTimeoutMs: null });
+    const sandbox = await client.sandboxes.get("sandbox-123");
+    await sandbox.filesystem.mkdir("/workspace/new/dir", { container: "worker" });
+
+    const mkdirCall = stub.calls[1]!;
+    expect(mkdirCall.method).toBe("POST");
+    expect(mkdirCall.url.startsWith(`${URL_BASE}/v1/sandboxes/sandbox-123/filesystem/directories`)).toBe(true);
+    expect(getSearchParam(mkdirCall.url, "path")).toBe("/workspace/new/dir");
+    expect(getSearchParam(mkdirCall.url, "container")).toBe("worker");
+  });
+
+  it("omits container when not set", async () => {
+    const stub = makeStubFetch(jsonResponse(sandboxResponseFixture()), emptyResponse(204));
+    const client = new Isola({ url: URL_BASE, fetch: stub.fetch, requestTimeoutMs: null });
+    const sandbox = await client.sandboxes.get("sandbox-123");
+    await sandbox.filesystem.mkdir("/workspace/new");
+
+    expect(getSearchParam(stub.calls[1]!.url, "container")).toBeNull();
+  });
+});
+
 describe("FilesystemEntry wire decoding", () => {
   it("rejects a missing name", async () => {
     const stub = makeStubFetch(


### PR DESCRIPTION
PR 4 of 5 from the `fs_ops` split. **Base: `fs-delete`** — review this diff against `fs-delete`.

Adds the **mkdir** operation (`POST .../filesystem/directories`) end to end: sidecar handler, gateway proxy, OpenAPI, Python/TypeScript SDKs, and tests. Missing parents are created; idempotent when the directory already exists; returns `409` when the path (or a parent) exists as a non-directory.

Stack: list → stat → delete → **mkdir** → move.