### PR TITLE
add filesystem move endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,12 +133,18 @@ sandbox = client.sandboxes.create(
 
 ### File I/O
 
-Read and write files inside sandboxes. Parent directories are created automatically.
+Read, write, and manage files inside sandboxes. Parent directories are created automatically.
 
 ```python
 sandbox.filesystem.write("/app/main.py", "print('hello from the sandbox')")
 data = sandbox.filesystem.read("/app/main.py")
 print(data.decode())  # "print('hello from the sandbox')"
+
+sandbox.filesystem.mkdir("/app/output")
+sandbox.filesystem.move("/app/main.py", "/app/output/main.py")
+for entry in sandbox.filesystem.list("/app/output"):
+    print(entry.name, entry.type, entry.size)
+sandbox.filesystem.delete("/app/output", recursive=True)
 ```
 
 ### Command execution

--- a/api/openapi/api-gateway.yaml
+++ b/api/openapi/api-gateway.yaml
@@ -415,6 +415,28 @@ components:
       required:
         - sandboxes
       type: object
+    MoveFilesystemEntryRequest:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - https://example.com/schemas/MoveFilesystemEntryRequest.json
+          format: uri
+          readOnly: true
+          type: string
+        destinationPath:
+          description: Destination path (absolute or relative to container cwd). Parent directories are created automatically.
+          minLength: 1
+          type: string
+        sourcePath:
+          description: Path to move (absolute or relative to container cwd)
+          minLength: 1
+          type: string
+      required:
+        - sourcePath
+        - destinationPath
+      type: object
     Network:
       additionalProperties: false
       properties:
@@ -1848,6 +1870,80 @@ paths:
                 $ref: "#/components/schemas/ErrorModel"
           description: Bad Gateway
       summary: List directory entries in sandbox filesystem
+      tags:
+        - sandboxes
+        - filesystem
+  /v1/sandboxes/{sandboxId}/filesystem/move:
+    post:
+      description: Renames or moves a file, directory, or symlink inside the sandbox container. Parent directories of the destination are created automatically. An existing destination file is overwritten.
+      operationId: moveSandboxFilesystemEntry
+      parameters:
+        - description: Sandbox identifier
+          in: path
+          name: sandboxId
+          required: true
+          schema:
+            description: Sandbox identifier
+            maxLength: 47
+            minLength: 1
+            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+            type: string
+        - description: Container name. Defaults to the only container if there is one, otherwise it's required.
+          explode: false
+          in: query
+          name: container
+          schema:
+            description: Container name. Defaults to the only container if there is one, otherwise it's required.
+            maxLength: 63
+            minLength: 1
+            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MoveFilesystemEntryRequest"
+        required: true
+      responses:
+        "204":
+          description: No Content
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Bad Request
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Internal Server Error
+        "502":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Bad Gateway
+      summary: Move a file or directory within sandbox filesystem
       tags:
         - sandboxes
         - filesystem

--- a/api/openapi/sandbox-sidecar.yaml
+++ b/api/openapi/sandbox-sidecar.yaml
@@ -222,6 +222,28 @@ components:
       required:
         - entries
       type: object
+    MoveFilesystemEntryRequest:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - https://example.com/schemas/MoveFilesystemEntryRequest.json
+          format: uri
+          readOnly: true
+          type: string
+        destinationPath:
+          description: Destination path (absolute or relative to container cwd). Parent directories are created automatically.
+          minLength: 1
+          type: string
+        sourcePath:
+          description: Path to move (absolute or relative to container cwd)
+          minLength: 1
+          type: string
+      required:
+        - sourcePath
+        - destinationPath
+      type: object
 info:
   description: Internal API for sandbox filesystem operations
   title: Isola Sandbox Sidecar API
@@ -866,6 +888,60 @@ paths:
                 $ref: "#/components/schemas/ErrorModel"
           description: Internal Server Error
       summary: List directory entries in the sandbox filesystem
+      tags:
+        - filesystem
+  /v1/filesystem/move:
+    post:
+      description: Renames or moves a file, directory, or symlink. Parent directories of the destination are created automatically. An existing destination file is overwritten.
+      operationId: moveFilesystemEntry
+      parameters:
+        - description: Container name. Defaults to the only container if there is one, otherwise it's required.
+          explode: false
+          in: query
+          name: container
+          schema:
+            description: Container name. Defaults to the only container if there is one, otherwise it's required.
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MoveFilesystemEntryRequest"
+        required: true
+      responses:
+        "204":
+          description: No Content
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Bad Request
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Unprocessable Entity
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Internal Server Error
+      summary: Move a file or directory within the sandbox filesystem
       tags:
         - filesystem
   /v1/filesystem/stat:

--- a/internal/api-gateway/filesystem/filesystem.go
+++ b/internal/api-gateway/filesystem/filesystem.go
@@ -52,6 +52,11 @@ type ListFilesystemEntriesResponse struct {
 	Entries []FilesystemEntry `json:"entries" doc:"Directory entries sorted by name"`
 }
 
+type MoveFilesystemEntryRequest struct {
+	SourcePath      string `json:"sourcePath" required:"true" minLength:"1" doc:"Path to move (absolute or relative to container cwd)"`
+	DestinationPath string `json:"destinationPath" required:"true" minLength:"1" doc:"Destination path (absolute or relative to container cwd). Parent directories are created automatically."`
+}
+
 type FilesystemWriteInput struct {
 	SandboxID string `path:"sandboxId" minLength:"1" maxLength:"47" pattern:"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$" doc:"Sandbox identifier"`
 	Path      string `query:"path" required:"true" minLength:"1" doc:"Destination path (absolute or relative to container cwd)"`
@@ -96,6 +101,12 @@ type FilesystemMkdirInput struct {
 	SandboxID string `path:"sandboxId" minLength:"1" maxLength:"47" pattern:"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$" doc:"Sandbox identifier"`
 	Path      string `query:"path" required:"true" minLength:"1" doc:"Directory path to create (absolute or relative to container cwd)"`
 	Container string `query:"container,omitempty" minLength:"1" maxLength:"63" pattern:"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$" doc:"Container name. Defaults to the only container if there is one, otherwise it's required."`
+}
+
+type FilesystemMoveInput struct {
+	SandboxID string `path:"sandboxId" minLength:"1" maxLength:"47" pattern:"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$" doc:"Sandbox identifier"`
+	Container string `query:"container,omitempty" minLength:"1" maxLength:"63" pattern:"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$" doc:"Container name. Defaults to the only container if there is one, otherwise it's required."`
+	Body      MoveFilesystemEntryRequest
 }
 
 type Handlers struct {
@@ -336,6 +347,22 @@ func (h *Handlers) CreateFilesystemDirectory(ctx context.Context, input *Filesys
 	return nil, nil
 }
 
+func (h *Handlers) MoveFilesystemEntry(ctx context.Context, input *FilesystemMoveInput) (*struct{}, error) {
+	params := url.Values{}
+	if input.Container != "" {
+		params.Set("container", input.Container)
+	}
+
+	_ = sidecarapi.MoveFilesystemEntryRequest(MoveFilesystemEntryRequest{}) // assert field compatibility
+	resp, err := h.callSidecar(ctx, input.SandboxID, http.MethodPost, "/v1/filesystem/move", params, input.Body)
+	if err != nil {
+		return nil, err
+	}
+	_ = resp.Body.Close()
+
+	return nil, nil
+}
+
 func Register(api huma.API, h *Handlers) {
 	huma.Register(api, huma.Operation{
 		OperationID: "writeSandboxFilesystem",
@@ -419,4 +446,15 @@ func Register(api huma.API, h *Handlers) {
 		DefaultStatus: http.StatusNoContent,
 		Errors:        []int{http.StatusBadRequest, http.StatusNotFound, http.StatusConflict, http.StatusBadGateway},
 	}, h.CreateFilesystemDirectory)
+
+	huma.Register(api, huma.Operation{
+		OperationID:   "moveSandboxFilesystemEntry",
+		Method:        http.MethodPost,
+		Path:          "/sandboxes/{sandboxId}/filesystem/move",
+		Summary:       "Move a file or directory within sandbox filesystem",
+		Description:   "Renames or moves a file, directory, or symlink inside the sandbox container. Parent directories of the destination are created automatically. An existing destination file is overwritten.",
+		Tags:          []string{"sandboxes", "filesystem"},
+		DefaultStatus: http.StatusNoContent,
+		Errors:        []int{http.StatusBadRequest, http.StatusNotFound, http.StatusConflict, http.StatusBadGateway},
+	}, h.MoveFilesystemEntry)
 }

--- a/internal/api-gateway/filesystem/filesystem_test.go
+++ b/internal/api-gateway/filesystem/filesystem_test.go
@@ -620,4 +620,66 @@ var _ = Describe("Filesystem Entry Proxy", func() {
 			Expect(resp.Code).To(Equal(http.StatusConflict))
 		})
 	})
+
+	Describe("POST /sandboxes/{sandboxId}/filesystem/move", func() {
+		It("proxies the move request with JSON body", func() {
+			var capturedPath, capturedContentType string
+			var capturedBody []byte
+			mockSidecar := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedPath = r.URL.Path
+				capturedContentType = r.Header.Get("Content-Type")
+				capturedBody, _ = io.ReadAll(r.Body)
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer mockSidecar.Close()
+
+			port := mockSidecar.Listener.Addr().(*net.TCPAddr).Port
+			api := newFilesystemTestAPI(&http.Client{}, port)
+			sbName := createRunningSandboxCR()
+
+			resp := api.Post(
+				fmt.Sprintf("/v1/sandboxes/%s/filesystem/move?container=main", sbName),
+				map[string]any{"sourcePath": "/workspace/a.txt", "destinationPath": "/workspace/b.txt"},
+			)
+
+			Expect(resp.Code).To(Equal(http.StatusNoContent))
+			Expect(capturedPath).To(Equal("/v1/filesystem/move"))
+			Expect(capturedContentType).To(Equal("application/json"))
+
+			var forwarded MoveFilesystemEntryRequest
+			Expect(json.Unmarshal(capturedBody, &forwarded)).To(Succeed())
+			Expect(forwarded.SourcePath).To(Equal("/workspace/a.txt"))
+			Expect(forwarded.DestinationPath).To(Equal("/workspace/b.txt"))
+		})
+
+		It("returns 422 when sourcePath is missing", func() {
+			api := newFilesystemTestAPI(&http.Client{}, 0)
+			sbName := createRunningSandboxCR()
+
+			resp := api.Post(
+				fmt.Sprintf("/v1/sandboxes/%s/filesystem/move", sbName),
+				map[string]any{"destinationPath": "/workspace/b.txt"},
+			)
+
+			Expect(resp.Code).To(Equal(http.StatusUnprocessableEntity))
+		})
+
+		It("forwards sidecar 404 errors", func() {
+			mockSidecar := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			}))
+			defer mockSidecar.Close()
+
+			port := mockSidecar.Listener.Addr().(*net.TCPAddr).Port
+			api := newFilesystemTestAPI(&http.Client{}, port)
+			sbName := createRunningSandboxCR()
+
+			resp := api.Post(
+				fmt.Sprintf("/v1/sandboxes/%s/filesystem/move", sbName),
+				map[string]any{"sourcePath": "/no-such", "destinationPath": "/workspace/b.txt"},
+			)
+
+			Expect(resp.Code).To(Equal(http.StatusNotFound))
+		})
+	})
 })

--- a/internal/sandbox-sidecar/filesystem/filesystem.go
+++ b/internal/sandbox-sidecar/filesystem/filesystem.go
@@ -73,6 +73,11 @@ type FilesystemMkdirInput struct {
 	Container string `query:"container,omitempty" doc:"Container name. Defaults to the only container if there is one, otherwise it's required."`
 }
 
+type FilesystemMoveInput struct {
+	Container string `query:"container,omitempty" doc:"Container name. Defaults to the only container if there is one, otherwise it's required."`
+	Body      sidecarapi.MoveFilesystemEntryRequest
+}
+
 type Handlers struct {
 	logger      *slog.Logger
 	procFS      proc.ProcFS
@@ -416,6 +421,64 @@ func (h *Handlers) CreateFilesystemDirectory(_ context.Context, input *Filesyste
 	return nil, nil
 }
 
+func (h *Handlers) MoveFilesystemEntry(_ context.Context, input *FilesystemMoveInput) (*struct{}, error) {
+	pid, resolvedSrc, hostSrc, err := h.resolveTarget(input.Body.SourcePath, input.Container)
+	if err != nil {
+		return nil, err
+	}
+
+	resolvedDst, herr := h.resolveAbsolutePath(input.Body.DestinationPath, pid)
+	if herr != nil {
+		h.logger.Error("failed to resolve path", "error", herr, "path", input.Body.DestinationPath, "container", input.Container)
+		return nil, herr
+	}
+	hostDst := filepath.Join(h.procFS.GetRoot(pid), resolvedDst)
+
+	if resolvedSrc == "/" || resolvedDst == "/" {
+		return nil, huma.Error400BadRequest("refusing to move filesystem root")
+	}
+
+	if _, err := os.Lstat(hostSrc); err != nil {
+		if os.IsNotExist(err) {
+			return nil, huma.Error404NotFound(fmt.Sprintf("source path not found: %s", input.Body.SourcePath))
+		}
+		h.logger.Error("failed to stat source path", "error", err, "path", hostSrc)
+		return nil, huma.Error500InternalServerError("failed to stat source path")
+	}
+
+	uid, gid, err := h.procFS.GetUIDGID(pid)
+	if err != nil {
+		h.logger.Error("failed to get container uid/gid", "error", err, "pid", pid)
+		return nil, huma.Error500InternalServerError("failed to get container uid/gid")
+	}
+
+	if err := mkdirAllChown(filepath.Dir(hostDst), uid, gid); err != nil {
+		h.logger.Error("failed to create parent directories", "error", err, "path", filepath.Dir(hostDst))
+		if errors.Is(err, errNotADirectory) || errors.Is(err, syscall.ENOTDIR) {
+			return nil, huma.Error409Conflict("a parent path component exists and is not a directory")
+		}
+		return nil, huma.Error500InternalServerError("failed to create parent directories")
+	}
+
+	if err := os.Rename(hostSrc, hostDst); err != nil {
+		switch {
+		case errors.Is(err, syscall.EXDEV):
+			// e.g. moving into or out of a tmpfs mount like /tmp
+			return nil, huma.Error400BadRequest("cannot move across filesystem boundaries")
+		case errors.Is(err, syscall.ENOTEMPTY), errors.Is(err, syscall.EEXIST),
+			errors.Is(err, syscall.EISDIR), errors.Is(err, syscall.ENOTDIR):
+			// exact errno varies by kernel and filesystem for the
+			// dest-is-directory / dest-not-empty / type-mismatch family
+			return nil, huma.Error409Conflict(fmt.Sprintf("destination conflicts with an existing entry: %s", input.Body.DestinationPath))
+		default:
+			h.logger.Error("failed to move path", "error", err, "source", hostSrc, "destination", hostDst)
+			return nil, huma.Error500InternalServerError("failed to move path")
+		}
+	}
+
+	return nil, nil
+}
+
 func Register(api huma.API, h *Handlers) {
 	huma.Register(api, huma.Operation{
 		OperationID: "postFilesystem",
@@ -499,4 +562,15 @@ func Register(api huma.API, h *Handlers) {
 		DefaultStatus: http.StatusNoContent,
 		Errors:        []int{http.StatusBadRequest, http.StatusConflict},
 	}, h.CreateFilesystemDirectory)
+
+	huma.Register(api, huma.Operation{
+		OperationID:   "moveFilesystemEntry",
+		Method:        http.MethodPost,
+		Path:          "/filesystem/move",
+		Summary:       "Move a file or directory within the sandbox filesystem",
+		Description:   "Renames or moves a file, directory, or symlink. Parent directories of the destination are created automatically. An existing destination file is overwritten.",
+		Tags:          []string{"filesystem"},
+		DefaultStatus: http.StatusNoContent,
+		Errors:        []int{http.StatusBadRequest, http.StatusNotFound, http.StatusConflict},
+	}, h.MoveFilesystemEntry)
 }

--- a/internal/sandbox-sidecar/filesystem/filesystem_test.go
+++ b/internal/sandbox-sidecar/filesystem/filesystem_test.go
@@ -552,6 +552,114 @@ var _ = Describe("Filesystem", func() {
 			Expect(resp.Code).To(Equal(http.StatusConflict))
 		})
 	})
+
+	Describe("POST /filesystem/move", func() {
+		It("renames a file", func() {
+			srcPath := filepath.Join(testRootDir, "/movedir/src.txt")
+			Expect(os.MkdirAll(filepath.Dir(srcPath), 0750)).To(Succeed())
+			Expect(os.WriteFile(srcPath, []byte("move me"), 0600)).To(Succeed())
+
+			resp := doMove("/movedir/src.txt", "/movedir/dst.txt")
+
+			Expect(resp.Code).To(Equal(http.StatusNoContent))
+			_, err := os.Lstat(srcPath)
+			Expect(os.IsNotExist(err)).To(BeTrue())
+			content, err := os.ReadFile(filepath.Join(testRootDir, "/movedir/dst.txt")) //nolint:gosec // test file path
+			Expect(err).NotTo(HaveOccurred())
+			Expect(content).To(Equal([]byte("move me")))
+		})
+
+		It("creates destination parent directories", func() {
+			srcPath := filepath.Join(testRootDir, "/movedir/parented.txt")
+			Expect(os.MkdirAll(filepath.Dir(srcPath), 0750)).To(Succeed())
+			Expect(os.WriteFile(srcPath, []byte("x"), 0600)).To(Succeed())
+
+			resp := doMove("/movedir/parented.txt", "/movedir/new/deep/dst.txt")
+
+			Expect(resp.Code).To(Equal(http.StatusNoContent))
+			_, err := os.Stat(filepath.Join(testRootDir, "/movedir/new/deep/dst.txt"))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("moves a directory", func() {
+			srcDir := filepath.Join(testRootDir, "/movedir/srcdir")
+			Expect(os.MkdirAll(srcDir, 0750)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(srcDir, "f.txt"), []byte("x"), 0600)).To(Succeed())
+
+			resp := doMove("/movedir/srcdir", "/movedir/dstdir")
+
+			Expect(resp.Code).To(Equal(http.StatusNoContent))
+			_, err := os.Stat(filepath.Join(testRootDir, "/movedir/dstdir/f.txt"))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("overwrites an existing destination file", func() {
+			srcPath := filepath.Join(testRootDir, "/movedir/over-src.txt")
+			dstPath := filepath.Join(testRootDir, "/movedir/over-dst.txt")
+			Expect(os.MkdirAll(filepath.Dir(srcPath), 0750)).To(Succeed())
+			Expect(os.WriteFile(srcPath, []byte("new"), 0600)).To(Succeed())
+			Expect(os.WriteFile(dstPath, []byte("old"), 0600)).To(Succeed())
+
+			resp := doMove("/movedir/over-src.txt", "/movedir/over-dst.txt")
+
+			Expect(resp.Code).To(Equal(http.StatusNoContent))
+			content, err := os.ReadFile(dstPath) //nolint:gosec // test file path
+			Expect(err).NotTo(HaveOccurred())
+			Expect(content).To(Equal([]byte("new")))
+		})
+
+		It("resolves relative source and destination paths", func() {
+			srcPath := filepath.Join(testRootDir, testCwd, "relmove-src.txt")
+			Expect(os.WriteFile(srcPath, []byte("rel"), 0600)).To(Succeed())
+
+			resp := doMove("relmove-src.txt", "relmove-dst.txt")
+
+			Expect(resp.Code).To(Equal(http.StatusNoContent))
+			_, err := os.Stat(filepath.Join(testRootDir, testCwd, "relmove-dst.txt"))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns 404 for nonexistent source", func() {
+			resp := doMove("/no-such-source", "/movedir/whatever")
+
+			Expect(resp.Code).To(Equal(http.StatusNotFound))
+		})
+
+		It("returns 409 when destination is a non-empty directory", func() {
+			srcDir := filepath.Join(testRootDir, "/movedir/conflict-src")
+			dstDir := filepath.Join(testRootDir, "/movedir/conflict-dst")
+			Expect(os.MkdirAll(srcDir, 0750)).To(Succeed())
+			Expect(os.MkdirAll(dstDir, 0750)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(dstDir, "occupied.txt"), []byte("x"), 0600)).To(Succeed())
+
+			resp := doMove("/movedir/conflict-src", "/movedir/conflict-dst")
+
+			Expect(resp.Code).To(Equal(http.StatusConflict))
+		})
+
+		It("returns 409 when moving a file onto a directory", func() {
+			srcPath := filepath.Join(testRootDir, "/movedir/type-src.txt")
+			dstDir := filepath.Join(testRootDir, "/movedir/type-dst")
+			Expect(os.MkdirAll(dstDir, 0750)).To(Succeed())
+			Expect(os.WriteFile(srcPath, []byte("x"), 0600)).To(Succeed())
+
+			resp := doMove("/movedir/type-src.txt", "/movedir/type-dst")
+
+			Expect(resp.Code).To(Equal(http.StatusConflict))
+		})
+
+		It("refuses to move the filesystem root", func() {
+			resp := doMove("/", "/movedir/root-copy")
+
+			Expect(resp.Code).To(Equal(http.StatusBadRequest))
+		})
+
+		It("returns 422 when sourcePath is missing", func() {
+			resp := testAPI.Post("/v1/filesystem/move", map[string]any{"destinationPath": "/somewhere"})
+
+			Expect(resp.Code).To(Equal(http.StatusUnprocessableEntity))
+		})
+	})
 })
 
 // errorMockProcFS returns errors for FindMarkedPID.

--- a/internal/sandbox-sidecar/filesystem/suite_test.go
+++ b/internal/sandbox-sidecar/filesystem/suite_test.go
@@ -125,3 +125,10 @@ func doDelete(path string) *httptest.ResponseRecorder {
 func doPostNoBody(path string) *httptest.ResponseRecorder {
 	return testAPI.Post(path)
 }
+
+func doMove(sourcePath, destinationPath string) *httptest.ResponseRecorder {
+	return testAPI.Post("/v1/filesystem/move", map[string]any{
+		"sourcePath":      sourcePath,
+		"destinationPath": destinationPath,
+	})
+}

--- a/internal/sidecar-api/types.go
+++ b/internal/sidecar-api/types.go
@@ -48,3 +48,8 @@ type FilesystemEntry struct {
 type ListFilesystemEntriesResponse struct {
 	Entries []FilesystemEntry `json:"entries" doc:"Directory entries sorted by name"`
 }
+
+type MoveFilesystemEntryRequest struct {
+	SourcePath      string `json:"sourcePath" required:"true" minLength:"1" doc:"Path to move (absolute or relative to container cwd)"`
+	DestinationPath string `json:"destinationPath" required:"true" minLength:"1" doc:"Destination path (absolute or relative to container cwd). Parent directories are created automatically."`
+}

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -238,6 +238,9 @@ sandbox.filesystem.exists("/tmp/hello.txt")  # True
 # Create a directory (parents included, idempotent)
 sandbox.filesystem.mkdir("/tmp/output/reports")
 
+# Move or rename
+sandbox.filesystem.move("/tmp/hello.txt", "/tmp/output/greeting.txt")
+
 # Delete a file, or a directory tree with recursive=True
 sandbox.filesystem.delete("/tmp/data.bin")
 sandbox.filesystem.delete("/tmp/output", recursive=True)

--- a/sdks/python/src/isola/_client.py
+++ b/sdks/python/src/isola/_client.py
@@ -140,10 +140,11 @@ class _SyncAPI:
         path: str,
         *,
         params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
         content: bytes | BinaryIO | None = None,
         headers: dict[str, str] | None = None,
     ) -> None:
-        self.request(method, path, params=params, content=content, headers=headers)
+        self.request(method, path, params=params, json_body=json_body, content=content, headers=headers)
 
     def open_stream(
         self,
@@ -260,10 +261,11 @@ class _AsyncAPI:
         path: str,
         *,
         params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
         content: bytes | BinaryIO | None = None,
         headers: dict[str, str] | None = None,
     ) -> None:
-        await self.request(method, path, params=params, content=content, headers=headers)
+        await self.request(method, path, params=params, json_body=json_body, content=content, headers=headers)
 
     def open_stream(
         self,

--- a/sdks/python/src/isola/_filesystem.py
+++ b/sdks/python/src/isola/_filesystem.py
@@ -187,6 +187,32 @@ class Filesystem:
             params=params,
         )
 
+    def move(self, source_path: str, destination_path: str, *, container: str | None = None) -> None:
+        """Move or rename a file, directory, or symlink in the sandbox.
+
+        Parent directories of the destination are created automatically.
+        An existing destination file is overwritten.
+
+        Args:
+            source_path: Absolute path to move.
+            destination_path: Absolute destination path.
+            container: Target container name. Only needed for
+                multi-container sandboxes.
+
+        Raises:
+            NotFoundError: If the source path does not exist.
+        """
+        params: dict[str, str] = {}
+        if container:
+            params["container"] = container
+
+        self._api.request_no_content(
+            "POST",
+            f"{_filesystem_path(self._sandbox_id)}/move",
+            params=params,
+            json_body={"sourcePath": source_path, "destinationPath": destination_path},
+        )
+
 
 class AsyncFilesystem:
     """Async version of Filesystem."""
@@ -347,4 +373,30 @@ class AsyncFilesystem:
             "POST",
             f"{_filesystem_path(self._sandbox_id)}/directories",
             params=params,
+        )
+
+    async def move(self, source_path: str, destination_path: str, *, container: str | None = None) -> None:
+        """Move or rename a file, directory, or symlink in the sandbox.
+
+        Parent directories of the destination are created automatically.
+        An existing destination file is overwritten.
+
+        Args:
+            source_path: Absolute path to move.
+            destination_path: Absolute destination path.
+            container: Target container name. Only needed for
+                multi-container sandboxes.
+
+        Raises:
+            NotFoundError: If the source path does not exist.
+        """
+        params: dict[str, str] = {}
+        if container:
+            params["container"] = container
+
+        await self._api.request_no_content(
+            "POST",
+            f"{_filesystem_path(self._sandbox_id)}/move",
+            params=params,
+            json_body={"sourcePath": source_path, "destinationPath": destination_path},
         )

--- a/sdks/python/tests/test_filesystem.py
+++ b/sdks/python/tests/test_filesystem.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import io
+import json
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import BinaryIO, cast
@@ -487,3 +488,65 @@ def test_filesystem_mkdir(sandbox_response_copy: dict[str, object]) -> None:
 
     assert mkdir_route.calls[0].request.url.params["path"] == "/workspace/new/dir"
     assert mkdir_route.calls[0].request.url.params["container"] == "worker"
+
+
+@respx.mock
+def test_filesystem_move(sandbox_response_copy: dict[str, object]) -> None:
+    respx.get("http://localhost:8080/v1/sandboxes/sandbox-123").mock(
+        return_value=httpx.Response(200, json=sandbox_response_copy)
+    )
+    move_route = respx.post("http://localhost:8080/v1/sandboxes/sandbox-123/filesystem/move").mock(
+        return_value=httpx.Response(204)
+    )
+
+    with Isola(url="http://localhost:8080") as client:
+        sandbox = client.sandboxes.get("sandbox-123")
+        sandbox.filesystem.move("/workspace/a.txt", "/workspace/b.txt")
+
+    body = json.loads(move_route.calls[0].request.content)
+    assert body == {"sourcePath": "/workspace/a.txt", "destinationPath": "/workspace/b.txt"}
+    assert "container" not in move_route.calls[0].request.url.params
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_async_filesystem_entry_operations(sandbox_response_copy: dict[str, object]) -> None:
+    respx.get("http://localhost:8080/v1/sandboxes/sandbox-123").mock(
+        return_value=httpx.Response(200, json=sandbox_response_copy)
+    )
+    respx.get("http://localhost:8080/v1/sandboxes/sandbox-123/filesystem/entries").mock(
+        return_value=httpx.Response(200, json={"entries": [_ENTRY_JSON]})
+    )
+    stat_route = respx.get("http://localhost:8080/v1/sandboxes/sandbox-123/filesystem/stat")
+    stat_route.side_effect = [
+        httpx.Response(200, json=_ENTRY_JSON),
+        httpx.Response(404, json={"title": "Not Found", "status": 404, "detail": "path not found"}),
+    ]
+    delete_route = respx.delete("http://localhost:8080/v1/sandboxes/sandbox-123/filesystem").mock(
+        return_value=httpx.Response(204)
+    )
+    mkdir_route = respx.post("http://localhost:8080/v1/sandboxes/sandbox-123/filesystem/directories").mock(
+        return_value=httpx.Response(204)
+    )
+    move_route = respx.post("http://localhost:8080/v1/sandboxes/sandbox-123/filesystem/move").mock(
+        return_value=httpx.Response(204)
+    )
+
+    async with AsyncIsola(url="http://localhost:8080") as client:
+        sandbox = await client.sandboxes.get("sandbox-123")
+        entries = await sandbox.filesystem.list("/workspace")
+        assert len(entries) == 1
+        assert entries[0].type == FilesystemEntryType.FILE
+
+        assert await sandbox.filesystem.exists("/workspace/file.txt") is True
+        assert await sandbox.filesystem.exists("/workspace/missing.txt") is False
+
+        await sandbox.filesystem.delete("/workspace/dir", recursive=True)
+        assert delete_route.calls[0].request.url.params["recursive"] == "true"
+
+        await sandbox.filesystem.mkdir("/workspace/new")
+        assert mkdir_route.calls[0].request.url.params["path"] == "/workspace/new"
+
+        await sandbox.filesystem.move("/a", "/b")
+        body = json.loads(move_route.calls[0].request.content)
+        assert body == {"sourcePath": "/a", "destinationPath": "/b"}

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -266,6 +266,9 @@ await sandbox.filesystem.exists("/tmp/hello.txt"); // true
 // Create a directory (parents included, idempotent)
 await sandbox.filesystem.mkdir("/tmp/output/reports");
 
+// Move or rename
+await sandbox.filesystem.move("/tmp/hello.txt", "/tmp/output/greeting.txt");
+
 // Delete a file, or a directory tree with recursive: true
 await sandbox.filesystem.delete("/tmp/data.bin");
 await sandbox.filesystem.delete("/tmp/output", { recursive: true });

--- a/sdks/typescript/src/filesystem.ts
+++ b/sdks/typescript/src/filesystem.ts
@@ -17,7 +17,13 @@
 import type { RequestOptions } from "./client";
 import { NotFoundError } from "./errors";
 import type { HttpClient } from "./internal/http";
-import { filesystemDirectoriesPath, filesystemEntriesPath, filesystemPath, filesystemStatPath } from "./internal/url";
+import {
+  filesystemDirectoriesPath,
+  filesystemEntriesPath,
+  filesystemMovePath,
+  filesystemPath,
+  filesystemStatPath,
+} from "./internal/url";
 import { FilesystemEntry, ListFilesystemEntriesResponse } from "./models";
 
 /** Options for most {@link Filesystem} operations. */
@@ -251,6 +257,38 @@ export class Filesystem {
       method: "POST",
       path: filesystemDirectoriesPath(this._sandboxId),
       params,
+      ...(req.signal ? { signal: req.signal } : {}),
+    });
+  }
+
+  /**
+   * Move or rename a file, directory, or symlink in the sandbox.
+   *
+   * Parent directories of the destination are created automatically.
+   * An existing destination file is overwritten.
+   *
+   * @param sourcePath - Absolute path to move.
+   * @param destinationPath - Absolute destination path.
+   * @param opts - File options (e.g. `container` for multi-container
+   * sandboxes).
+   * @throws {NotFoundError} If the source path does not exist.
+   * @throws {APIError} If the API returns a non-2xx response.
+   * @throws {APIConnectionError} If the request cannot reach the API.
+   */
+  async move(
+    sourcePath: string,
+    destinationPath: string,
+    opts: FileOptions = {},
+    req: RequestOptions = {},
+  ): Promise<void> {
+    const params: Record<string, string> = {};
+    if (opts.container) params.container = opts.container;
+
+    await this._api.requestNoContent({
+      method: "POST",
+      path: filesystemMovePath(this._sandboxId),
+      params,
+      jsonBody: { sourcePath, destinationPath },
       ...(req.signal ? { signal: req.signal } : {}),
     });
   }

--- a/sdks/typescript/src/internal/url.ts
+++ b/sdks/typescript/src/internal/url.ts
@@ -106,6 +106,10 @@ export function filesystemDirectoriesPath(sandboxId: string): string {
   return `${filesystemPath(sandboxId)}/directories`;
 }
 
+export function filesystemMovePath(sandboxId: string): string {
+  return `${filesystemPath(sandboxId)}/move`;
+}
+
 // Builds a URL with optional query string. Drops undefined/null values.
 // Uses quoteQueryComponent so spaces become `+` and !'()* are percent-encoded,
 // matching Python httpx's QueryParams.__str__ wire output.

--- a/sdks/typescript/tests/filesystem.test.ts
+++ b/sdks/typescript/tests/filesystem.test.ts
@@ -463,6 +463,36 @@ describe("Filesystem.mkdir", () => {
   });
 });
 
+describe("Filesystem.move", () => {
+  it("posts source and destination as JSON body", async () => {
+    const stub = makeStubFetch(jsonResponse(sandboxResponseFixture()), emptyResponse(204));
+    const client = new Isola({ url: URL_BASE, fetch: stub.fetch, requestTimeoutMs: null });
+    const sandbox = await client.sandboxes.get("sandbox-123");
+    await sandbox.filesystem.move("/workspace/a.txt", "/workspace/b.txt", { container: "worker" });
+
+    const moveCall = stub.calls[1]!;
+    expect(moveCall.method).toBe("POST");
+    expect(moveCall.url.startsWith(`${URL_BASE}/v1/sandboxes/sandbox-123/filesystem/move`)).toBe(true);
+    expect(getSearchParam(moveCall.url, "container")).toBe("worker");
+    expect(moveCall.headers.get("content-type")).toBe("application/json");
+    expect(JSON.parse(moveCall.bodyText)).toEqual({
+      sourcePath: "/workspace/a.txt",
+      destinationPath: "/workspace/b.txt",
+    });
+  });
+
+  it("raises NotFoundError when source is missing", async () => {
+    const stub = makeStubFetch(
+      jsonResponse(sandboxResponseFixture()),
+      jsonResponse({ detail: "source path not found" }, { status: 404 }),
+    );
+    const client = new Isola({ url: URL_BASE, fetch: stub.fetch, requestTimeoutMs: null });
+    const sandbox = await client.sandboxes.get("sandbox-123");
+
+    await expect(sandbox.filesystem.move("/no-such", "/workspace/b.txt")).rejects.toBeInstanceOf(NotFoundError);
+  });
+});
+
 describe("FilesystemEntry wire decoding", () => {
   it("rejects a missing name", async () => {
     const stub = makeStubFetch(


### PR DESCRIPTION
PR 5 of 5 from the `fs_ops` split. **Base: `fs-mkdir`** — review this diff against `fs-mkdir`.

Adds the **move** operation (`POST .../filesystem/move`) end to end: sidecar handler, gateway proxy, OpenAPI, Python/TypeScript SDKs, and tests. Renames/moves a file, directory, or symlink; destination parents are created; an existing destination file is overwritten; cross-filesystem moves and root moves are rejected; destination-conflict errno families map to `409`.

This PR also carries the move-only plumbing: the `MoveFilesystemEntryRequest` type, the Python client `request_no_content(json_body=...)` support, and the combined async SDK test. The root README filesystem walkthrough lands here (it spans the full op family).

With all 5 PRs merged, the tree is identical to the original `fs_ops` branch.

Stack: list → stat → delete → mkdir → **move**.